### PR TITLE
Rename ToNSString to ReownToNSString to avoid naming conflicts

### DIFF
--- a/src/Reown.Sign.Unity/Plugins/iOS/CanOpenUrl.m
+++ b/src/Reown.Sign.Unity/Plugins/iOS/CanOpenUrl.m
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-NSString *ToNSString(char* string) {
+NSString *ReownToNSString(char* string) {
     return [NSString stringWithUTF8String:string];
 }
 
 bool _CanOpenURL (char* url) {
-    return [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:ToNSString(url)]];
+    return [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:ReownToNSString(url)]];
 }


### PR DESCRIPTION
## Problem
The `ToNSString` function name in the iOS native plugin can collide with other packages that might have similar function names, causing naming conflicts in projects that use multiple packages.

## Solution
Renamed `ToNSString` to `ReownToNSString` to make it more specific to the Reown library and avoid potential naming conflicts.

## Changes
- Renamed function from `ToNSString` to `ReownToNSString` in `src/Reown.Sign.Unity/Plugins/iOS/CanOpenUrl.m`
- Updated the function call in `_CanOpenURL` to use the new name
- No breaking changes to the public API

## Testing
- Verified no linting errors
- Functionality remains the same, only the internal function name changed
- The function still converts C strings to NSString as intended

## Impact
- Prevents naming conflicts with other packages
- Maintains backward compatibility
- No changes to public APIs or Unity integration