### PR TITLE
fix(ci): use absolute path for Vercel working-directory

### DIFF
--- a/.github/workflows/unity-build-test.yml
+++ b/.github/workflows/unity-build-test.yml
@@ -136,4 +136,4 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           github-comment: true
-          working-directory: Builds/WebGL/WebGL
+          working-directory: ${{ github.workspace }}/Builds/WebGL/WebGL


### PR DESCRIPTION
## Summary
- `amondnet/vercel-action` v42.2.0 switched to API-based deployment, which rejects relative paths (`Provided path Builds/WebGL/WebGL is not absolute`).
- The deploy step has been failing on every PR since the dependabot bump from 42.1.0 → 42.2.0 in commit `cde6898` (Apr 13, 2026).
- Prefix the WebGL build directory with `${{ github.workspace }}` so the action receives an absolute path.

## Test plan
- [ ] CI: `Deploy to Vercel` step succeeds and posts the preview URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)