### PR TITLE
test: improve test quality from audit findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ reown-dotnet/
 │   └── Reown.ZKCandySample.Unity/    # Zero-knowledge proofs demo
 │
 ├── test/                             # Test projects (target net8.0;net9.0;net10.0)
-│   ├── Reown.Core.Common.Test/       # Note: excluded from Reown.NoUnity.slnf
+│   ├── Reown.Core.Common.Test/
 │   ├── Reown.Core.Crypto.Test/
 │   ├── Reown.Core.Network.Test/
 │   ├── Reown.Core.Storage.Test/
@@ -289,7 +289,6 @@ com.reown.appkit.unity
 - Integration tests run single-threaded (`-m:1`) to coordinate relay communication
 - `Reown.Sign.Test` has custom `xunit.runner.json`: parallelization disabled, `stopOnFail: true`, `longRunningTestSeconds: 250`
 - `Rown.TestUtils` provides shared fixtures: `TwoClientsFixture<T>` (two-client dapp↔wallet scenarios), `CryptoWalletFixture` (Nethereum HD wallet), `TestOutputHelperLogger` (xUnit→Reown logger bridge), `TempFolder` (auto-cleanup temp dirs)
-- `Reown.Core.Common.Test` exists in `Reown.slnx` but is excluded from `Reown.NoUnity.slnf` — it won't run with the standard `dotnet test Reown.NoUnity.slnf` command
 - When modifying code, check if corresponding tests exist and add tests for new functionality
 - Unity playmode tests require a desktop target platform (Windows/macOS/Linux) to be selected, as they depend on the desktop AppKit UI layout
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
+    <PackageVersion Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Nethereum.Signer" Version="6.1.0" />
     <PackageVersion Include="ZXing.Net" Version="0.16.10" />
   </ItemGroup>

--- a/Reown.NoUnity.slnf
+++ b/Reown.NoUnity.slnf
@@ -11,6 +11,7 @@
       "src\\Reown.Sign.Nethereum\\Reown.Sign.Nethereum.csproj",
       "src\\Reown.Sign\\Reown.Sign.csproj",
       "src\\Reown.WalletKit\\Reown.WalletKit.csproj",
+      "test\\Reown.Core.Common.Test\\Reown.Core.Common.Test.csproj",
       "test\\Reown.Core.Crypto.Test\\Reown.Core.Crypto.Test.csproj",
       "test\\Reown.Core.Network.Test\\Reown.Core.Network.Test.csproj",
       "test\\Reown.Core.Storage.Test\\Reown.Core.Storage.Test.csproj",

--- a/src/Reown.Core/Reown.Core.csproj
+++ b/src/Reown.Core/Reown.Core.csproj
@@ -19,5 +19,6 @@
     </ItemGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="Reown.Core.Network.Test" />
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>
 </Project>

--- a/src/Reown.Sign/Reown.Sign.csproj
+++ b/src/Reown.Sign/Reown.Sign.csproj
@@ -16,4 +16,7 @@
     <ItemGroup>
         <PackageReference Include="Nethereum.Signer"/>
     </ItemGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="Reown.Sign.Test"/>
+    </ItemGroup>
 </Project>

--- a/src/Reown.Sign/Runtime/Internals/EngineValidation.cs
+++ b/src/Reown.Sign/Runtime/Internals/EngineValidation.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Reown.Core.Common.Model.Errors;
 using Reown.Core.Common.Utils;
-using Reown.Core.Models.Relay;
 using Reown.Core.Network.Models;
 using Reown.Sign.Interfaces;
 using Reown.Sign.Models;
@@ -29,51 +27,8 @@ namespace Reown.Sign
 
         Task IEnginePrivate.IsValidSessionSettleRequest(SessionSettle settle)
         {
-            if (settle == null)
-            {
-                throw new ArgumentNullException(nameof(settle));
-            }
-
-            var relay = settle.Relay;
-            var controller = settle.Controller;
-            var namespaces = settle.Namespaces;
-            var expiry = settle.Expiry;
-
-            ValidateSessionSettleRelay(relay);
-            ValidateSessionSettleController(controller);
-            ValidateSessionSettleNamespaces(namespaces);
-            ValidateSessionSettleExpiry(expiry);
-
+            EngineValidator.ValidateSessionSettleRequest(settle);
             return Task.CompletedTask;
-
-            void ValidateSessionSettleRelay(ProtocolOptions relayToValidate)
-            {
-                if (relayToValidate != null && string.IsNullOrWhiteSpace(relayToValidate.Protocol))
-                {
-                    throw new ArgumentException("Relay protocol should be a non-empty string.");
-                }
-            }
-
-            void ValidateSessionSettleController(Participant controllerToValidate)
-            {
-                if (string.IsNullOrWhiteSpace(controllerToValidate?.PublicKey))
-                {
-                    throw new ArgumentException("Controller public key should be a non-empty string.");
-                }
-            }
-
-            void ValidateSessionSettleNamespaces(Namespaces namespacesToValidate)
-            {
-                ValidateNamespaces(namespacesToValidate, "OnSessionSettleRequest()");
-            }
-
-            void ValidateSessionSettleExpiry(long expiryToValidate)
-            {
-                if (Clock.IsExpired(expiryToValidate))
-                {
-                    throw new InvalidOperationException("SessionSettleRequest has expired.");
-                }
-            }
         }
 
         async Task IEnginePrivate.IsValidApprove(ApproveParams @params)
@@ -91,20 +46,10 @@ namespace Reown.Sign
             await IsValidProposalId(id);
             var proposal = Client.Proposal.Get(id);
 
-            ValidateNamespaces(namespaces, "approve()");
-            ValidateConformingNamespaces(proposal.RequiredNamespaces, namespaces, "update()");
+            EngineValidator.ValidateNamespaces(namespaces, "approve()");
+            EngineValidator.ValidateConformingNamespaces(proposal.RequiredNamespaces, namespaces, "update()");
 
-            if (relayProtocol != null && string.IsNullOrWhiteSpace(relayProtocol))
-            {
-                throw new ArgumentException("RelayProtocol should be a non-empty string.");
-            }
-
-            if (@params.SessionProperties != null && properties.Values.Any(string.IsNullOrWhiteSpace))
-            {
-                throw new ArgumentException("SessionProperties must be in Dictionary<string, string> format with no null or empty/whitespace values. "
-                                            + $"Received: {JsonConvert.SerializeObject(@params.SessionProperties)}"
-                );
-            }
+            EngineValidator.ValidateApproveOptions(relayProtocol, properties);
         }
 
         async Task IEnginePrivate.IsValidReject(RejectParams @params)
@@ -119,10 +64,7 @@ namespace Reown.Sign
 
             await IsValidProposalId(id);
 
-            if (reason == null || string.IsNullOrWhiteSpace(reason.Message))
-            {
-                throw new ArgumentException("Reject reason should be a non-empty string.");
-            }
+            EngineValidator.ValidateRejectReason(reason);
         }
 
         async Task IEnginePrivate.IsValidUpdate(string topic, Namespaces namespaces)
@@ -131,8 +73,8 @@ namespace Reown.Sign
 
             var session = Client.Session.Get(topic);
 
-            ValidateNamespaces(namespaces, "update()");
-            ValidateConformingNamespaces(session.RequiredNamespaces, namespaces, "update()");
+            EngineValidator.ValidateNamespaces(namespaces, "update()");
+            EngineValidator.ValidateConformingNamespaces(session.RequiredNamespaces, namespaces, "update()");
         }
 
         async Task IEnginePrivate.IsValidExtend(string topic)
