### PR TITLE
fix(ci): add explicit permissions to workflow files

### DIFF
--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -14,6 +14,9 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
       - ".github/dependabot.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -14,6 +14,10 @@ on:
       - '.editorconfig'
       - '.github/ISSUE_TEMPLATE/**'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/unity-build-test.yml
+++ b/.github/workflows/unity-build-test.yml
@@ -11,6 +11,9 @@ on:
       - 'Directory.Packages.props'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -114,6 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: buildForAllSupportedPlatforms
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Resolve CodeQL code scanning alerts [#10](https://github.com/reown-com/reown-dotnet/security/code-scanning/10), [#14](https://github.com/reown-com/reown-dotnet/security/code-scanning/14), [#16](https://github.com/reown-com/reown-dotnet/security/code-scanning/16), [#17](https://github.com/reown-com/reown-dotnet/security/code-scanning/17) for missing `GITHUB_TOKEN` permissions
- Add workflow-level `permissions: contents: read` as a restrictive default to all four flagged workflows
- Add `contents: read` to the `deployToVercel` job which was missing it alongside its existing `pull-requests: write`
- Add `pull-requests: read` to `sonarcloud.yml` (needed by SonarCloud scanner for PR metadata)

| Workflow | Workflow-level | Job-level overrides |
|---|---|---|
| `dotnet-build-test.yml` | `contents: read` | — |
| `sonarcloud.yml` | `contents: read`, `pull-requests: read` | — |
| `release.yml` | `contents: read` | `unity` job: `contents: write` (pushes git tags) |
| `unity-build-test.yml` | `contents: read` | `testAllModes`: `contents: read`, `checks: write`, `pull-requests: write`; `deployToVercel`: `contents: read`, `pull-requests: write` |

## Test plan
- [x] `.NET Build & Test` workflow passes (checkout + composite test action)
- [x] `SonarCloud` workflow passes (PR analysis decoration still works)
- [x] `Build Unity Sample` workflow passes (build, test, Vercel deploy all succeed)
- [ ] `Release` workflow — verify on next merge to main (nuget publish + git tag push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)