### PR TITLE
chore: add .NET 9 and .NET 10 target framework support

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,7 +37,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           project_context: |
             This repository is a multi-package .NET + Unity SDK (libraries under src/) with sample Unity projects under playground/ and sample/.
-            Target frameworks: net7.0, net8.0, netstandard2.1 (centralized via src/Directory.Build.props).
+            Target frameworks: net7.0, net8.0, net9.0, net10.0, netstandard2.1 (centralized via src/Directory.Build.props).
             C# language version: 9.0 (LangVersion set centrally).
 
             Packages used by both .NET and Unity (must compile for netstandard2.1 and be Unity-compatible):

--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, windows-latest]
         os: [windows-latest]
-        dotnet-version: [8.0.x]
+        dotnet-version: [8.0.x, 9.0.x, 10.0.x]
         test-type: [unit-tests, integration-tests]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -40,8 +40,9 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
+            8.0.x
             9.0.x
-            ${{ matrix.dotnet-version }}
+            10.0.x
 
       - name: Cache NuGet packages
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,9 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
-            9.0.x
             8.0.x
+            9.0.x
+            10.0.x
 
       - name: Install dotnet-script
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -40,8 +40,9 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
-            9.0.x
             8.0.x
+            9.0.x
+            10.0.x
       - name: Cache NuGet packages
         uses: actions/cache@v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ reown-dotnet/
 │   ├── Reown.UniTask.Unity/          # UniTask/async patterns demo
 │   └── Reown.ZKCandySample.Unity/    # Zero-knowledge proofs demo
 │
-├── test/                             # Test projects (target net8.0 only)
+├── test/                             # Test projects (target net8.0;net9.0;net10.0)
 │   ├── Reown.Core.Common.Test/       # Note: excluded from Reown.NoUnity.slnf
 │   ├── Reown.Core.Crypto.Test/
 │   ├── Reown.Core.Network.Test/
@@ -232,9 +232,9 @@ Current `[VersionMarker]` usage:
 
 ### Target Frameworks
 
-.NET packages target: `net7.0`, `net8.0`, `netstandard2.1`
+.NET packages target: `net7.0`, `net8.0`, `net9.0`, `net10.0`, `netstandard2.1`
 
-Test projects target: `net8.0` only (with `ImplicitUsings` and `Nullable` enabled)
+Test projects target: `net8.0`, `net9.0`, `net10.0` (with `ImplicitUsings` and `Nullable` enabled)
 
 C# language version is set to 9.0 for Unity IL2CPP compatibility.
 
@@ -283,7 +283,7 @@ com.reown.appkit.unity
 
 ### Testing Requirements
 
-- Tests use xUnit framework with Microsoft.NET.Test.Sdk, targeting `net8.0` only
+- Tests use xUnit framework with Microsoft.NET.Test.Sdk, targeting `net8.0`, `net9.0`, and `net10.0`
 - Unit tests are marked with `[Trait("Category", "unit")]`
 - Integration tests are marked with `[Trait("Category", "integration")]` and require `PROJECT_ID` environment variable
 - Integration tests run single-threaded (`-m:1`) to coordinate relay communication
@@ -309,7 +309,7 @@ com.reown.appkit.unity
 ### CI/CD Pipeline
 
 **Pull Request Validation:**
-- .NET unit and integration tests on Windows (`dotnet-build-test.yml`) — requires .NET 9.0.x and 8.0.x SDKs
+- .NET unit and integration tests on Windows (`dotnet-build-test.yml`) — requires .NET 8.0.x, 9.0.x, and 10.0.x SDKs; runs across all three target frameworks
 - Unity builds for Windows, Android, WebGL using `game-ci/unity-builder` v4.5 (`unity-build-test.yml`)
 - Unity playmode and editmode tests using `game-ci/unity-test-runner` v4.3.1
 - WebGL deployment to Vercel with PR comment (runs after Unity build job)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <DefaultVersion>1.6.0</DefaultVersion>
-        <DefaultTargetFrameworks>net7.0;net8.0;netstandard2.1;</DefaultTargetFrameworks>
+        <DefaultTargetFrameworks>net7.0;net8.0;net9.0;net10.0;netstandard2.1;</DefaultTargetFrameworks>
         <Copyright>reown inc.</Copyright>
         <PackageProjectUrl>https://reown.com/</PackageProjectUrl>
         <RepositoryUrl>https://github.com/reown-com/reown-dotnet</RepositoryUrl>

--- a/test/Reown.Core.Common.Test/Reown.Core.Common.Test.csproj
+++ b/test/Reown.Core.Common.Test/Reown.Core.Common.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/test/Reown.Core.Crypto.Test/Reown.Core.Crypto.Test.csproj
+++ b/test/Reown.Core.Crypto.Test/Reown.Core.Crypto.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/test/Reown.Core.Network.Test/Reown.Core.Network.Test.csproj
+++ b/test/Reown.Core.Network.Test/Reown.Core.Network.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/test/Reown.Core.Storage.Test/Reown.Core.Storage.Test.csproj
+++ b/test/Reown.Core.Storage.Test/Reown.Core.Storage.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/test/Reown.Sign.Test/Reown.Sign.Test.csproj
+++ b/test/Reown.Sign.Test/Reown.Sign.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/test/Reown.WalletKit.Test/Reown.WalletKit.Test.csproj
+++ b/test/Reown.WalletKit.Test/Reown.WalletKit.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/test/Rown.TestUtils/Rown.TestUtils.csproj
+++ b/test/Rown.TestUtils/Rown.TestUtils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary
- Add `net9.0` and `net10.0` to `DefaultTargetFrameworks` in `src/Directory.Build.props`; all `src/` projects inherit automatically.
- Multi-target every test project across `net8.0;net9.0;net10.0` (was `net8.0` only).
- Expand the `.NET Build & Test` CI matrix to run unit and integration tests on `8.0.x`, `9.0.x`, and `10.0.x` SDKs. Install the net10 SDK in the `release.yml` and `sonarcloud.yml` workflows so they can build the new TFM.
- Refresh `AGENTS.md` and the `claude-review.yml` project context to mention the new frameworks.

C# `LangVersion` remains `9.0` — no source code changed, no Unity/IL2CPP compatibility impact.

## Local validation
- Build Reown.NoUnity.slnf in Release: 0 errors across all five TFMs.
- Unit tests: 34/34 passing on each of net8.0, net9.0, net10.0.
- Integration tests (with PROJECT_ID): 38/38 passing on each of net8.0, net9.0, net10.0.

## Test plan
- [ ] CI: `.NET Build & Test` passes on all 6 matrix cells (3 SDKs x {unit, integration}).
- [ ] CI: SonarCloud analysis builds successfully with the new net10.0 TFM present.
- [ ] CI: Unity build/test workflows remain green (no changes to Unity targets).
- [ ] On merge to `main`, the `release.yml` NuGet job packs and publishes 1.6.0 with all five TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)