@@ -151,9 +93,9 @@ namespace Reown.Sign
 
             var session = Client.Session.Get(topic);
             var namespaces = session.Namespaces;
-            ValidateNamespacesChainId(namespaces, chainId);
+            EngineValidator.ValidateNamespacesChainId(namespaces, chainId);
 
-            var validMethods = GetNamespacesMethodsForChainId(namespaces, chainId);
+            var validMethods = EngineValidator.GetNamespacesMethodsForChainId(namespaces, chainId);
             if (!validMethods.Contains(request.Method))
             {
                 throw new NamespacesException($"Method {request.Method} not found in namespaces for chainId {chainId}.");
@@ -197,9 +139,9 @@ namespace Reown.Sign
             var session = Client.Session.Get(topic);
             var namespaces = session.Namespaces;
 
-            ValidateNamespacesChainId(namespaces, chainId);
+            EngineValidator.ValidateNamespacesChainId(namespaces, chainId);
 
-            if (!GetNamespacesEventsForChainId(namespaces, chainId).Contains(eventData.Name))
+            if (!EngineValidator.GetNamespacesEventsForChainId(namespaces, chainId).Contains(eventData.Name))
             {
                 throw new NamespacesException($"Event {eventData.Name} not found in namespaces for chainId {chainId}.");
             }
@@ -284,210 +226,14 @@ namespace Reown.Sign
             }
         }
 
-        private static List<string> GetNamespacesEventsForChainId(Namespaces namespaces, string chainId)
-        {
-            var events = new List<string>();
-            foreach (var ns in namespaces.Values)
-            {
-                var chains = GetAccountsChains(ns.Accounts);
-                if (chains.Contains(chainId)) events.AddRange(ns.Events);
-            }
-
-            return events;
-        }
-
-        private static void ValidateAccounts(string[] accounts, string context)
-        {
-            foreach (var account in accounts)
-            {
-                if (!Core.Utils.IsValidAccountId(account))
-                {
-                    throw new FormatException($"{context}, account {account} should be a string and conform to 'namespace:chainId:address' format.");
-                }
-            }
-        }
-
-        private static void ValidateNamespaces(Namespaces namespaces, string method)
-        {
-            if (namespaces == null)
-            {
-                throw new ArgumentNullException(nameof(namespaces));
-            }
-
-            foreach (var ns in namespaces.Values)
-            {
-                ValidateAccounts(ns.Accounts, $"{method} namespace");
-            }
-        }
-
-        private List<string> GetNamespacesMethodsForChainId(Namespaces namespaces, string chainId)
-        {
-            var methods = new List<string>();
-            foreach (var ns in namespaces.Values)
-            {
-                var chains = GetAccountsChains(ns.Accounts);
-                if (chains.Contains(chainId)) methods.AddRange(ns.Methods);
-            }
-
-            return methods;
-        }
-
-        private List<string> GetNamespacesChains(Namespaces namespaces)
-        {
-            List<string> chains = new();
-            foreach (var ns in namespaces.Values)
-            {
-                chains.AddRange(GetAccountsChains(ns.Accounts));
-            }
-
-            return chains;
-        }
-
-        private void ValidateNamespacesChainId(Namespaces namespaces, string chainId)
-        {
-            if (!Core.Utils.IsValidChainId(chainId))
-            {
-                throw new FormatException($"ChainId {chainId} should be a string and conform to CAIP-2.");
-            }
-
-            var chains = GetNamespacesChains(namespaces);
-            if (!chains.Contains(chainId))
-            {
-                throw new NamespacesException($"ChainId {chainId} is invalid or not found in namespaces.");
-            }
-        }
-
-        private void ValidateConformingNamespaces(
-            RequiredNamespaces requiredNamespaces,
-            Namespaces namespaces,
-            string context)
-        {
-            if (requiredNamespaces == null)
-                return;
-            
-            var requiredNamespaceKeys = requiredNamespaces.Keys.ToArray();
-            var namespaceKeys = namespaces.Keys.ToArray();
-
-            if (!HasOverlap(requiredNamespaceKeys, namespaceKeys))
-            {
-                throw new NamespacesException($"Namespaces keys don't satisfy requiredNamespaces, {context}.");
-            }
-
-            foreach (var key in requiredNamespaceKeys)
-            {
-                var requiredNamespaceChains = requiredNamespaces[key].Chains;
-                var namespaceChains = GetAccountsChains(namespaces[key].Accounts);
-
-                if (!HasOverlap(requiredNamespaceChains, namespaceChains))
-                {
-                    throw new NamespacesException($"Namespaces chains don't satisfy requiredNamespaces chains for {key}, {context}.");
-                }
-
-                if (!HasOverlap(requiredNamespaces[key].Methods, namespaces[key].Methods))
-                {
-                    throw new NamespacesException($"Namespaces methods don't satisfy requiredNamespaces methods for {key}, {context}.");
-                }
-
-                if (!HasOverlap(requiredNamespaces[key].Events, namespaces[key].Events))
-                {
-                    throw new NamespacesException($"Namespaces events don't satisfy requiredNamespaces events for {key}, {context}.");
-                }
-            }
-        }
-
-        private bool HasOverlap(string[] a, string[] b)
-        {
-            var matches = a.Where(b.Contains);
-            return matches.Count() == a.Length;
-        }
-
-        private static string[] GetAccountsChains(string[] accounts)
-        {
-            List<string> chains = new()
-            {
-            };
-            foreach (var account in accounts)
-            {
-                var values = account.Split(":");
-                var chain = values[0];
-                var chainId = values[1];
-
-                chains.Add($"{chain}:{chainId}");
-            }
-
-            return chains.ToArray();
-        }
-
         private bool IsSessionCompatible(Session session, RequiredNamespaces requiredNamespaces)
         {
-            var compatible = true;
-
-            var sessionKeys = session.Namespaces.Keys.ToArray();
-            var paramsKeys = requiredNamespaces.Keys.ToArray();
-
-            if (!HasOverlap(paramsKeys, sessionKeys)) return false;
-
-            try
-            {
-                foreach (var key in sessionKeys)
-                {
-                    var value = session.Namespaces[key];
-                    var accounts = value.Accounts;
-                    var methods = value.Methods;
-                    var events = value.Events;
-                    var chains = GetAccountsChains(accounts);
-                    var requiredNamespace = requiredNamespaces[key];
-
-                    if (!HasOverlap(requiredNamespace.Chains, chains) ||
-                        !HasOverlap(requiredNamespace.Methods, methods) ||
-                        !HasOverlap(requiredNamespace.Events, events))
-                    {
-                        compatible = false;
-                    }
-                }
-            }
-            catch (KeyNotFoundException e)
-            {
-                return false;
-            }
-
-            return compatible;
+            return EngineValidator.IsSessionCompatible(session, requiredNamespaces);
         }
 
         void IEnginePrivate.ValidateAuthParams(AuthParams authParams)
         {
-            if (authParams.Chains == null || authParams.Chains.Length == 0)
-            {
-                throw new ArgumentException("Chains should be a non-empty array.");
-            }
-
-            if (string.IsNullOrWhiteSpace(authParams.Uri))
-            {
-                throw new ArgumentException("Uri should be a non-empty string.");
-            }
-
-            if (string.IsNullOrWhiteSpace(authParams.Domain))
-            {
-                throw new ArgumentException("Domain should be a non-empty string.");
-            }
-
-            if (string.IsNullOrWhiteSpace(authParams.Nonce))
-            {
-                throw new ArgumentException("Nonce should be a non-empty string.");
-            }
-
-            // Reject multi-namespace requests
-            var uniqueNamespaces = authParams.Chains.Select(chain => chain.Split(":")[0]).Distinct().ToArray();
-            if (uniqueNamespaces.Length > 1)
-            {
-                throw new ArgumentException("Multi-namespace requests are not supported. Please request single namespace only.");
-            }
-
-            var @namespace = authParams.Chains[0].Split(":")[0];
-            if (@namespace != "eip155")
-            {
-                throw new ArgumentException("Only eip155 namespace is supported for authenticated sessions. Please use .connect() for non-eip155 chains.");
-            }
+            EngineValidator.ValidateAuthParams(authParams);
         }
     }
 }

