### PR TITLE
fix: native mobile deeplink on desktop

### DIFF
--- a/sample/Reown.AppKit.Unity/Assets/Scripts/AppInit.cs
+++ b/sample/Reown.AppKit.Unity/Assets/Scripts/AppInit.cs
@@ -114,6 +114,7 @@ namespace Sample
             }
 
             PlayerPrefs.SetString("RE_WEB_WALLET_URL", url);
+            PlayerPrefs.SetString("RE_RECENT_WALLET_DEEPLINK", url);
             PlayerPrefs.Save();
             Debug.Log($"Web Wallet URL set to {url}");
         }

--- a/src/Reown.AppKit.Unity/Runtime/Connectors/Profile/ProfileConnector.cs
+++ b/src/Reown.AppKit.Unity/Runtime/Connectors/Profile/ProfileConnector.cs
@@ -23,7 +23,21 @@ namespace Reown.AppKit.Unity.Profile
 
         public Account PreferredAccount { get; private set; }
 
+        public static string WebWalletUrl
+        {
+            get
+            {
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+                // Allow to override the web wallet URL in development
+                return PlayerPrefs.GetString("RE_WEB_WALLET_URL", DefaultWebWalletUrl);
+#else
+                return DefaultWebWalletUrl;
+#endif
+            }
+        }
+
         private const string PreferredAccountTypeKey = "PreferredAccount";
+        private const string DefaultWebWalletUrl = "https://web-wallet.walletconnect.org/";
 
         public ProfileConnector()
         {
@@ -34,6 +48,8 @@ namespace Reown.AppKit.Unity.Profile
         {
             try
             {
+                PlayerPrefs.SetString("RE_RECENT_WALLET_DEEPLINK", WebWalletUrl);
+
                 var addressProvider = SignClient.AddressProvider;
                 var sessionProperties = addressProvider.DefaultSession.SessionProperties;
 

--- a/src/Reown.AppKit.Unity/Runtime/Presenters/SocialLoginPresenter.cs
+++ b/src/Reown.AppKit.Unity/Runtime/Presenters/SocialLoginPresenter.cs
@@ -13,9 +13,6 @@ namespace Reown.AppKit.Unity
         private WalletConnectConnectionProposal _connectionProposal;
         private readonly WaitForSecondsRealtime _waitForSeconds05;
 
-        private const string DefaultWebWalletUrl = "https://web-wallet.walletconnect.org/";
-
-        private string _webWalletUrl;
         private string _providerName;
 
         public SocialLoginPresenter(RouterController router, VisualElement parent, bool hideView = true) : base(router, parent, hideView)
@@ -27,18 +24,12 @@ namespace Reown.AppKit.Unity
         {
             base.OnVisibleCore();
 
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
-            _webWalletUrl = PlayerPrefs.GetString("RE_WEB_WALLET_URL", DefaultWebWalletUrl);
-#else
-            _webWalletUrl = DefaultWebWalletUrl;
-#endif
-            
             _providerName = PlayerPrefs.GetString("RE_SOCIAL_PROVIDER_NAME", "unknown");
             View.MainLabel.text = $"Log in with {_providerName}";
             View.MessageLabel.text = "Preparing to connect...";
 
             View.ProviderIcon.vectorImage = Resources.Load<VectorImage>($"Reown/AppKit/Images/Social/{_providerName}");
-            
+
             if (!AppKit.ConnectorController
                     .TryGetConnector<ProfileConnector>
                         (ConnectorType.Profile, out var connector))
@@ -65,7 +56,7 @@ namespace Reown.AppKit.Unity
 
         private void OpenWebWallet()
         {
-            var deepLink = Linker.BuildConnectionDeepLink(_webWalletUrl, _connectionProposal.Uri);
+            var deepLink = Linker.BuildConnectionDeepLink(ProfileConnector.WebWalletUrl, _connectionProposal.Uri);
             deepLink = $"{deepLink}&provider={_providerName}";
             Application.OpenURL(deepLink);
         }

--- a/src/Reown.AppKit.Unity/Runtime/Utils/WalletUtils.cs
+++ b/src/Reown.AppKit.Unity/Runtime/Utils/WalletUtils.cs
@@ -56,6 +56,7 @@ namespace Reown.AppKit.Unity.Utils
         public static void RemoveLastViewedWallet()
         {
             PlayerPrefs.DeleteKey("RE_LAST_VIEWED_WALLET");
+            PlayerPrefs.DeleteKey("RE_RECENT_WALLET_DEEPLINK");
         }
 
         public static bool TryGetLastViewedWallet(out Wallet wallet)


### PR DESCRIPTION
This PR fixes a bug that caused Linker to trigger native redirect URLs of mobile wallets on desktop when sending session request.

Related: #67