### PR TITLE
fix: calling unity os info api from worker thread throws

### DIFF
--- a/src/Reown.Core/Runtime/Controllers/Relayer.cs
+++ b/src/Reown.Core/Runtime/Controllers/Relayer.cs
@@ -225,7 +225,7 @@ namespace Reown.Core.Controllers
         }
 
         /// <summary>
-        ///     Unsubscribe to a given topic optionally specify unsubscribe options
+        ///     Unsubscribe from a given topic optionally specify unsubscribe options
         /// </summary>
         /// <param name="topic">Tbe topic to unsubscribe to</param>
         /// <param name="opts">(Optional) Unsubscribe options specifying protocol options</param>

--- a/src/Reown.Core/Runtime/Controllers/Subscriber.cs
+++ b/src/Reown.Core/Runtime/Controllers/Subscriber.cs
@@ -187,7 +187,7 @@ namespace Reown.Core.Controllers
         }
 
         /// <summary>
-        ///     Unsubscribe to a given topic with optional UnsubscribeOptions
+        ///     Unsubscribe from a given topic with optional UnsubscribeOptions
         /// </summary>
         /// <param name="topic">The topic to unsubscribe from</param>
         /// <param name="opts">The options to specify the subscription id as well as protocol options</param>
@@ -249,9 +249,7 @@ namespace Reown.Core.Controllers
 
             return false;
         }
