### PR TITLE
fix: chain doesn't support Smart Account

### DIFF
--- a/src/Reown.AppKit.Unity/Runtime/AppKitCore.cs
+++ b/src/Reown.AppKit.Unity/Runtime/AppKitCore.cs
@@ -81,8 +81,8 @@ namespace Reown.AppKit.Unity
                     return;
                 }
 
-                var isConnectedToReownWallet = ConnectorController.ActiveConnector is ProfileConnector;
-                ModalController.Open(isConnectedToReownWallet ? ViewType.AccountPortfolio : ViewType.AccountSettings);
+                var accountViewType = GetAccountViewType();
+                ModalController.Open(accountViewType);
             }
             else
             {
@@ -185,6 +185,18 @@ namespace Reown.AppKit.Unity
             Linker.OpenSessionProposalDeepLink(connectionProposal.Uri, baseUrl);
 
             await tcsConnection.Task;
+        }
+
+        private static ViewType GetAccountViewType()
+        {
+            if (ConnectorController.ActiveConnector is not ProfileConnector profileConnector)
+                return ViewType.AccountSettings;
+
+            if (profileConnector.PreferredAccountType == AccountType.SmartAccount
+                && profileConnector.IsSmartAccountEnabled(NetworkController.ActiveChain.ChainId))
+                return ViewType.AccountPortfolio;
+
+            return ViewType.AccountSettings;
         }
 
         protected virtual ModalController CreateModalController()

--- a/src/Reown.AppKit.Unity/Runtime/Connectors/WalletConnect/WalletConnectConnector.cs
+++ b/src/Reown.AppKit.Unity/Runtime/Connectors/WalletConnect/WalletConnectConnector.cs
@@ -69,9 +69,7 @@ namespace Reown.AppKit.Unity
         {
             "chainChanged",
             "accountsChanged",
-            "message",
-            "disconnect",
-            "connect"
+            "reown_updateEmail"
         };
 
         protected override Task InitializeAsyncCore(AppKitConfig config, SignClientUnity signClient)

--- a/src/Reown.AppKit.Unity/Runtime/Connectors/WalletConnect/WalletConnectConnector.cs
+++ b/src/Reown.AppKit.Unity/Runtime/Connectors/WalletConnect/WalletConnectConnector.cs
@@ -110,7 +110,7 @@ namespace Reown.AppKit.Unity
             OnAccountChanged(new AccountChangedEventArgs(Account));
         }
 
-        private async void SessionDeletedHandler(object sender, EventArgs e)
+        private void SessionDeletedHandler(object sender, EventArgs e)
         {
             if (!IsAccountConnected)
                 return;

--- a/src/Reown.AppKit.Unity/Runtime/Presenters/AccountSettingsPresenter.cs
+++ b/src/Reown.AppKit.Unity/Runtime/Presenters/AccountSettingsPresenter.cs
@@ -80,7 +80,10 @@ namespace Reown.AppKit.Unity
 
         protected virtual void CreateSmartAccountToggleButton(VisualElement buttonsListView)
         {
-            if (AppKit.ConnectorController.ActiveConnector is not ProfileConnector)
+            if (AppKit.ConnectorController.ActiveConnector is not ProfileConnector profileConnector)
+                return;
+
+            if (!profileConnector.IsSmartAccountEnabled(AppKit.Account.ChainId))
                 return;
 
             _profileConnector = (ProfileConnector)AppKit.ConnectorController.ActiveConnector;

--- a/src/Reown.AppKit.Unity/Runtime/Presenters/AccountSettingsPresenter.cs
+++ b/src/Reown.AppKit.Unity/Runtime/Presenters/AccountSettingsPresenter.cs
@@ -86,7 +86,7 @@ namespace Reown.AppKit.Unity
             if (!profileConnector.IsSmartAccountEnabled(AppKit.Account.ChainId))
                 return;
 
-            _profileConnector = (ProfileConnector)AppKit.ConnectorController.ActiveConnector;
+            _profileConnector = profileConnector;
 
             var anotherAccountType = _profileConnector.PreferredAccountType == AccountType.SmartAccount
                 ? AccountType.Eoa.ToFriendlyString()


### PR DESCRIPTION
Unity AppKit didn't distinguish between networks that support Smart Accounts and those that do not which in some cases resulted in "chain doesn't support Smart Account" errors when sending requests.

This PR addresses that issue: if a chain doesn't support Smart Accounts, the preferred account will be automatically set to EOA.

It also fixes a bug where the `AppKit.AccountChanged` event used a cached preferred account when changing chains. 