### PR TITLE
chore: upgrade Nethereum to 6.1.0

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   review:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,13 +7,12 @@ on:
   issue_comment:
     types: [created]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-  cancel-in-progress: false
-
 jobs:
   review:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+      cancel-in-progress: true
     if: |
       (github.event_name == 'pull_request' && (github.event.action == 'ready_for_review' || github.event.pull_request.draft == false))
       || (

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.1" />
-    <PackageVersion Include="Nethereum.HdWallet" Version="6.0.4" />
-    <PackageVersion Include="Nethereum.Web3" Version="6.0.4" />
+    <PackageVersion Include="Nethereum.HdWallet" Version="6.1.0" />
+    <PackageVersion Include="Nethereum.Web3" Version="6.1.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NUnit" Version="3.5.0" />
     <PackageVersion Include="Websocket.Client" Version="5.1.2" />
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Nethereum.Signer" Version="6.0.4" />
+    <PackageVersion Include="Nethereum.Signer" Version="6.1.0" />
     <PackageVersion Include="ZXing.Net" Version="0.16.10" />
   </ItemGroup>
 </Project>

--- a/playground/Reown.AbstractSample.Unity/Packages/packages-lock.json
+++ b/playground/Reown.AbstractSample.Unity/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.nethereum.unity": {
-      "version": "4.26.0",
+      "version": "6.1.0",
       "depth": 3,
       "source": "registry",
       "dependencies": {},
@@ -86,7 +86,7 @@
       "source": "registry",
       "dependencies": {
         "com.reown.sign": "1.4.0",
-        "com.nethereum.unity": "4.26.0"
+        "com.nethereum.unity": "6.1.0"
       },
       "url": "https://package.openupm.com"
     },

--- a/playground/Reown.Customization.Unity/Packages/packages-lock.json
+++ b/playground/Reown.Customization.Unity/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.nethereum.unity": {
-      "version": "4.19.1",
+      "version": "6.1.0",
       "depth": 3,
       "source": "registry",
       "dependencies": {},
@@ -87,7 +87,7 @@
       "source": "registry",
       "dependencies": {
         "com.reown.sign": "1.0.1",
-        "com.nethereum.unity": "4.19.1"
+        "com.nethereum.unity": "6.1.0"
       },
       "url": "https://package.openupm.com"
     },

--- a/playground/Reown.Playground.Unity/Packages/manifest.json
+++ b/playground/Reown.Playground.Unity/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.nethereum.unity": "4.19.2",
+    "com.nethereum.unity": "6.1.0",
     "com.reown.appkit.unity": "file:./../../../src/Reown.AppKit.Unity",
     "com.reown.core": "file:./../../../src/Reown.Core",
     "com.reown.core.common": "file:./../../../src/Reown.Core.Common",

--- a/playground/Reown.Playground.Unity/Packages/packages-lock.json
+++ b/playground/Reown.Playground.Unity/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.nethereum.unity": {
-      "version": "4.19.2",
+      "version": "6.1.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -79,7 +79,7 @@
       "source": "local",
       "dependencies": {
         "com.reown.sign": "1.0.0",
-        "com.nethereum.unity": "4.19.1"
+        "com.nethereum.unity": "6.1.0"
       }
     },
     "com.reown.sign.nethereum.unity": {

--- a/playground/Reown.RoninSample.Unity/Packages/packages-lock.json
+++ b/playground/Reown.RoninSample.Unity/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.nethereum.unity": {
-      "version": "4.26.0",
+      "version": "6.1.0",
       "depth": 3,
       "source": "registry",
       "dependencies": {},
@@ -87,7 +87,7 @@
       "source": "registry",
       "dependencies": {
         "com.reown.sign": "1.4.0",
-        "com.nethereum.unity": "4.26.0"
+        "com.nethereum.unity": "6.1.0"
       },
       "url": "https://package.openupm.com"
     },

--- a/playground/Reown.SeiSample.Unity/Packages/packages-lock.json
+++ b/playground/Reown.SeiSample.Unity/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.nethereum.unity": {
-      "version": "5.0.0",
+      "version": "6.1.0",
       "depth": 3,
       "source": "registry",
       "dependencies": {},
@@ -87,7 +87,7 @@
       "source": "registry",
       "dependencies": {
         "com.reown.sign": "1.4.3",
-        "com.nethereum.unity": "5.0.0"
+        "com.nethereum.unity": "6.1.0"
       },
       "url": "https://package.openupm.com"
     },

--- a/playground/Reown.SolanaCore.Unity/Packages/packages-lock.json
+++ b/playground/Reown.SolanaCore.Unity/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.nethereum.unity": {
-      "version": "5.0.0",
+      "version": "6.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -80,7 +80,7 @@
       "source": "local",
       "dependencies": {
         "com.reown.sign": "1.5.0",
-        "com.nethereum.unity": "5.0.0"
+        "com.nethereum.unity": "6.1.0"
       }
     },
     "com.reown.sign.nethereum.unity": {

--- a/playground/Reown.SolanaSdk.Unity/Packages/packages-lock.json
+++ b/playground/Reown.SolanaSdk.Unity/Packages/packages-lock.json
@@ -8,7 +8,7 @@
       "hash": "6eee66190fb6d7182518cc3b41e3919e054699b6"
     },
     "com.nethereum.unity": {
-      "version": "5.0.0",
+      "version": "6.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -96,7 +96,7 @@
       "source": "local",
       "dependencies": {
         "com.reown.sign": "1.5.0",
-        "com.nethereum.unity": "5.0.0"
+        "com.nethereum.unity": "6.1.0"
       }
     },
     "com.reown.sign.nethereum.unity": {

--- a/playground/Reown.UniTask.Unity/Packages/packages-lock.json
+++ b/playground/Reown.UniTask.Unity/Packages/packages-lock.json
@@ -8,7 +8,7 @@
       "url": "https://package.openupm.com"
     },
     "com.nethereum.unity": {
-      "version": "4.26.0",
+      "version": "6.1.0",
       "depth": 3,
       "source": "registry",
       "dependencies": {},
@@ -94,7 +94,7 @@
       "source": "registry",
       "dependencies": {
         "com.reown.sign": "1.2.0",
-        "com.nethereum.unity": "4.26.0"
+        "com.nethereum.unity": "6.1.0"
       },
       "url": "https://package.openupm.com"
     },

--- a/sample/Reown.AppKit.Unity/Packages/packages-lock.json
+++ b/sample/Reown.AppKit.Unity/Packages/packages-lock.json
@@ -29,7 +29,7 @@
       "url": "https://package.openupm.com"
     },
     "com.nethereum.unity": {
-      "version": "5.0.0",
+      "version": "6.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -108,7 +108,7 @@
       "source": "local",
       "dependencies": {
         "com.reown.sign": "1.5.2",
-        "com.nethereum.unity": "5.0.0"
+        "com.nethereum.unity": "6.1.0"
       }
     },
     "com.reown.sign.nethereum.unity": {

--- a/src/Reown.Sign.Nethereum/package.json
+++ b/src/Reown.Sign.Nethereum/package.json
@@ -10,6 +10,6 @@
   ],
   "dependencies": {
     "com.reown.sign": "1.5.2",
-    "com.nethereum.unity": "5.0.0"
+    "com.nethereum.unity": "6.1.0"
   }
 }


### PR DESCRIPTION
## Summary
Upgrade Nethereum from 6.0.4 to 6.1.0 across all NuGet packages (Web3, HdWallet, Signer) and UPM dependencies