-
-        private event EventHandler onSubscriberReady;
-
+        
         private async Task Restart()
         {
             _restartTask = new TaskCompletionSource<bool>();
@@ -269,14 +267,12 @@ namespace Reown.Core.Controllers
 
         protected virtual void RegisterEventListeners()
         {
-            _relayer.CoreClient.HeartBeat.OnPulse += (sender, @event) => { CheckPending(); };
+            _relayer.CoreClient.HeartBeat.OnPulse += (_, _) => CheckPending();
 
-            _relayer.OnConnected += (sender, connection) => { OnConnect(); };
-
-            _relayer.OnDisconnected += (sender, args) => { OnDisconnect(); };
+            _relayer.OnConnected += (_, _) => OnConnect();
+            _relayer.OnDisconnected += (_, _) => OnDisconnect();
 
             Created += AsyncPersist;
-
             Deleted += AsyncPersist;
         }
 
@@ -403,9 +399,6 @@ namespace Reown.Core.Controllers
         {
             _cached = Array.Empty<ActiveSubscription>();
             _initialized = true;
-
-            if (onSubscriberReady != null)
-                onSubscriberReady(this, EventArgs.Empty);
         }
 
         protected virtual void OnDisconnect()
@@ -481,8 +474,7 @@ namespace Reown.Core.Controllers
 
         protected virtual void AddSubscription(string id, ActiveSubscription subscription)
         {
-            if (_subscriptions.ContainsKey(id))
-                _subscriptions.Remove(id);
+            _subscriptions.Remove(id);
 
             _subscriptions.Add(id, subscription);
             _topicMap.Set(subscription.Topic, id);

--- a/src/Reown.Sign.Unity/Runtime/UnityRelayUrlBuilder.cs
+++ b/src/Reown.Sign.Unity/Runtime/UnityRelayUrlBuilder.cs
@@ -6,39 +6,92 @@ namespace Reown.Sign.Unity
 {
     public class UnityRelayUrlBuilder : RelayUrlBuilder
     {
-        public override (string name, string version) GetOsInfo()
+        private static string _cachedOsName;
+        private static string _cachedOsVersion;
+
+#if UNITY_IOS || UNITY_STANDALONE_OSX
+        private static string _cachedBundleId;
+#endif
+
+#if UNITY_ANDROID
+        private static string _cachedPackageName;
+#endif
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        private static string _cachedOrigin;
+#endif
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
+        private static void InitializeCaches()
+        {
+            ComputeOsInfoCache();
+            ComputePlatformIdCaches();
+        }
+
+        private static void ComputeOsInfoCache()
         {
 #if UNITY_ANDROID && !UNITY_EDITOR
             var splitOS = SystemInfo.operatingSystem.Split(' ');
-            return ("android", splitOS[2]);
+            _cachedOsName = "android";
+            _cachedOsVersion = splitOS[2];
 #elif UNITY_IOS && !UNITY_EDITOR
             var splitOS = SystemInfo.operatingSystem.Split(' ');
             // var platform = splitOS[0].ToLower();
             var version = splitOS[1];
-            return ("ios", version);
+            _cachedOsName = "ios";
+            _cachedOsVersion = version;
 #elif UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
             var osString = SystemInfo.operatingSystem;
             var startIndex = osString.IndexOf("OS X", StringComparison.Ordinal) + 5;
             var version = osString.Substring(startIndex);
-            return ("macos", version);
+            _cachedOsName = "macos";
+            _cachedOsVersion = version;
 #elif UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
             var splitOS = SystemInfo.operatingSystem.Split(' ');
             var version = splitOS[1]; // e.g. Vista or 11
             var architecture = splitOS[^1]; // e.g. 64bit
-            return ("windows", $"{version}-{architecture}");
+            _cachedOsName = "windows";
+            _cachedOsVersion = $"{version}-{architecture}";
 #elif UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX
             var splitOS = SystemInfo.operatingSystem.Split(' ');
             if (splitOS.Length < 5)
-                return ("linux", "unknown");
-
-            var kernelVersion = splitOS[1];
-            var distribution = splitOS[2];
-            var architecture = splitOS[splitOS.Length - 1];
-            
-            return ("linux", $"{distribution}-{kernelVersion}-{architecture}");
+            {
+                _cachedOsName = "linux";
+                _cachedOsVersion = "unknown";
+            }
+            else
+            {
+                var kernelVersion = splitOS[1];
+                var distribution = splitOS[2];
+                var architecture = splitOS[splitOS.Length - 1];
+                _cachedOsName = "linux";
+                _cachedOsVersion = $"{distribution}-{kernelVersion}-{architecture}";
+            }
 #else
-            return base.GetOsInfo();
+            var baseInfo = new RelayUrlBuilder().GetOsInfo();
+            _cachedOsName = baseInfo.name;
+            _cachedOsVersion = baseInfo.version;
 #endif
+        }
+
+        private static void ComputePlatformIdCaches()
+        {
+#if UNITY_IOS || UNITY_STANDALONE_OSX
+            _cachedBundleId = Application.identifier;
+#endif
+
+#if UNITY_ANDROID
+            _cachedPackageName = Application.identifier;
+#endif
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            _cachedOrigin = Application.identifier;
+#endif
+        }
+
+        public override (string name, string version) GetOsInfo()
+        {
+            return (_cachedOsName, _cachedOsVersion);
         }
 
         public override (string name, string version) GetSdkInfo()
@@ -46,10 +99,11 @@ namespace Reown.Sign.Unity
             return ("reown-unity", SignMetadata.Version);
         }
 
+#pragma warning disable S1185
         protected override bool TryGetBundleId(out string bundleId)
         {
 #if UNITY_IOS || UNITY_STANDALONE_OSX
-            bundleId = Application.identifier;
+            bundleId = _cachedBundleId;
             return true;
 #else
             return base.TryGetBundleId(out bundleId);
@@ -59,7 +113,7 @@ namespace Reown.Sign.Unity
         protected override bool TryGetPackageName(out string packageName)
         {
 #if UNITY_ANDROID
-            packageName = Application.identifier;
+            packageName = _cachedPackageName;
             return true;
 #else
             return base.TryGetPackageName(out packageName);
@@ -69,11 +123,12 @@ namespace Reown.Sign.Unity
         protected override bool TryGetOrigin(out string origin)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            origin = Application.identifier;
+            origin = _cachedOrigin;
             return true;
 #else
             return base.TryGetOrigin(out origin);
 #endif
         }
     }
+#pragma warning restore S1185
 }


### PR DESCRIPTION
Compute and cache OS/platform info on the main thread at startup using Unity's lifecycle hooks, and `GetOsInfo()` (and related getters) simply return those immutable values. This avoids calling Unity APIs from worker threads and eliminates repeated parsing/allocations.

There's also a small cleanup to the Subscriber class.