--- a/src/Reown.Sign/Runtime/Internals/EngineValidator.cs
+++ b/src/Reown.Sign/Runtime/Internals/EngineValidator.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Reown.Core.Common.Model.Errors;
+using Reown.Core.Common.Utils;
+using Reown.Core.Network.Models;
+using Reown.Sign.Models;
+using Reown.Sign.Models.Engine;
+using Reown.Sign.Models.Engine.Methods;
+
+namespace Reown.Sign
+{
+    /// <summary>
+    ///     Pure validation helpers extracted from <see cref="Engine" />. These methods do not
+    ///     depend on engine instance state (relay client, session store, pairing store) and are
+    ///     therefore safe to call from unit tests without standing up a full engine.
+    /// </summary>
+    internal static class EngineValidator
+    {
+        internal static string[] GetAccountsChains(string[] accounts)
+        {
+            List<string> chains = new()
+            {
+            };
+            foreach (var account in accounts)
+            {
+                var values = account.Split(":");
+                var chain = values[0];
+                var chainId = values[1];
+
+                chains.Add($"{chain}:{chainId}");
+            }
+
+            return chains.ToArray();
+        }
+
+        internal static bool HasOverlap(string[] a, string[] b)
+        {
+            var matches = a.Where(b.Contains);
+            return matches.Count() == a.Length;
+        }
+
+        internal static List<string> GetNamespacesEventsForChainId(Namespaces namespaces, string chainId)
+        {
+            var events = new List<string>();
+            foreach (var ns in namespaces.Values)
+            {
+                var chains = GetAccountsChains(ns.Accounts);
+                if (chains.Contains(chainId)) events.AddRange(ns.Events);
+            }
+
+            return events;
+        }
+
+        internal static List<string> GetNamespacesMethodsForChainId(Namespaces namespaces, string chainId)
+        {
+            var methods = new List<string>();
+            foreach (var ns in namespaces.Values)
+            {
+                var chains = GetAccountsChains(ns.Accounts);
+                if (chains.Contains(chainId)) methods.AddRange(ns.Methods);
+            }
+
+            return methods;
+        }
+
+        internal static List<string> GetNamespacesChains(Namespaces namespaces)
+        {
+            List<string> chains = new();
+            foreach (var ns in namespaces.Values)
+            {
+                chains.AddRange(GetAccountsChains(ns.Accounts));
+            }
+
+            return chains;
+        }
+
+        internal static void ValidateAccounts(string[] accounts, string context)
+        {
+            foreach (var account in accounts)
+            {
+                if (!Core.Utils.IsValidAccountId(account))
+                {
+                    throw new FormatException($"{context}, account {account} should be a string and conform to 'namespace:chainId:address' format.");
+                }
+            }
+        }
+
+        internal static void ValidateNamespaces(Namespaces namespaces, string method)
+        {
+            if (namespaces == null)
+            {
+                throw new ArgumentNullException(nameof(namespaces));
+            }
+
+            foreach (var ns in namespaces.Values)
+            {
+                ValidateAccounts(ns.Accounts, $"{method} namespace");
+            }
+        }
+
+        internal static void ValidateNamespacesChainId(Namespaces namespaces, string chainId)
+        {
+            if (!Core.Utils.IsValidChainId(chainId))
+            {
+                throw new FormatException($"ChainId {chainId} should be a string and conform to CAIP-2.");
+            }
+
+            var chains = GetNamespacesChains(namespaces);
+            if (!chains.Contains(chainId))
+            {
+                throw new NamespacesException($"ChainId {chainId} is invalid or not found in namespaces.");
+            }
+        }
+
+        internal static void ValidateConformingNamespaces(
+            RequiredNamespaces requiredNamespaces,
+            Namespaces namespaces,
+            string context)
+        {
+            if (requiredNamespaces == null)
+                return;
+
+            var requiredNamespaceKeys = requiredNamespaces.Keys.ToArray();
+            var namespaceKeys = namespaces.Keys.ToArray();
+
+            if (!HasOverlap(requiredNamespaceKeys, namespaceKeys))
+            {
+                throw new NamespacesException($"Namespaces keys don't satisfy requiredNamespaces, {context}.");
+            }
+
+            foreach (var key in requiredNamespaceKeys)
+            {
+                var requiredNamespaceChains = requiredNamespaces[key].Chains;
+                var namespaceChains = GetAccountsChains(namespaces[key].Accounts);
+
+                if (!HasOverlap(requiredNamespaceChains, namespaceChains))
+                {
+                    throw new NamespacesException($"Namespaces chains don't satisfy requiredNamespaces chains for {key}, {context}.");
+                }
+
+                if (!HasOverlap(requiredNamespaces[key].Methods, namespaces[key].Methods))
+                {
+                    throw new NamespacesException($"Namespaces methods don't satisfy requiredNamespaces methods for {key}, {context}.");
+                }
+
+                if (!HasOverlap(requiredNamespaces[key].Events, namespaces[key].Events))
+                {
+                    throw new NamespacesException($"Namespaces events don't satisfy requiredNamespaces events for {key}, {context}.");
+                }
+            }
+        }
+
+        internal static bool IsSessionCompatible(Session session, RequiredNamespaces requiredNamespaces)
+        {
+            var compatible = true;
+
+            var sessionKeys = session.Namespaces.Keys.ToArray();
+            var paramsKeys = requiredNamespaces.Keys.ToArray();
+
+            if (!HasOverlap(paramsKeys, sessionKeys)) return false;
+
+            try
+            {
+                foreach (var key in sessionKeys)
+                {
+                    var value = session.Namespaces[key];
+                    var accounts = value.Accounts;
+                    var methods = value.Methods;
+                    var events = value.Events;
+                    var chains = GetAccountsChains(accounts);
+                    var requiredNamespace = requiredNamespaces[key];
+
+                    if (!HasOverlap(requiredNamespace.Chains, chains) ||
+                        !HasOverlap(requiredNamespace.Methods, methods) ||
+                        !HasOverlap(requiredNamespace.Events, events))
+                    {
+                        compatible = false;
+                    }
+                }
+            }
+            catch (KeyNotFoundException)
+            {
+                return false;
+            }
+
+            return compatible;
+        }
+
+        internal static void ValidateAuthParams(AuthParams authParams)
+        {
+            if (authParams.Chains == null || authParams.Chains.Length == 0)
+            {
+                throw new ArgumentException("Chains should be a non-empty array.");
+            }
+
+            if (string.IsNullOrWhiteSpace(authParams.Uri))
+            {
+                throw new ArgumentException("Uri should be a non-empty string.");
+            }
+
+            if (string.IsNullOrWhiteSpace(authParams.Domain))
+            {
+                throw new ArgumentException("Domain should be a non-empty string.");
+            }
+
+            if (string.IsNullOrWhiteSpace(authParams.Nonce))
+            {
+                throw new ArgumentException("Nonce should be a non-empty string.");
+            }
+
+            // Reject multi-namespace requests
+            var uniqueNamespaces = authParams.Chains.Select(chain => chain.Split(":")[0]).Distinct().ToArray();
+            if (uniqueNamespaces.Length > 1)
+            {
+                throw new ArgumentException("Multi-namespace requests are not supported. Please request single namespace only.");
+            }
+
+            var @namespace = authParams.Chains[0].Split(":")[0];
+            if (@namespace != "eip155")
+            {
+                throw new ArgumentException("Only eip155 namespace is supported for authenticated sessions. Please use .connect() for non-eip155 chains.");
+            }
+        }
+
+        internal static void ValidateApproveOptions(string relayProtocol, Dictionary<string, string> sessionProperties)
+        {
+            if (relayProtocol != null && string.IsNullOrWhiteSpace(relayProtocol))
+            {
+                throw new ArgumentException("RelayProtocol should be a non-empty string.");
+            }
+
+            if (sessionProperties != null && sessionProperties.Values.Any(string.IsNullOrWhiteSpace))
+            {
+                throw new ArgumentException("SessionProperties must be in Dictionary<string, string> format with no null or empty/whitespace values. "
+                                            + $"Received: {JsonConvert.SerializeObject(sessionProperties)}"
+                );
+            }
+        }
+
+        internal static void ValidateRejectReason(Error reason)
+        {
+            if (reason == null || string.IsNullOrWhiteSpace(reason.Message))
+            {
+                throw new ArgumentException("Reject reason should be a non-empty string.");
+            }
+        }
+
+        internal static void ValidateSessionSettleRequest(SessionSettle settle)
+        {
+            if (settle == null)
+            {
+                throw new ArgumentNullException(nameof(settle));
+            }
+
+            var relay = settle.Relay;
+            var controller = settle.Controller;
+            var namespaces = settle.Namespaces;
+            var expiry = settle.Expiry;
+
+            if (relay != null && string.IsNullOrWhiteSpace(relay.Protocol))
+            {
+                throw new ArgumentException("Relay protocol should be a non-empty string.");
+            }
+
+            if (string.IsNullOrWhiteSpace(controller?.PublicKey))
+            {
+                throw new ArgumentException("Controller public key should be a non-empty string.");
+            }
+
+            ValidateNamespaces(namespaces, "OnSessionSettleRequest()");
+
+            if (Clock.IsExpired(expiry))
+            {
+                throw new InvalidOperationException("SessionSettleRequest has expired.");
+            }
+        }
+    }
+}

