### PR TITLE
Fix for Unity 6.x

### DIFF
--- a/src/Reown.AppKit.Unity/Runtime/Presenters/WebAppPresenter.cs
+++ b/src/Reown.AppKit.Unity/Runtime/Presenters/WebAppPresenter.cs
@@ -53,7 +53,7 @@ namespace Reown.AppKit.Unity
 
         private void OnOpenLinkClicked()
         {
-            var encodedUri = HttpUtility.UrlEncode(_connectionProposal.Uri);
+            var encodedUri = System.Net.WebUtility.UrlEncode(_connectionProposal.Uri);
             var url = Path.Combine(_wallet.WebappLink, $"wc?uri={encodedUri}");
             Debug.Log(url);
             Application.OpenURL(url);

--- a/src/Reown.Core.Common/Runtime/Utils/Extensions.cs
+++ b/src/Reown.Core.Common/Runtime/Utils/Extensions.cs
@@ -57,8 +57,8 @@ namespace Reown.Core.Common.Utils
                 delim = "&";
             }
 
-            return source + delim + HttpUtility.UrlEncode(key)
-                   + "=" + HttpUtility.UrlEncode(value);
+            return source + delim + System.Net.WebUtility.UrlEncode(key)
+                   + "=" + System.Net.WebUtility.UrlEncode(value);
         }
 
         public static async Task<T> WithTimeout<T>(this Task<T> task, int timeout = 1000,


### PR DESCRIPTION
My unity6.0.x runtime can not use HttpUtillity.UrlEncode
Please fix it.