### PR TITLE
chore: pin external gh actions

### DIFF
--- a/.github/workflows/unity-build-test.yml
+++ b/.github/workflows/unity-build-test.yml
@@ -24,7 +24,7 @@ jobs:
           - Android # Build an Android .apk standalone app.
           - WebGL # WebGL.
     steps:
-      - uses: jlumbroso/free-disk-space@v1.3.1
+      - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
@@ -33,7 +33,7 @@ jobs:
           path: ${{ matrix.projectPath }}/Library
           key: Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}
           restore-keys: Library-
-      - uses: game-ci/unity-builder@v4
+      - uses: game-ci/unity-builder@3b26780ddfe24a0ee2aebb0a65297ab69fc5bb4c # v4.5
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -76,7 +76,7 @@ jobs:
           path: ${{ matrix.projectPath }}/Library
           key: Library-${{ matrix.projectPath }}-${{ matrix.testMode }}
           restore-keys: Library-
-      - uses: game-ci/unity-test-runner@v4
+      - uses: game-ci/unity-test-runner@3b26780ddfe24a0ee2aebb0a65297ab69fc5bb4c # v4.5
         id: tests
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -114,7 +114,7 @@ jobs:
           name: Build-WebGL
           path: Builds/WebGL
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@16e87c0a08142b0d0d33b76aeaf20823c381b9b9 # v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
Reference specific commit hash to version external actions (except the ones made by GitHub).

From SonarCloud:
> GitHub Actions workflows can leverage actions and reusable workflows created by others. These external actions can be used to perform various tasks, such as checking out code, building applications, and deploying artifacts. If your workflow uses a third-party action or a workflow without referencing to a specific commit hash, you are at risk of pulling in code that you have not reviewed.