--- a/test/Reown.Core.Common.Test/HexByteConvertorExtensionsTests.cs
+++ b/test/Reown.Core.Common.Test/HexByteConvertorExtensionsTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace Reown.Core.Common.Test;
 
+[Trait("Category", "unit")]
 public class HexByteConvertorExtensionsTests
 {
     [Theory]

--- a/test/Reown.Core.Common.Test/Reown.Core.Common.Test.csproj
+++ b/test/Reown.Core.Common.Test/Reown.Core.Common.Test.csproj
@@ -16,6 +16,10 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Reown.Core.Crypto.Test/CryptoFixtures.cs
+++ b/test/Reown.Core.Crypto.Test/CryptoFixtures.cs
@@ -3,31 +3,29 @@ namespace Reown.Core.Crypto.Test;
 public class CryptoFixture : IDisposable
 {
     public Crypto PeerA { get; private set; }
-        
+
     public Crypto PeerB { get; private set; }
 
-    private readonly TaskCompletionSource<bool> _initCompleted = new();
+    private readonly Task _initTask;
 
     public CryptoFixture()
     {
         PeerA = new Crypto();
         PeerB = new Crypto();
 
-        Init();
+        _initTask = InitAsync();
     }
 
-    private async void Init()
+    private async Task InitAsync()
     {
         await Task.WhenAll(PeerA.Init(), PeerB.Init());
-            
-        _initCompleted.SetResult(true);
     }
-        
+
     public Task WaitForModulesReady()
     {
-        return _initCompleted.Task;
+        return _initTask;
     }
-        
+
     public void Dispose()
     {
         PeerA.Storage.Clear();

--- a/test/Reown.Core.Crypto.Test/Reown.Core.Crypto.Test.csproj
+++ b/test/Reown.Core.Crypto.Test/Reown.Core.Crypto.Test.csproj
@@ -16,6 +16,10 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Reown.Core.Network.Test/Reown.Core.Network.Test.csproj
+++ b/test/Reown.Core.Network.Test/Reown.Core.Network.Test.csproj
@@ -16,6 +16,11 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="NSubstitute" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Reown.Core.Network.Test/SubscriberBatchSubscribeTests.cs
+++ b/test/Reown.Core.Network.Test/SubscriberBatchSubscribeTests.cs
@@ -1,16 +1,12 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using Reown.Core.Controllers;
-using Reown.Core.Common;
+using NSubstitute;
 using Reown.Core.Common.Model.Relay;
+using Reown.Core.Controllers;
 using Reown.Core.Interfaces;
 using Reown.Core.Models.Relay;
 using Reown.Core.Models.Subscriber;
-using Reown.Core.Network;
-using Reown.Core.Network.Models;
 using Xunit;
 
 namespace Reown.Core.Network.Test
@@ -27,7 +23,7 @@ namespace Reown.Core.Network.Test
         [Trait("Category", "unit")]
         public async Task BatchSubscribe_SplitsLargeRequestsIntoBatches()
         {
-            var relayer = new TestRelayer();
+            var relayer = Substitute.For<IRelayer>();
             var subscriber = new TestSubscriber(relayer);
 
             var relay = new ProtocolOptions { Protocol = RelayProtocols.Default };
@@ -85,221 +81,6 @@ namespace Reown.Core.Network.Test
                 BatchCalls.Add(topics);
                 var ids = topics.Select(topic => $"id-{topic}").ToArray();
                 return Task.FromResult(ids);
-            }
-        }
-
-        /// <summary>
-        ///     Minimal relayer stub for subscriber tests.
-        /// </summary>
-        private sealed class TestRelayer : IRelayer
-        {
-            /// <summary>
-            ///     Gets the core client for this relayer.
-            /// </summary>
-            public ICoreClient CoreClient => null!;
-
-            /// <summary>
-            ///     Gets whether the transport was explicitly closed.
-            /// </summary>
-            public bool TransportExplicitlyClosed => false;
-
-            /// <summary>
-            ///     Gets the subscriber module.
-            /// </summary>
-            public ISubscriber Subscriber => null!;
-
-            /// <summary>
-            ///     Gets the publisher module.
-            /// </summary>
-            public IPublisher Publisher => null!;
-
-            /// <summary>
-            ///     Gets the message tracker module.
-            /// </summary>
-            public IMessageTracker Messages => null!;
-
-            /// <summary>
-            ///     Gets the JSON-RPC provider.
-            /// </summary>
-            public IJsonRpcProvider Provider => null!;
-
-            /// <summary>
-            ///     Gets or sets the connection timeout.
-            /// </summary>
-            public TimeSpan? ConnectionTimeout { get; set; }
-
-            /// <summary>
-            ///     Gets whether the relayer is connected.
-            /// </summary>
-            public bool Connected => true;
-
-            /// <summary>
-            ///     Gets whether the relayer is connecting.
-            /// </summary>
-            public bool Connecting => false;
-
-            /// <summary>
-            ///     Gets the relayer name.
-            /// </summary>
-            public string Name => "test-relayer";
-
-            /// <summary>
-            ///     Gets the relayer context.
-            /// </summary>
-            public string Context => "test-relayer";
-
-            /// <summary>
-            ///     Raised when the relayer connects.
-            /// </summary>
-            public event EventHandler OnConnected
-            {
-                add { }
-                remove { }
-            }
-
-            /// <summary>
-            ///     Raised when the relayer disconnects.
-            /// </summary>
-            public event EventHandler OnDisconnected
-            {
-                add { }
-                remove { }
-            }
-
-            /// <summary>
-            ///     Raised when the relayer errors.
-            /// </summary>
-            public event EventHandler<Exception> OnErrored
-            {
-                add { }
-                remove { }
-            }
-
-            /// <summary>
-            ///     Raised when a message is received.
-            /// </summary>
-            public event EventHandler<MessageEvent> OnMessageReceived
-            {
-                add { }
-                remove { }
-            }
-
-            /// <summary>
-            ///     Raised when the transport closes.
-            /// </summary>
-            public event EventHandler OnTransportClosed
-            {
-                add { }
-                remove { }
-            }
-
-            /// <summary>
-            ///     Raised when the connection stalls.
-            /// </summary>
-            public event EventHandler OnConnectionStalled
-            {
-                add { }
-                remove { }
-            }
-
-            /// <summary>
-            ///     Initializes the relayer.
-            /// </summary>
-            /// <returns>A completed task.</returns>
-            public Task Init()
-            {
-                return Task.CompletedTask;
-            }
-
-            /// <summary>
-            ///     Publishes a message to the relay.
-            /// </summary>
-            /// <param name="topic">The topic to publish in.</param>
-            /// <param name="message">The message payload.</param>
-            /// <param name="opts">Publish options.</param>
-            /// <returns>A task representing the publish.</returns>
-            public Task Publish(string topic, string message, PublishOptions opts = null)
-            {
-                throw new NotImplementedException();
-            }
-
-            /// <summary>
-            ///     Subscribes to a topic.
-            /// </summary>
-            /// <param name="topic">The topic to subscribe to.</param>
-            /// <param name="opts">Subscribe options.</param>
-            /// <returns>A task returning the subscription id.</returns>
-            public Task<string> Subscribe(string topic, SubscribeOptions opts = null)
-            {
-                throw new NotImplementedException();
-            }
-
-            /// <summary>
-            ///     Unsubscribes from a topic.
-            /// </summary>
-            /// <param name="topic">The topic to unsubscribe from.</param>
-            /// <param name="opts">Unsubscribe options.</param>
-            /// <returns>A task representing the unsubscribe.</returns>
-            public Task Unsubscribe(string topic, UnsubscribeOptions opts = null)
-            {
-                throw new NotImplementedException();
-            }
-
-            /// <summary>
-            ///     Sends a JSON-RPC request.
-            /// </summary>
-            /// <typeparam name="T">The request payload type.</typeparam>
-            /// <typeparam name="TR">The response payload type.</typeparam>
-            /// <param name="request">The request arguments.</param>
-            /// <param name="context">Optional request context.</param>
-            /// <returns>A task returning the response.</returns>
-            public Task<TR> Request<T, TR>(IRequestArguments<T> request, object context = null)
-            {
-                throw new NotImplementedException();
-            }
-
-            /// <summary>
-            ///     Closes the transport connection.
-            /// </summary>
-            /// <returns>A completed task.</returns>
-            public Task TransportClose()
-            {
-                return Task.CompletedTask;
-            }
-
-            /// <summary>
-            ///     Opens the transport connection.
-            /// </summary>
-            /// <param name="relayUrl">Optional relay URL.</param>
-            /// <returns>A completed task.</returns>
-            public Task TransportOpen(string relayUrl = null)
-            {
-                return Task.CompletedTask;
-            }
-
-            /// <summary>
-            ///     Restarts the transport connection.
-            /// </summary>
-            /// <param name="relayUrl">Optional relay URL.</param>
-            /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>A completed task.</returns>
-            public Task RestartTransport(string relayUrl = null, CancellationToken cancellationToken = default)
-            {
-                return Task.CompletedTask;
-            }
-
-            /// <summary>
-            ///     Signals that the connection has stalled.
-            /// </summary>
-            void IRelayer.TriggerConnectionStalled()
-            {
-            }
-
-            /// <summary>
-            ///     Disposes of the relayer.
-            /// </summary>
-            public void Dispose()
-            {
             }
         }
     }

--- a/test/Reown.Core.Storage.Test/Reown.Core.Storage.Test.csproj
+++ b/test/Reown.Core.Storage.Test/Reown.Core.Storage.Test.csproj
@@ -16,6 +16,10 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Reown.Sign.Test/AuthenticateTests.cs
+++ b/test/Reown.Sign.Test/AuthenticateTests.cs
@@ -71,7 +71,7 @@ public class AuthenticateTests : IClassFixture<SignClientFixture>, IClassFixture
 
     // This test simulates the scenario where the wallet supports all the requested chains and methods
     // and replies with a single signature
-    [Fact]
+    [Fact] [Trait("Category", "integration")]
     public async Task TestAuthenticate_SingleSignature_AllChainsAndMethods()
     {
         await _signClientFixture.WaitForClientsReady();
@@ -158,7 +158,7 @@ public class AuthenticateTests : IClassFixture<SignClientFixture>, IClassFixture
 
     // This test simulates the scenario where the wallet supports subset of the requested chains and all methods
     // and replies with a single signature
-    [Fact]
+    [Fact] [Trait("Category", "integration")]
     public async Task TestAuthenticate_SingleSignature_SomeChainsAllMethods()
     {
         await _signClientFixture.WaitForClientsReady();
@@ -251,7 +251,7 @@ public class AuthenticateTests : IClassFixture<SignClientFixture>, IClassFixture
 
     // This test simulates the scenario where the wallet supports subset of the requested chains and methods
     // and replies with a single signature
-    [Fact]
+    [Fact] [Trait("Category", "integration")]
     public async Task TestAuthenticate_SingleSignature_SomeChainsAndMethods()
     {
         await _signClientFixture.WaitForClientsReady();
@@ -350,7 +350,7 @@ public class AuthenticateTests : IClassFixture<SignClientFixture>, IClassFixture
     }
 
     // This test simulates the scenario where the wallet supports all the requested chains and methods
-    [Fact]
+    [Fact] [Trait("Category", "integration")]
     public async Task TestAuthenticate_MultipleSignatures_AllChainsAndMethods()
     {
         await _signClientFixture.WaitForClientsReady();
@@ -423,7 +423,7 @@ public class AuthenticateTests : IClassFixture<SignClientFixture>, IClassFixture
     }
 
     // This test simulates the scenario where the wallet supports subset of requested chains and all methods
-    [Fact]
+    [Fact] [Trait("Category", "integration")]
     public async Task TestAuthenticate_MultipleSignatures_SomeChainsAllMethods()
     {
         await _signClientFixture.WaitForClientsReady();
@@ -504,7 +504,7 @@ public class AuthenticateTests : IClassFixture<SignClientFixture>, IClassFixture
     }
 
     // This test simulates the scenario where the wallet supports subset of requested chains and methods
-    [Fact]
+    [Fact] [Trait("Category", "integration")]
     public async Task TestAuthenticate_MultipleSignatures_SomeChainsAndMethods()
     {
         await _signClientFixture.WaitForClientsReady();
@@ -593,7 +593,7 @@ public class AuthenticateTests : IClassFixture<SignClientFixture>, IClassFixture
     }
 
     // Should establish normal sign session when URI doesn't specify `wc_sessionAuthenticate` method"
-    [Fact]
+    [Fact] [Trait("Category", "integration")]
     public async Task TestAuthenticate_NoWcAuthenticateInUri()
     {
         await _signClientFixture.WaitForClientsReady();
@@ -652,7 +652,7 @@ public class AuthenticateTests : IClassFixture<SignClientFixture>, IClassFixture
     }
 
     // Should establish normal sign session when wallet hasn't subscribed to SessionAuthenticateRequest event
-    [Fact]
+    [Fact] [Trait("Category", "integration")]
     public async Task TestAuthenticate_NoWcAuthenticateListeners()
     {
         await _signClientFixture.WaitForClientsReady();

--- a/test/Reown.Sign.Test/EngineValidatorTests.cs
+++ b/test/Reown.Sign.Test/EngineValidatorTests.cs
@@ -1,0 +1,620 @@
+using System;
+using System.Collections.Generic;
+using Reown.Core.Common.Model.Errors;
+using Reown.Core.Common.Utils;
+using Reown.Core.Models.Relay;
+using Reown.Core.Network.Models;
+using Reown.Sign.Models;
+using Reown.Sign.Models.Engine;
+using Reown.Sign.Models.Engine.Methods;
+using Xunit;
+
+namespace Reown.Sign.Test
+{
+    /// <summary>
+    ///     Unit tests for <see cref="EngineValidator" />. These tests exercise pure validation
+    ///     logic without standing up a live <see cref="Engine" /> or relay client.
+    /// </summary>
+    public class EngineValidatorTests
+    {
+        private const string EthAccount = "eip155:1:0x0000000000000000000000000000000000000000";
+        private const string EthChain = "eip155:1";
+
+        private static Namespaces SingleEip155Namespace(
+            string[]? accounts = null,
+            string[]? methods = null,
+            string[]? events = null)
+        {
+            return new Namespaces
+            {
+                ["eip155"] = new Namespace
+                {
+                    Accounts = accounts ?? new[] { EthAccount },
+                    Methods = methods ?? new[] { "eth_sign" },
+                    Events = events ?? new[] { "chainChanged" }
+                }
+            };
+        }
+
+        private static RequiredNamespaces SingleEip155Required(
+            string[]? chains = null,
+            string[]? methods = null,
+            string[]? events = null)
+        {
+            return new RequiredNamespaces
+            {
+                ["eip155"] = new ProposedNamespace
+                {
+                    Chains = chains ?? new[] { EthChain },
+                    Methods = methods ?? new[] { "eth_sign" },
+                    Events = events ?? new[] { "chainChanged" }
+                }
+            };
+        }
+
+        // -------------------- GetAccountsChains --------------------
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void GetAccountsChains_ExtractsChainPrefix()
+        {
+            var chains = EngineValidator.GetAccountsChains(new[]
+            {
+                "eip155:1:0xabc",
+                "eip155:137:0xdef",
+                "solana:101:somepubkey"
+            });
+
+            Assert.Equal(new[] { "eip155:1", "eip155:137", "solana:101" }, chains);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void GetAccountsChains_EmptyInput_ReturnsEmpty()
+        {
+            var chains = EngineValidator.GetAccountsChains(Array.Empty<string>());
+            Assert.Empty(chains);
+        }
+
+        // -------------------- HasOverlap --------------------
+
+        [Theory]
+        [Trait("Category", "unit")]
+        [InlineData(new[] { "a", "b" }, new[] { "a", "b", "c" }, true)]
+        [InlineData(new[] { "a" }, new[] { "a" }, true)]
+        [InlineData(new string[0], new[] { "a" }, true)]
+        [InlineData(new[] { "a", "b" }, new[] { "a" }, false)]
+        [InlineData(new[] { "a" }, new string[0], false)]
+        public void HasOverlap_ReturnsExpected(string[] a, string[] b, bool expected)
+        {
+            Assert.Equal(expected, EngineValidator.HasOverlap(a, b));
+        }
+
+        // -------------------- ValidateAccounts --------------------
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateAccounts_ValidAccount_DoesNotThrow()
+        {
+            EngineValidator.ValidateAccounts(new[] { EthAccount }, "ctx");
+        }
+
+        [Theory]
+        [Trait("Category", "unit")]
+        [InlineData("nochain")]
+        [InlineData("eip155:1")] // missing address
+        [InlineData("eip155::0xabc")] // empty reference
+        public void ValidateAccounts_InvalidAccount_ThrowsFormatOrArgument(string badAccount)
+        {
+            // IsValidAccountId throws ArgumentException on malformed ids; ValidateAccounts wraps
+            // the boolean result in a FormatException. Either is acceptable from a contract view,
+            // so we accept both.
+            var ex = Record.Exception(() => EngineValidator.ValidateAccounts(new[] { badAccount }, "ctx"));
+            Assert.NotNull(ex);
+            Assert.True(ex is FormatException || ex is ArgumentException,
+                $"Expected FormatException or ArgumentException but got {ex!.GetType().Name}: {ex.Message}");
+        }
+
+        // -------------------- ValidateNamespaces --------------------
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateNamespaces_Null_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => EngineValidator.ValidateNamespaces(null!, "approve()"));
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateNamespaces_ValidNamespaces_DoesNotThrow()
+        {
+            EngineValidator.ValidateNamespaces(SingleEip155Namespace(), "approve()");
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateNamespaces_BadlyFormattedAccount_Throws()
+        {
+            var ns = SingleEip155Namespace(accounts: new[] { "not-a-valid-account" });
+            Assert.ThrowsAny<Exception>(() => EngineValidator.ValidateNamespaces(ns, "approve()"));
+        }
+
+        // -------------------- ValidateNamespacesChainId --------------------
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateNamespacesChainId_ValidChainPresent_DoesNotThrow()
+        {
+            EngineValidator.ValidateNamespacesChainId(SingleEip155Namespace(), EthChain);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateNamespacesChainId_InvalidChainIdFormat_ThrowsFormatException()
+        {
+            var ex = Assert.Throws<FormatException>(
+                () => EngineValidator.ValidateNamespacesChainId(SingleEip155Namespace(), "not_a_chain_id"));
+            Assert.Contains("CAIP-2", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateNamespacesChainId_ChainIdNotInNamespaces_ThrowsNamespacesException()
+        {
+            var ex = Assert.Throws<NamespacesException>(
+                () => EngineValidator.ValidateNamespacesChainId(SingleEip155Namespace(), "eip155:999"));
+            Assert.Contains("eip155:999", ex.Message);
+        }
+
+        // -------------------- ValidateConformingNamespaces --------------------
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateConformingNamespaces_NullRequired_DoesNotThrow()
+        {
+            EngineValidator.ValidateConformingNamespaces(null!, SingleEip155Namespace(), "update()");
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateConformingNamespaces_AllConform_DoesNotThrow()
+        {
+            EngineValidator.ValidateConformingNamespaces(
+                SingleEip155Required(),
+                SingleEip155Namespace(),
+                "update()");
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateConformingNamespaces_MissingKey_Throws()
+        {
+            var required = new RequiredNamespaces
+            {
+                ["solana"] = new ProposedNamespace
+                {
+                    Chains = new[] { "solana:101" },
+                    Methods = new[] { "sol_sign" },
+                    Events = Array.Empty<string>()
+                }
+            };
+
+            var ex = Assert.Throws<NamespacesException>(() =>
+                EngineValidator.ValidateConformingNamespaces(required, SingleEip155Namespace(), "update()"));
+            Assert.Contains("requiredNamespaces", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateConformingNamespaces_MissingChain_Throws()
+        {
+            var required = SingleEip155Required(chains: new[] { "eip155:1", "eip155:137" });
+            var ex = Assert.Throws<NamespacesException>(() =>
+                EngineValidator.ValidateConformingNamespaces(required, SingleEip155Namespace(), "update()"));
+            Assert.Contains("chains", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateConformingNamespaces_MissingMethod_Throws()
+        {
+            var required = SingleEip155Required(methods: new[] { "eth_sign", "eth_signTypedData" });
+            var ex = Assert.Throws<NamespacesException>(() =>
+                EngineValidator.ValidateConformingNamespaces(required, SingleEip155Namespace(), "update()"));
+            Assert.Contains("methods", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateConformingNamespaces_MissingEvent_Throws()
+        {
+            var required = SingleEip155Required(events: new[] { "chainChanged", "accountsChanged" });
+            var ex = Assert.Throws<NamespacesException>(() =>
+                EngineValidator.ValidateConformingNamespaces(required, SingleEip155Namespace(), "update()"));
+            Assert.Contains("events", ex.Message);
+        }
+
+        // -------------------- GetNamespaces{Methods,Events,Chains}ForChainId --------------------
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void GetNamespacesMethodsForChainId_ReturnsMatchingMethods()
+        {
+            var ns = SingleEip155Namespace(methods: new[] { "eth_sign", "personal_sign" });
+            var methods = EngineValidator.GetNamespacesMethodsForChainId(ns, EthChain);
+            Assert.Equal(new[] { "eth_sign", "personal_sign" }, methods);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void GetNamespacesMethodsForChainId_UnknownChain_ReturnsEmpty()
+        {
+            var methods = EngineValidator.GetNamespacesMethodsForChainId(SingleEip155Namespace(), "eip155:999");
+            Assert.Empty(methods);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void GetNamespacesEventsForChainId_ReturnsMatchingEvents()
+        {
+            var ns = SingleEip155Namespace(events: new[] { "chainChanged", "accountsChanged" });
+            var events = EngineValidator.GetNamespacesEventsForChainId(ns, EthChain);
+            Assert.Equal(new[] { "chainChanged", "accountsChanged" }, events);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void GetNamespacesChains_AggregatesFromAllNamespaces()
+        {
+            var ns = new Namespaces
+            {
+                ["eip155"] = new Namespace
+                {
+                    Accounts = new[] { EthAccount },
+                    Methods = Array.Empty<string>(),
+                    Events = Array.Empty<string>()
+                },
+                ["solana"] = new Namespace
+                {
+                    Accounts = new[] { "solana:101:pubkey" },
+                    Methods = Array.Empty<string>(),
+                    Events = Array.Empty<string>()
+                }
+            };
+
+            var chains = EngineValidator.GetNamespacesChains(ns);
+            Assert.Contains("eip155:1", chains);
+            Assert.Contains("solana:101", chains);
+        }
+
+        // -------------------- IsSessionCompatible --------------------
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void IsSessionCompatible_FullMatch_ReturnsTrue()
+        {
+            var session = new Session { Namespaces = SingleEip155Namespace() };
+            Assert.True(EngineValidator.IsSessionCompatible(session, SingleEip155Required()));
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void IsSessionCompatible_MissingRequiredKey_ReturnsFalse()
+        {
+            var session = new Session { Namespaces = SingleEip155Namespace() };
+            var required = new RequiredNamespaces
+            {
+                ["solana"] = new ProposedNamespace
+                {
+                    Chains = new[] { "solana:101" },
+                    Methods = Array.Empty<string>(),
+                    Events = Array.Empty<string>()
+                }
+            };
+
+            Assert.False(EngineValidator.IsSessionCompatible(session, required));
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void IsSessionCompatible_MissingMethod_ReturnsFalse()
+        {
+            var session = new Session { Namespaces = SingleEip155Namespace(methods: new[] { "eth_sign" }) };
+            var required = SingleEip155Required(methods: new[] { "eth_sign", "eth_sendTransaction" });
+            Assert.False(EngineValidator.IsSessionCompatible(session, required));
+        }
+
+        // -------------------- ValidateAuthParams --------------------
+
+        private static AuthParams MakeValidAuthParams()
+        {
+            return new AuthParams(
+                chains: new[] { EthChain },
+                domain: "example.com",
+                nonce: "abc123",
+                uri: "https://example.com",
+                nbf: null,
+                exp: null,
+                statement: null,
+                requestId: null,
+                resources: null,
+                methods: null);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateAuthParams_Valid_DoesNotThrow()
+        {
+            EngineValidator.ValidateAuthParams(MakeValidAuthParams());
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateAuthParams_NullChains_ThrowsArgumentException()
+        {
+            var p = MakeValidAuthParams();
+            p.Chains = null!;
+            var ex = Assert.Throws<ArgumentException>(() => EngineValidator.ValidateAuthParams(p));
+            Assert.Contains("Chains", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateAuthParams_EmptyChains_ThrowsArgumentException()
+        {
+            var p = MakeValidAuthParams();
+            p.Chains = Array.Empty<string>();
+            Assert.Throws<ArgumentException>(() => EngineValidator.ValidateAuthParams(p));
+        }
+
+        [Theory]
+        [Trait("Category", "unit")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        public void ValidateAuthParams_BlankUri_ThrowsArgumentException(string? uri)
+        {
+            var p = MakeValidAuthParams();
+            p.Uri = uri!;
+            var ex = Assert.Throws<ArgumentException>(() => EngineValidator.ValidateAuthParams(p));
+            Assert.Contains("Uri", ex.Message);
+        }
+
+        [Theory]
+        [Trait("Category", "unit")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("\t")]
+        public void ValidateAuthParams_BlankDomain_ThrowsArgumentException(string? domain)
+        {
+            var p = MakeValidAuthParams();
+            p.Domain = domain!;
+            var ex = Assert.Throws<ArgumentException>(() => EngineValidator.ValidateAuthParams(p));
+            Assert.Contains("Domain", ex.Message);
+        }
+
+        [Theory]
+        [Trait("Category", "unit")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void ValidateAuthParams_BlankNonce_ThrowsArgumentException(string? nonce)
+        {
+            var p = MakeValidAuthParams();
+            p.Nonce = nonce!;
+            var ex = Assert.Throws<ArgumentException>(() => EngineValidator.ValidateAuthParams(p));
+            Assert.Contains("Nonce", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateAuthParams_MultipleNamespaces_ThrowsArgumentException()
+        {
+            var p = MakeValidAuthParams();
+            p.Chains = new[] { "eip155:1", "solana:101" };
+            var ex = Assert.Throws<ArgumentException>(() => EngineValidator.ValidateAuthParams(p));
+            Assert.Contains("Multi-namespace", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateAuthParams_NonEip155Namespace_ThrowsArgumentException()
+        {
+            var p = MakeValidAuthParams();
+            p.Chains = new[] { "solana:101" };
+            var ex = Assert.Throws<ArgumentException>(() => EngineValidator.ValidateAuthParams(p));
+            Assert.Contains("eip155", ex.Message);
+        }
+
+        // -------------------- ValidateSessionSettleRequest --------------------
+
+        private static SessionSettle MakeValidSettle()
+        {
+            return new SessionSettle
+            {
+                Controller = new Participant { PublicKey = "deadbeef" },
+                Relay = new ProtocolOptions { Protocol = "irn" },
+                Namespaces = SingleEip155Namespace(),
+                Expiry = Clock.CalculateExpiry(Clock.ONE_HOUR)
+            };
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateSessionSettleRequest_Valid_DoesNotThrow()
+        {
+            EngineValidator.ValidateSessionSettleRequest(MakeValidSettle());
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateSessionSettleRequest_Null_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => EngineValidator.ValidateSessionSettleRequest(null!));
+        }
+
+        [Theory]
+        [Trait("Category", "unit")]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ValidateSessionSettleRequest_BlankRelayProtocol_ThrowsArgumentException(string protocol)
+        {
+            var s = MakeValidSettle();
+            s.Relay = new ProtocolOptions { Protocol = protocol };
+            var ex = Assert.Throws<ArgumentException>(() => EngineValidator.ValidateSessionSettleRequest(s));
+            Assert.Contains("Relay protocol", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateSessionSettleRequest_NullController_ThrowsArgumentException()
+        {
+            var s = MakeValidSettle();
+            s.Controller = null!;
+            var ex = Assert.Throws<ArgumentException>(() => EngineValidator.ValidateSessionSettleRequest(s));
+            Assert.Contains("Controller", ex.Message);
+        }
+
+        [Theory]
+        [Trait("Category", "unit")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        public void ValidateSessionSettleRequest_BlankControllerKey_ThrowsArgumentException(string? key)
+        {
+            var s = MakeValidSettle();
+            s.Controller = new Participant { PublicKey = key! };
+            Assert.Throws<ArgumentException>(() => EngineValidator.ValidateSessionSettleRequest(s));
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateSessionSettleRequest_NullNamespaces_ThrowsArgumentNullException()
+        {
+            var s = MakeValidSettle();
+            s.Namespaces = null!;
+            Assert.Throws<ArgumentNullException>(() => EngineValidator.ValidateSessionSettleRequest(s));
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateSessionSettleRequest_ExpiredExpiry_ThrowsInvalidOperationException()
+        {
+            var s = MakeValidSettle();
+            s.Expiry = 1; // far in the past
+            var ex = Assert.Throws<InvalidOperationException>(() => EngineValidator.ValidateSessionSettleRequest(s));
+            Assert.Contains("expired", ex.Message);
+        }
+
+        // -------------------- ValidateApproveOptions --------------------
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateApproveOptions_NullRelayProtocolAndNullSessionProperties_DoesNotThrow()
+        {
+            EngineValidator.ValidateApproveOptions(null, null);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateApproveOptions_NonEmptyRelayProtocol_DoesNotThrow()
+        {
+            EngineValidator.ValidateApproveOptions("irn", null);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateApproveOptions_ValidSessionProperties_DoesNotThrow()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                ["foo"] = "bar",
+                ["baz"] = "qux"
+            };
+            EngineValidator.ValidateApproveOptions("irn", properties);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateApproveOptions_EmptySessionPropertiesDictionary_DoesNotThrow()
+        {
+            EngineValidator.ValidateApproveOptions(null, new Dictionary<string, string>());
+        }
+
+        [Theory]
+        [Trait("Category", "unit")]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("\t")]
+        public void ValidateApproveOptions_BlankRelayProtocol_ThrowsArgumentException(string protocol)
+        {
+            var ex = Assert.Throws<ArgumentException>(
+                () => EngineValidator.ValidateApproveOptions(protocol, null));
+            Assert.Contains("RelayProtocol", ex.Message);
+        }
+
+        [Theory]
+        [Trait("Category", "unit")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ValidateApproveOptions_SessionPropertiesContainsBlankValue_ThrowsArgumentException(string? badValue)
+        {
+            var properties = new Dictionary<string, string>
+            {
+                ["good"] = "value",
+                ["bad"] = badValue!
+            };
+
+            var ex = Assert.Throws<ArgumentException>(
+                () => EngineValidator.ValidateApproveOptions(null, properties));
+            Assert.Contains("SessionProperties", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateApproveOptions_BlankRelayProtocolCheckedBeforeSessionProperties()
+        {
+            // Both are invalid; the relay-protocol check must fire first to preserve the
+            // original ordering inside IsValidApprove.
+            var properties = new Dictionary<string, string>
+            {
+                ["bad"] = null!
+            };
+
+            var ex = Assert.Throws<ArgumentException>(
+                () => EngineValidator.ValidateApproveOptions("", properties));
+            Assert.Contains("RelayProtocol", ex.Message);
+        }
+
+        // -------------------- ValidateRejectReason --------------------
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateRejectReason_ValidReason_DoesNotThrow()
+        {
+            EngineValidator.ValidateRejectReason(new Error { Code = 5000, Message = "user rejected" });
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ValidateRejectReason_NullReason_ThrowsArgumentException()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => EngineValidator.ValidateRejectReason(null!));
+            Assert.Contains("Reject reason", ex.Message);
+        }
+
+        [Theory]
+        [Trait("Category", "unit")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("\t")]
+        public void ValidateRejectReason_BlankMessage_ThrowsArgumentException(string? message)
+        {
+            var ex = Assert.Throws<ArgumentException>(
+                () => EngineValidator.ValidateRejectReason(new Error { Code = 5000, Message = message! }));
+            Assert.Contains("Reject reason", ex.Message);
+        }
+    }
+}

--- a/test/Reown.Sign.Test/Reown.Sign.Test.csproj
+++ b/test/Reown.Sign.Test/Reown.Sign.Test.csproj
@@ -16,6 +16,10 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Reown.WalletKit.Test/Reown.WalletKit.Test.csproj
+++ b/test/Reown.WalletKit.Test/Reown.WalletKit.Test.csproj
@@ -16,6 +16,10 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

Applies the top-5 prioritized fixes plus follow-ups from a multi-skill test-quality audit of the .NET test suite.

- **Validation seam** — extracts 14 pure validation helpers from `EngineValidation` into a new static `EngineValidator`, leaving `EngineValidation` partial methods as thin forwarders. Exception types and messages preserved byte-for-byte.
- **Test coverage** — adds 71 unit tests for the extracted validators in `EngineValidatorTests`, plus `Reown.Core.Common.Test` is now included in `Reown.NoUnity.slnf` and runs with the standard `dotnet test` command.
- **Test correctness** — fixes `CryptoFixtures` `async void Init()` that could silently swallow exceptions and deadlock awaiters; replaces with a `Task` field set from the constructor.
- **Categorization** — tags `AuthenticateTests` as `integration` (8 facts) and `HexByteConvertorExtensionsTests` as `unit` so `--filter Category=...` works correctly.
- **Infrastructure** — adds `coverlet.collector` to all test projects via central package management for coverage collection.
- **Mocking** — replaces the 58-line hand-rolled `TestRelayer` in `SubscriberBatchSubscribeTests` with `Substitute.For<IRelayer>()`. Requires `InternalsVisibleTo("DynamicProxyGenAssembly2")` on `Reown.Core` so Castle DynamicProxy can implement `IRelayer.TriggerConnectionStalled()` (which is `internal`).

## Extraction shape

```mermaid
graph LR
    A[EngineValidation.cs<br/>partial class] -->|forwards to| B[EngineValidator.cs<br/>static internal]
    A -->|IsValidApprove| C[ValidateApproveOptions]
    A -->|IsValidReject| D[ValidateRejectReason]
    A -->|IsValidConnect| E[ValidateNamespaces<br/>ValidateConformingNamespaces]
    A -->|IsValidApprove| E
    B --> F[EngineValidatorTests.cs<br/>71 unit tests]
```

## Test plan

- [x] `dotnet build Reown.NoUnity.slnf` — 0 errors, 0 warnings
- [x] `dotnet test Reown.NoUnity.slnf --filter Category=unit` — 151/151 passing on net10.0
- [ ] CI .NET unit + integration tests (Windows)
- [ ] CI Unity builds (Windows/Android/WebGL)
- [ ] CI SonarCloud coverage now collects from all test projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)