### PR TITLE
chore: add "com.unity.modules.androidjni" to dependencies

### DIFF
--- a/sample/Reown.AppKit.Unity/Packages/packages-lock.json
+++ b/sample/Reown.AppKit.Unity/Packages/packages-lock.json
@@ -125,6 +125,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
+        "com.unity.modules.androidjni": "1.0.0",
         "com.reown.sign": "1.4.3"
       }
     },

--- a/src/Reown.Sign.Unity/package.json
+++ b/src/Reown.Sign.Unity/package.json
@@ -9,6 +9,7 @@
     "walletconnect"
   ],
   "dependencies": {
+    "com.unity.modules.androidjni": "1.0.0",
     "com.reown.sign": "1.4.3"
   }
 }


### PR DESCRIPTION
Add `com.unity.modules.androidjni` to the list of dependencies to enable the Android JNI built-in module if it is disabled.