### PR TITLE
fix: siwe back button visible

### DIFF
--- a/src/Reown.AppKit.Unity/Runtime/Connectors/Connector.cs
+++ b/src/Reown.AppKit.Unity/Runtime/Connectors/Connector.cs
@@ -122,9 +122,8 @@ namespace Reown.AppKit.Unity
 
             try
             {
-                var account = await GetAccountAsyncCore();
-                var ethAddress = account.Address;
-                var ethChainId = Core.Utils.ExtractChainReference(account.ChainId);
+                var ethAddress = Account.Address;
+                var ethChainId = Core.Utils.ExtractChainReference(Account.ChainId);
 
                 var siweMessage = await AppKit.SiweController.CreateMessageAsync(ethAddress, ethChainId);
 

--- a/src/Reown.AppKit.Unity/Runtime/Presenters/ModalHeaderPresenter.cs
+++ b/src/Reown.AppKit.Unity/Runtime/Presenters/ModalHeaderPresenter.cs
@@ -134,8 +134,17 @@ namespace Reown.AppKit.Unity
             // Left slot
             if (Router.HistoryCount > 1)
             {
-                _goBackIconLink.style.display = DisplayStyle.Flex;
-                View.leftSlot.style.visibility = Visibility.Visible;
+                if (args.newPresenter.EnableCloseButton)
+                {
+                    _goBackIconLink.style.display = DisplayStyle.Flex;
+                    View.leftSlot.style.visibility = Visibility.Visible;
+                }
+                else
+                {
+                    _goBackIconLink.style.display = DisplayStyle.None;
+                    View.leftSlot.style.visibility = Visibility.Hidden;
+                }
+               
             }
             else if (_leftSlotItems.TryGetValue(args.newViewType, out var newItem))
             {


### PR DESCRIPTION
This allowed users to leave SIWE UI and continue to the app without signature validation.