### PR TITLE
chore: optimise CI workflows

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,6 +7,10 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   review:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -14,8 +14,13 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
         # os: [ubuntu-latest, windows-latest]
@@ -34,6 +39,13 @@ jobs:
           dotnet-version: |
             9.0.x
             ${{ matrix.dotnet-version }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-
 
       - name: Run tests
         uses: ./.github/actions/test-dotnet

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,10 +3,24 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - '.editorconfig'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**.md'
+      - '.editorconfig'
+      - '.github/ISSUE_TEMPLATE/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Build and analyze
     runs-on: windows-latest
     steps:
@@ -24,6 +38,12 @@ jobs:
           dotnet-version: |
             9.0.x
             8.0.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-
       - name: Cache SonarQube Cloud packages
         uses: actions/cache@v5
         with:

--- a/.github/workflows/sync-unity-package-version.yml
+++ b/.github/workflows/sync-unity-package-version.yml
@@ -10,6 +10,10 @@ on:
       - "src/Directory.Build.props"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/unity-build-test.yml
+++ b/.github/workflows/unity-build-test.yml
@@ -3,7 +3,17 @@ name: Build Unity Sample
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+    paths:
+      - 'src/**'
+      - 'sample/**'
+      - 'playground/**'
+      - 'Reown.slnx'
+      - 'Directory.Packages.props'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   buildForAllSupportedPlatforms:
@@ -50,6 +60,7 @@ jobs:
           name: Build-${{ matrix.targetPlatform }}
           path: Builds/${{ matrix.targetPlatform }}
   testAllModes:
+    if: github.event.pull_request.draft == false
     name: Test in ${{ matrix.testMode }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Add concurrency groups with `cancel-in-progress` to all PR-facing workflows to cancel redundant runs when new commits are pushed to the same PR
- Skip draft PRs in `dotnet-build-test`, `sonarcloud`, and Unity test jobs to avoid wasting CI minutes on WIP
- Add NuGet package caching (`actions/cache`) to `dotnet-build-test` and `sonarcloud` workflows to speed up restore times
- Add path filters to `unity-build-test` so expensive Unity builds only trigger when source code, samples, or package config changes (not docs/CI-config-only changes)
- Add `paths-ignore` to `sonarcloud` for markdown and config-only changes
- Use `cancel-in-progress: false` for `sync-unity-package-version` since it performs `git push` operations and shouldn't be interrupted mid-run

## Workflows changed

| Workflow | Concurrency | Skip drafts | NuGet cache | Path filters |
|---|---|---|---|---|
| `dotnet-build-test.yml` | ✅ | ✅ | ✅ | — (already has `paths-ignore`) |
| `unity-build-test.yml` | ✅ | ✅ (tests) | — | ✅ |
| `sonarcloud.yml` | ✅ | ✅ | ✅ | ✅ (`paths-ignore`) |
| `claude-review.yml` | ✅ | — | — | — |
| `sync-unity-package-version.yml` | ✅ (no cancel) | — | — | — |

## Test plan

- [ ] Verify `dotnet-build-test` runs on non-draft PRs and skips draft PRs
- [ ] Verify `unity-build-test` doesn't trigger on docs-only changes
- [ ] Verify `sonarcloud` skips markdown-only PRs
- [ ] Verify NuGet cache is populated on first run and restored on subsequent runs
- [ ] Verify pushing a new commit cancels in-progress runs on the same PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)