### PR TITLE
fix(sign): GetHashCode/Equals contract + expand unit coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ Current `[VersionMarker]` usage:
 
 Test projects target: `net8.0`, `net9.0`, `net10.0` (with `ImplicitUsings` and `Nullable` enabled)
 
-C# language version is set to 9.0 for Unity IL2CPP compatibility.
+C# language version is set to 9.0 for `src/` projects (via `src/Directory.Build.props`) for Unity IL2CPP compatibility. Test projects are not compiled by Unity, so `test/Directory.Build.props` pins them to C# 12.0 — the highest version supported by the lowest test target framework (net8.0). Use modern C# (up to 12.0) freely in tests.
 
 ### Key Dependencies
 
@@ -278,7 +278,7 @@ com.reown.appkit.unity
 - Follow existing code conventions in each file
 - Use existing libraries and utilities rather than adding new dependencies
 - Place `using` directives at the top of files (ImplicitUsings is disabled in src projects)
-- C# language version is 9.0 — do not use C# 10+ features (file-scoped namespaces, global usings, etc.) as they are incompatible with Unity IL2CPP/AOT compilation
+- C# language version is 9.0 for `src/` — do not use C# 10+ features (file-scoped namespaces, global usings, etc.) as they are incompatible with Unity IL2CPP/AOT compilation. This applies only to `src/`; test projects are pinned to C# 12.0 (see Target Frameworks) and may use newer features
 - Use centralized package versioning: add new NuGet dependencies to `Directory.Packages.props`, not individual `.csproj` files
 
 ### Testing Requirements

--- a/src/Reown.Core.Crypto/Runtime/Encoder/Base58Encoding.cs
+++ b/src/Reown.Core.Crypto/Runtime/Encoder/Base58Encoding.cs
@@ -9,7 +9,7 @@ namespace Reown.Core.Crypto.Encoder
     public static class Base58Encoding
     {
         public const int CheckSumSizeInBytes = 4;
-        private const string DIGITS = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+        private const string Digits = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
         public static byte[] AddCheckSum(byte[] data)
         {
@@ -44,7 +44,7 @@ namespace Reown.Core.Crypto.Encoder
             {
                 var remainder = (int)(intData % 58);
                 intData /= 58;
-                result = DIGITS[remainder] + result;
+                result = Digits[remainder] + result;
             }
 
             // Append `1` for each leading 0 byte
@@ -67,7 +67,7 @@ namespace Reown.Core.Crypto.Encoder
             BigInteger intData = 0;
             for (var i = 0; i < s.Length; i++)
             {
-                var digit = DIGITS.IndexOf(s[i]); //Slow
+                var digit = Digits.IndexOf(s[i]); //Slow
                 if (digit < 0)
                     throw new FormatException($"Invalid Base58 character `{s[i]}` at position {i}");
                 intData = intData * 58 + digit;

--- a/src/Reown.Sign/Runtime/Models/Namespace.cs
+++ b/src/Reown.Sign/Runtime/Models/Namespace.cs
@@ -112,7 +112,30 @@ namespace Reown.Sign.Models
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Accounts, Methods, Events);
+            return ContentHashCode(Accounts, Methods, Events);
+        }
+
+        private static int ContentHashCode(string[] accounts, string[] methods, string[] events)
+        {
+            var hash = new HashCode();
+            hash.Add(UnorderedHashCode(accounts));
+            hash.Add(UnorderedHashCode(methods));
+            hash.Add(UnorderedHashCode(events));
+            return hash.ToHashCode();
+        }
+
+        private static int UnorderedHashCode(string[] values)
+        {
+            if (values == null)
+                return 0;
+
+            var hash = 0;
+            foreach (var value in values)
+            {
+                hash ^= value?.GetHashCode() ?? 0;
+            }
+
+            return hash;
         }
 
         public bool TryGetChains(out string[] chainIds)
@@ -182,7 +205,7 @@ namespace Reown.Sign.Models
 
             public int GetHashCode(Namespace obj)
             {
-                return HashCode.Combine(obj.Accounts, obj.Methods, obj.Events);
+                return ContentHashCode(obj.Accounts, obj.Methods, obj.Events);
             }
         }
     }

--- a/src/Reown.Sign/Runtime/Models/Namespace.cs
+++ b/src/Reown.Sign/Runtime/Models/Namespace.cs
@@ -81,7 +81,18 @@ namespace Reown.Sign.Models
 
         private static bool ArrayEquals(string[] a, string[] b)
         {
-            return a.Length == b.Length && Array.TrueForAll(a, b.Contains) && Array.TrueForAll(b, a.Contains);
+            if (ReferenceEquals(a, b))
+            {
+                return true;
+            }
+
+            if (a == null || b == null || a.Length != b.Length)
+            {
+                return false;
+            }
+
+            return a.OrderBy(value => value, StringComparer.Ordinal)
+                .SequenceEqual(b.OrderBy(value => value, StringComparer.Ordinal), StringComparer.Ordinal);
         }
 
         private bool Equals(Namespace other)
@@ -132,7 +143,10 @@ namespace Reown.Sign.Models
             var hash = 0;
             foreach (var value in values)
             {
-                hash ^= value?.GetHashCode() ?? 0;
+                unchecked
+                {
+                    hash += value?.GetHashCode() ?? 0;
+                }
             }
 
             return hash;

--- a/src/Reown.Sign/Runtime/Models/ProposedNamespace.cs
+++ b/src/Reown.Sign/Runtime/Models/ProposedNamespace.cs
@@ -112,7 +112,32 @@ namespace Reown.Sign.Models
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Chains, Methods, Events);
+            return ContentHashCode(Chains, Methods, Events);
+        }
+
+        private static int ContentHashCode(string[] chains, string[] methods, string[] events)
+        {
+            var hash = new HashCode();
+            hash.Add(UnorderedHashCode(chains));
+            hash.Add(UnorderedHashCode(methods));
+            hash.Add(UnorderedHashCode(events));
+            return hash.ToHashCode();
+        }
+
+        private static int UnorderedHashCode(string[] values)
+        {
+            if (values == null)
+            {
+                return 0;
+            }
+
+            var hash = 0;
+            foreach (var value in values)
+            {
+                hash ^= value == null ? 0 : value.GetHashCode();
+            }
+
+            return hash;
         }
 
         private sealed class RequiredNamespaceEqualityComparer : IEqualityComparer<ProposedNamespace>
@@ -145,7 +170,7 @@ namespace Reown.Sign.Models
 
             public int GetHashCode(ProposedNamespace obj)
             {
-                return HashCode.Combine(obj.Chains, obj.Methods, obj.Events);
+                return ContentHashCode(obj.Chains, obj.Methods, obj.Events);
             }
         }
     }

--- a/src/Reown.Sign/Runtime/Models/ProposedNamespace.cs
+++ b/src/Reown.Sign/Runtime/Models/ProposedNamespace.cs
@@ -81,7 +81,18 @@ namespace Reown.Sign.Models
 
         protected bool ArrayEquals(string[] a, string[] b)
         {
-            return a.Length == b.Length && a.All(b.Contains) && b.All(a.Contains);
+            if (ReferenceEquals(a, b))
+            {
+                return true;
+            }
+
+            if (a == null || b == null || a.Length != b.Length)
+            {
+                return false;
+            }
+
+            return a.OrderBy(value => value, StringComparer.Ordinal)
+                .SequenceEqual(b.OrderBy(value => value, StringComparer.Ordinal), StringComparer.Ordinal);
         }
 
         protected bool Equals(ProposedNamespace other)
@@ -134,7 +145,10 @@ namespace Reown.Sign.Models
             var hash = 0;
             foreach (var value in values)
             {
-                hash ^= value == null ? 0 : value.GetHashCode();
+                unchecked
+                {
+                    hash += value?.GetHashCode() ?? 0;
+                }
             }
 
             return hash;

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup Label="C#">
+        <!--
+            Test projects are not compiled by Unity, so they are not bound to the C# 9.0
+            limit that src/Directory.Build.props imposes for IL2CPP/AOT compatibility.
+            Pinned to 12.0 (the highest version supported by the lowest target framework,
+            net8.0) so it stays consistent across net8.0;net9.0;net10.0.
+        -->
+        <LangVersion>12.0</LangVersion>
+    </PropertyGroup>
+</Project>

--- a/test/Reown.Core.Common.Test/Base64Tests.cs
+++ b/test/Reown.Core.Common.Test/Base64Tests.cs
@@ -1,0 +1,45 @@
+using Reown.Core.Common.Utils;
+using Xunit;
+
+namespace Reown.Core.Common.Test;
+
+[Trait("Category", "unit")]
+public class Base64Tests
+{
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 2)]
+    [InlineData(2, 3)]
+    [InlineData(3, 4)]
+    [InlineData(6, 8)]
+    [InlineData(7, 10)]
+    public void GetBase64UrlEncodeLength_ReturnsExpectedLength(int length, int expected)
+    {
+        Assert.Equal(expected, Base64.GetBase64UrlEncodeLength(length));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(7)]
+    public void EncodeToBase64UrlString_MatchesUrlSafeUnpaddedBase64(int length)
+    {
+        var bytes = new byte[length];
+        for (var i = 0; i < length; i++)
+        {
+            bytes[i] = (byte)(i * 53 + 200);
+        }
+
+        var expected = Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        Assert.Equal(expected, Base64.EncodeToBase64UrlString(bytes));
+    }
+
+    [Fact]
+    public void EncodeToBase64UrlString_UsesUrlSafeAlphabet()
+    {
+        Assert.Equal("__79", Base64.EncodeToBase64UrlString([0xFF, 0xFE, 0xFD]));
+    }
+}

--- a/test/Reown.Core.Common.Test/DictionaryComparerTests.cs
+++ b/test/Reown.Core.Common.Test/DictionaryComparerTests.cs
@@ -1,0 +1,65 @@
+using Reown.Core.Common.Utils;
+using Xunit;
+
+namespace Reown.Core.Common.Test;
+
+[Trait("Category", "unit")]
+public class DictionaryComparerTests
+{
+    private static readonly DictionaryComparer<string, int> Comparer = new();
+
+    [Fact]
+    public void Equals_IdenticalDictionaries_IgnoresOrder_ReturnsTrue()
+    {
+        var x = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var y = new Dictionary<string, int> { ["b"] = 2, ["a"] = 1 };
+
+        Assert.True(Comparer.Equals(x, y));
+    }
+
+    [Fact]
+    public void Equals_DifferentCounts_ReturnsFalse()
+    {
+        var x = new Dictionary<string, int> { ["a"] = 1 };
+        var y = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+
+        Assert.False(Comparer.Equals(x, y));
+    }
+
+    [Fact]
+    public void Equals_DifferentKeys_ReturnsFalse()
+    {
+        var x = new Dictionary<string, int> { ["a"] = 1 };
+        var y = new Dictionary<string, int> { ["b"] = 1 };
+
+        Assert.False(Comparer.Equals(x, y));
+    }
+
+    [Fact]
+    public void Equals_DifferentValues_ReturnsFalse()
+    {
+        var x = new Dictionary<string, int> { ["a"] = 1 };
+        var y = new Dictionary<string, int> { ["a"] = 2 };
+
+        Assert.False(Comparer.Equals(x, y));
+    }
+
+    [Fact]
+    public void Equals_UsesProvidedValueComparer()
+    {
+        var comparer = new DictionaryComparer<string, string>(StringComparer.OrdinalIgnoreCase);
+        var x = new Dictionary<string, string> { ["k"] = "VALUE" };
+        var y = new Dictionary<string, string> { ["k"] = "value" };
+
+        Assert.True(comparer.Equals(x, y));
+    }
+
+    [Fact]
+    public void GetHashCode_EqualDictionaries_ProduceSameHash()
+    {
+        var x = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var y = new Dictionary<string, int> { ["b"] = 2, ["a"] = 1 };
+
+        Assert.Equal(Comparer.GetHashCode(x), Comparer.GetHashCode(y));
+    }
+}

--- a/test/Reown.Core.Common.Test/HexByteConvertorExtensionsTests.cs
+++ b/test/Reown.Core.Common.Test/HexByteConvertorExtensionsTests.cs
@@ -53,4 +53,113 @@ public class HexByteConvertorExtensionsTests
         Assert.Equal(expectedEmptyWithPrefix, resultEmptyWithPrefix);
         Assert.Equal(expectedEmptyWithoutPrefix, resultEmptyWithoutPrefix);
     }
+
+    [Fact]
+    public void StringToHex_EncodesUtf8()
+    {
+        Assert.Equal("0x48656c6c6f", "Hello".ToHex(true));
+    }
+
+    [Theory]
+    [InlineData(255, true, "0xff")]
+    [InlineData(255, false, "ff")]
+    public void IntToHex_FormatsValue(int value, bool prefix, string expected)
+    {
+        Assert.Equal(expected, value.ToHex(prefix));
+    }
+
+    [Theory]
+    [InlineData("0x1a2b3c", true)]
+    [InlineData("1a2b3c", true)]
+    [InlineData("0xABCDEF", true)]
+    [InlineData("deadBEEF", true)]
+    [InlineData("0x", true)]
+    [InlineData("0x1g", false)]
+    [InlineData("xyz", false)]
+    public void IsHex_VariousInputs_ReturnsExpected(string value, bool expected)
+    {
+        Assert.Equal(expected, value.IsHex());
+    }
+
+    [Theory]
+    [InlineData("0xabc", true)]
+    [InlineData("abc", false)]
+    public void HasHexPrefix_ChecksLeadingPrefix(string value, bool expected)
+    {
+        Assert.Equal(expected, value.HasHexPrefix());
+    }
+
+    [Theory]
+    [InlineData("0xabc", "abc")]
+    [InlineData("abc", "abc")]
+    public void RemoveHexPrefix_StripsLeadingPrefix(string value, string expected)
+    {
+        Assert.Equal(expected, value.RemoveHexPrefix());
+    }
+
+    [Theory]
+    [InlineData("abc", "0xabc")]
+    [InlineData("0xabc", "0xabc")]
+    public void EnsureHexPrefix_AddsPrefixWhenMissing(string value, string expected)
+    {
+        Assert.Equal(expected, value.EnsureHexPrefix());
+    }
+
+    [Fact]
+    public void EnsureHexPrefix_NullValue_ReturnsNull()
+    {
+        string? value = null;
+
+        Assert.Null(value.EnsureHexPrefix());
+    }
+
+    [Theory]
+    [InlineData("0xABCDEF", "abcdef", true)]
+    [InlineData("0xabc", "0xdef", false)]
+    public void IsTheSameHex_ComparesCaseInsensitivelyIgnoringPrefix(string first, string second, bool expected)
+    {
+        Assert.Equal(expected, first.IsTheSameHex(second));
+    }
+
+    [Fact]
+    public void HexToByteArray_RoundTripsWithToHex()
+    {
+        var bytes = new byte[] { 0x48, 0x65, 0x6c, 0x6c, 0x6f };
+
+        Assert.Equal(bytes, bytes.ToHex(true).HexToByteArray());
+    }
+
+    [Fact]
+    public void HexToByteArray_OddLengthString_PadsLeadingZero()
+    {
+        Assert.Equal(new byte[] { 0x0a }, "a".HexToByteArray());
+    }
+
+    [Fact]
+    public void HexToByteArray_EmptyString_ReturnsEmpty()
+    {
+        Assert.Empty("".HexToByteArray());
+    }
+
+    [Fact]
+    public void HexToByteArray_InvalidCharacter_ThrowsFormatException()
+    {
+        Assert.Throws<FormatException>(() => "0xZZ".HexToByteArray());
+    }
+
+    [Fact]
+    public void ToHexCompact_TrimsLeadingZeros()
+    {
+        var bytes = new byte[] { 0x00, 0x0a };
+
+        Assert.Equal("a", bytes.ToHexCompact());
+    }
+
+    [Fact]
+    public void ToHexCompact_AllZeroBytes_ReturnsEmptyString()
+    {
+        var bytes = new byte[] { 0x00, 0x00 };
+
+        Assert.Equal(string.Empty, bytes.ToHexCompact());
+    }
 }

--- a/test/Reown.Core.Common.Test/SdkErrorsTests.cs
+++ b/test/Reown.Core.Common.Test/SdkErrorsTests.cs
@@ -1,0 +1,69 @@
+using Reown.Core.Common.Model.Errors;
+using Xunit;
+
+namespace Reown.Core.Common.Test;
+
+[Trait("Category", "unit")]
+public class SdkErrorsTests
+{
+    public static IEnumerable<object[]> AllErrorTypes()
+    {
+        foreach (var type in Enum.GetValues<ErrorType>())
+        {
+            yield return [type];
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllErrorTypes))]
+    public void MessageFromType_EveryErrorType_ReturnsNonEmptyMessage(ErrorType type)
+    {
+        var message = SdkErrors.MessageFromType(type);
+
+        Assert.False(string.IsNullOrWhiteSpace(message));
+    }
+
+    [Theory]
+    [InlineData(ErrorType.GENERIC, "{message}")]
+    [InlineData(ErrorType.JSONRPC_REQUEST_METHOD_REJECTED, "User rejected the request.")]
+    [InlineData(ErrorType.USER_DISCONNECTED, "User disconnected.")]
+    [InlineData(ErrorType.SESSION_SETTLEMENT_FAILED, "Session settlement failed.")]
+    [InlineData(ErrorType.WC_METHOD_UNSUPPORTED, "Unsupported wc_ method")]
+    [InlineData(ErrorType.UNKNOWN, "Unknown error {params}")]
+    public void MessageFromType_KnownTypes_ReturnsExpectedMessage(ErrorType type, string expected)
+    {
+        Assert.Equal(expected, SdkErrors.MessageFromType(type));
+    }
+
+    [Theory]
+    [InlineData(ErrorType.SETTLE_TIMEOUT)]
+    [InlineData(ErrorType.SESSION_REQUEST_EXPIRED)]
+    public void MessageFromType_UnmappedTypes_FallsBackToGenericMessage(ErrorType type)
+    {
+        Assert.Equal("{message}", SdkErrors.MessageFromType(type));
+    }
+
+    [Fact]
+    public void MessageFromType_WithContext_AppendsContext()
+    {
+        var message = SdkErrors.MessageFromType(ErrorType.USER_DISCONNECTED, "extra context");
+
+        Assert.Equal("User disconnected. extra context", message);
+    }
+
+    [Fact]
+    public void MessageFromType_WithoutContext_ReturnsBareMessage()
+    {
+        var message = SdkErrors.MessageFromType(ErrorType.USER_DISCONNECTED);
+
+        Assert.Equal("User disconnected.", message);
+    }
+
+    [Fact]
+    public void MessageFromType_TemplateMessageWithContext_AppendsContextWithoutSubstitution()
+    {
+        var message = SdkErrors.MessageFromType(ErrorType.UNAUTHORIZED_UPDATE_REQUEST, "session");
+
+        Assert.Equal("Unauthorized {context} update request session", message);
+    }
+}

--- a/test/Reown.Core.Crypto.Test/Base58EncodingTests.cs
+++ b/test/Reown.Core.Crypto.Test/Base58EncodingTests.cs
@@ -1,0 +1,117 @@
+using Reown.Core.Crypto.Encoder;
+using Xunit;
+
+namespace Reown.Core.Crypto.Test;
+
+[Trait("Category", "unit")]
+public class Base58EncodingTests
+{
+    [Fact]
+    public void Encode_EmptyArray_ReturnsEmptyString()
+    {
+        Assert.Equal(string.Empty, Base58Encoding.Encode([]));
+    }
+
+    [Fact]
+    public void Encode_LeadingZeroBytes_ProducesLeadingOnes()
+    {
+        var encoded = Base58Encoding.Encode([0, 0, 5]);
+
+        Assert.StartsWith("11", encoded);
+    }
+
+    [Fact]
+    public void EncodeDecode_RoundTripsArbitraryBytes()
+    {
+        var data = new byte[]
+        {
+            0,
+            0,
+            1,
+            2,
+            3,
+            250,
+            17,
+            99
+        };
+
+        var roundTripped = Base58Encoding.Decode(Base58Encoding.Encode(data));
+
+        Assert.Equal(data, roundTripped);
+    }
+
+    [Fact]
+    public void Decode_LeadingOnes_ProducesLeadingZeroBytes()
+    {
+        var decoded = Base58Encoding.Decode("11" + Base58Encoding.Encode([7]));
+
+        Assert.Equal(new byte[]
+        {
+            0,
+            0,
+            7
+        }, decoded);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("O0Il")]
+    [InlineData("abc+def")]
+    public void Decode_InvalidCharacter_ThrowsFormatException(string value)
+    {
+        Assert.Throws<FormatException>(() => Base58Encoding.Decode(value));
+    }
+
+    [Fact]
+    public void AddCheckSum_AppendsChecksumBytes()
+    {
+        var data = new byte[]
+        {
+            1,
+            2,
+            3,
+            4
+        };
+
+        var withChecksum = Base58Encoding.AddCheckSum(data);
+
+        Assert.Equal(data.Length + Base58Encoding.CheckSumSizeInBytes, withChecksum.Length);
+    }
+
+    [Fact]
+    public void EncodeWithCheckSum_DecodeWithCheckSum_RoundTrips()
+    {
+        var data = new byte[]
+        {
+            10,
+            20,
+            30,
+            40,
+            50,
+            60,
+            70,
+            80
+        };
+
+        var roundTripped = Base58Encoding.DecodeWithCheckSum(Base58Encoding.EncodeWithCheckSum(data));
+
+        Assert.Equal(data, roundTripped);
+    }
+
+    [Fact]
+    public void VerifyAndRemoveCheckSum_TamperedData_ReturnsNull()
+    {
+        var withChecksum = Base58Encoding.AddCheckSum([1, 2, 3, 4, 5]);
+        withChecksum[0] ^= 0xFF;
+
+        Assert.Null(Base58Encoding.VerifyAndRemoveCheckSum(withChecksum));
+    }
+
+    [Fact]
+    public void DecodeWithCheckSum_MissingChecksum_ThrowsFormatException()
+    {
+        var encodedWithoutChecksum = Base58Encoding.Encode([1, 2, 3, 4, 5, 6, 7, 8]);
+
+        Assert.Throws<FormatException>(() => Base58Encoding.DecodeWithCheckSum(encodedWithoutChecksum));
+    }
+}

--- a/test/Reown.Core.Crypto.Test/CryptoEncodingTests.cs
+++ b/test/Reown.Core.Crypto.Test/CryptoEncodingTests.cs
@@ -1,0 +1,44 @@
+using Reown.Core.Common.Model.Relay;
+using Reown.Core.Crypto.Models;
+using Reown.Core.Crypto.Test.Model;
+using Reown.Core.Network.Models;
+using Xunit;
+
+namespace Reown.Core.Crypto.Test;
+
+[Trait("Category", "unit")]
+public class CryptoEncodingTests : IClassFixture<CryptoFixture>
+{
+    private readonly CryptoFixture _fixture;
+
+    public CryptoEncodingTests(CryptoFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static JsonRpcRequest<TopicData> SamplePayload()
+    {
+        var api = RelayProtocols.DefaultProtocol;
+        return new JsonRpcRequest<TopicData>(api.Subscribe, new TopicData { Topic = "test" });
+    }
+
+    [Fact]
+    public async Task Encode_Type1MissingSenderKey_ThrowsArgumentException()
+    {
+        await _fixture.WaitForModulesReady();
+
+        var options = new EncodeOptions { Type = Crypto.Type1, ReceiverPublicKey = "receiver" };
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _fixture.PeerA.Encode("topic", SamplePayload(), options));
+    }
+
+    [Fact]
+    public async Task Encode_Type1MissingReceiverKey_ThrowsArgumentException()
+    {
+        await _fixture.WaitForModulesReady();
+
+        var options = new EncodeOptions { Type = Crypto.Type1, SenderPublicKey = "sender" };
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _fixture.PeerA.Encode("topic", SamplePayload(), options));
+    }
+}

--- a/test/Reown.Core.Network.Test/ErrorTests.cs
+++ b/test/Reown.Core.Network.Test/ErrorTests.cs
@@ -1,0 +1,92 @@
+using Reown.Core.Common.Model.Errors;
+using Reown.Core.Network.Models;
+using Xunit;
+
+namespace Reown.Core.Network.Test;
+
+[Trait("Category", "unit")]
+public class ErrorTests
+{
+    [Fact]
+    public void FromErrorType_PopulatesCodeAndMessage()
+    {
+        var error = Error.FromErrorType(ErrorType.USER_DISCONNECTED);
+
+        Assert.Equal((long)ErrorType.USER_DISCONNECTED, error.Code);
+        Assert.Equal("User disconnected.", error.Message);
+        Assert.Null(error.Data);
+    }
+
+    [Fact]
+    public void FromErrorType_WithContextAndData_AppendsContextAndStoresData()
+    {
+        var error = Error.FromErrorType(ErrorType.USER_DISCONNECTED, "session-123", "extra");
+
+        Assert.Equal("User disconnected. session-123", error.Message);
+        Assert.Equal("extra", error.Data);
+    }
+
+    [Fact]
+    public void Equals_SameValues_ReturnsTrue()
+    {
+        var a = new Error { Code = 1, Message = "m", Data = "d" };
+        var b = new Error { Code = 1, Message = "m", Data = "d" };
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_DifferentValues_ReturnsFalse()
+    {
+        var a = new Error { Code = 1, Message = "m", Data = "d" };
+        var b = new Error { Code = 2, Message = "m", Data = "d" };
+
+        Assert.False(a.Equals(b));
+    }
+
+    [Fact]
+    public void Equals_NullOrOtherType_ReturnsFalse()
+    {
+        var a = new Error { Code = 1 };
+
+        Assert.False(a.Equals(null));
+        Assert.False(a.Equals("not an error"));
+    }
+
+    [Fact]
+    public void CodeMessageDataComparer_EqualErrors_ReturnsTrue()
+    {
+        var a = new Error { Code = 1, Message = "m", Data = "d" };
+        var b = new Error { Code = 1, Message = "m", Data = "d" };
+
+        Assert.True(Error.CodeMessageDataComparer.Equals(a, b));
+        Assert.Equal(Error.CodeMessageDataComparer.GetHashCode(a), Error.CodeMessageDataComparer.GetHashCode(b));
+    }
+
+    [Fact]
+    public void CodeMessageDataComparer_DifferentMessage_ReturnsFalse()
+    {
+        var a = new Error { Code = 1, Message = "m", Data = "d" };
+        var b = new Error { Code = 1, Message = "different", Data = "d" };
+
+        Assert.False(Error.CodeMessageDataComparer.Equals(a, b));
+    }
+
+    [Fact]
+    public void CodeMessageDataComparer_SameReference_ReturnsTrue()
+    {
+        var a = new Error { Code = 1 };
+
+        Assert.True(Error.CodeMessageDataComparer.Equals(a, a));
+    }
+
+    [Fact]
+    public void CodeMessageDataComparer_NullOperand_ReturnsFalse()
+    {
+        var a = new Error { Code = 1 };
+
+        Assert.False(Error.CodeMessageDataComparer.Equals(a, null));
+        Assert.False(Error.CodeMessageDataComparer.Equals(null, a));
+    }
+}

--- a/test/Reown.Sign.Test/AccountTests.cs
+++ b/test/Reown.Sign.Test/AccountTests.cs
@@ -1,0 +1,75 @@
+using Reown.Sign.Models;
+using Xunit;
+
+namespace Reown.Sign.Test;
+
+[Trait("Category", "unit")]
+public class AccountTests
+{
+    [Fact]
+    public void Constructor_FromAccountId_ParsesChainIdAndAddress()
+    {
+        var account = new Account("eip155:1:0xAbC123");
+
+        Assert.Equal("eip155:1", account.ChainId);
+        Assert.Equal("0xAbC123", account.Address);
+        Assert.Equal("eip155:1:0xAbC123", account.AccountId);
+    }
+
+    [Fact]
+    public void Constructor_FromAddressAndChainId_ComposesAccountId()
+    {
+        var account = new Account("0xabc", "eip155:1");
+
+        Assert.Equal("eip155:1:0xabc", account.AccountId);
+        Assert.Equal("eip155:1:0xabc", account.ToString());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_NullOrEmptyAccountId_Throws(string accountId)
+    {
+        Assert.Throws<ArgumentException>(() => new Account(accountId));
+    }
+
+    [Theory]
+    [InlineData("eip155")]
+    [InlineData("eip155:1")]
+    public void Constructor_MalformedAccountId_Throws(string accountId)
+    {
+        Assert.Throws<ArgumentException>(() => new Account(accountId));
+    }
+
+    [Fact]
+    public void Equals_SameAccountId_ReturnsTrueAndEqualHashCode()
+    {
+        var a = new Account("eip155:1:0xabc");
+        var b = new Account("0xabc", "eip155:1");
+
+        Assert.True(a.Equals(b));
+        Assert.True(a.Equals((object)b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_DifferentAccountOrNonAccount_ReturnsFalse()
+    {
+        var a = new Account("eip155:1:0xabc");
+        var b = new Account("eip155:1:0xdef");
+
+        Assert.False(a.Equals(b));
+        Assert.False(a.Equals("not-an-account"));
+    }
+
+    [Fact]
+    public void EqualityOperator_IgnoresCase()
+    {
+        var a = new Account("eip155:1:0xABC");
+        var b = new Account("eip155:1:0xabc");
+
+        Assert.True(a == b);
+        Assert.False(a != b);
+    }
+}

--- a/test/Reown.Sign.Test/ConnectOptionsTests.cs
+++ b/test/Reown.Sign.Test/ConnectOptionsTests.cs
@@ -1,0 +1,153 @@
+using Reown.Core.Common.Utils;
+using Reown.Core.Models.Relay;
+using Reown.Sign.Models;
+using Reown.Sign.Models.Engine;
+using Xunit;
+
+namespace Reown.Sign.Test;
+
+[Trait("Category", "unit")]
+public class ConnectOptionsTests
+{
+    [Fact]
+    public void DefaultConstructor_InitializesEmptyNamespaces()
+    {
+        var options = new ConnectOptions();
+
+        Assert.NotNull(options.RequiredNamespaces);
+        Assert.Empty(options.RequiredNamespaces);
+        Assert.NotNull(options.OptionalNamespaces);
+        Assert.Empty(options.OptionalNamespaces);
+        Assert.Null(options.SessionProperties);
+        Assert.Equal(Clock.FIVE_MINUTES, options.Expiry);
+    }
+
+    [Fact]
+    public void ParameterizedConstructor_NullArgs_AppliesDefaults()
+    {
+        var options = new ConnectOptions(null, null, null, null, null);
+
+        Assert.NotNull(options.RequiredNamespaces);
+        Assert.NotNull(options.OptionalNamespaces);
+        Assert.Null(options.SessionProperties);
+        Assert.Equal("", options.PairingTopic);
+        Assert.Null(options.Relays);
+    }
+
+    [Fact]
+    public void ParameterizedConstructor_WithValues_AssignsProvided()
+    {
+        var required = new RequiredNamespaces();
+        var optional = new Dictionary<string, ProposedNamespace>();
+        var props = new Dictionary<string, string> { ["k"] = "v" };
+        var relays = new ProtocolOptions { Protocol = "irn" };
+
+        var options = new ConnectOptions(required, "topic", relays, optional, props);
+
+        Assert.Same(required, options.RequiredNamespaces);
+        Assert.Same(optional, options.OptionalNamespaces);
+        Assert.Same(props, options.SessionProperties);
+        Assert.Equal("topic", options.PairingTopic);
+        Assert.Same(relays, options.Relays);
+    }
+
+    [Fact]
+    public void RequireNamespace_AddsAndReturnsSameInstance()
+    {
+        var options = new ConnectOptions();
+
+        var result = options.RequireNamespace("eip155", new ProposedNamespace().WithChain("eip155:1"));
+
+        Assert.Same(options, result);
+        Assert.True(options.RequiredNamespaces.ContainsKey("eip155"));
+    }
+
+    [Fact]
+    public void WithOptionalNamespace_Adds()
+    {
+        var options = new ConnectOptions();
+
+        options.WithOptionalNamespace("solana", new ProposedNamespace().WithChain("solana:1"));
+
+        Assert.True(options.OptionalNamespaces.ContainsKey("solana"));
+    }
+
+    [Fact]
+    public void AddSessionProperty_InitializesDictionaryWhenNull()
+    {
+        var options = new ConnectOptions();
+
+        options.AddSessionProperty("k", "v");
+
+        Assert.Equal("v", options.SessionProperties["k"]);
+    }
+
+    [Fact]
+    public void WithSessionProperties_ReplacesDictionary()
+    {
+        var props = new Dictionary<string, string> { ["a"] = "b" };
+
+        var options = new ConnectOptions().WithSessionProperties(props);
+
+        Assert.Same(props, options.SessionProperties);
+    }
+
+    [Fact]
+    public void UseRequireNamespaces_Replaces()
+    {
+        var required = new RequiredNamespaces();
+
+        var options = new ConnectOptions().UseRequireNamespaces(required);
+
+        Assert.Same(required, options.RequiredNamespaces);
+    }
+
+    [Fact]
+    public void WithPairingTopic_Sets()
+    {
+        var options = new ConnectOptions().WithPairingTopic("pair-topic");
+
+        Assert.Equal("pair-topic", options.PairingTopic);
+    }
+
+    [Fact]
+    public void WithOptions_SetsRelays()
+    {
+        var relays = new ProtocolOptions { Protocol = "irn" };
+
+        var options = new ConnectOptions().WithOptions(relays);
+
+        Assert.Same(relays, options.Relays);
+    }
+
+    [Fact]
+    public void WithExpiry_Seconds_SetsExpiry()
+    {
+        var options = new ConnectOptions().WithExpiry(120);
+
+        Assert.Equal(120, options.Expiry);
+    }
+
+    [Fact]
+    public void WithExpiry_TimeSpan_SetsExpiryInSeconds()
+    {
+        var options = new ConnectOptions().WithExpiry(TimeSpan.FromMinutes(2));
+
+        Assert.Equal(120, options.Expiry);
+    }
+
+    [Fact]
+    public void BuilderMethods_AreChainable()
+    {
+        var options = new ConnectOptions()
+            .WithPairingTopic("t")
+            .WithExpiry(60)
+            .AddSessionProperty("k", "v")
+            .RequireNamespace("eip155", new ProposedNamespace().WithChain("eip155:1"));
+
+        Assert.Equal("t", options.PairingTopic);
+        Assert.Equal(60, options.Expiry);
+        Assert.True(options.RequiredNamespaces.ContainsKey("eip155"));
+        Assert.Equal("v", options.SessionProperties["k"]);
+    }
+}

--- a/test/Reown.Sign.Test/CoreUtilsTests.cs
+++ b/test/Reown.Sign.Test/CoreUtilsTests.cs
@@ -1,0 +1,91 @@
+using CoreUtils = Reown.Core.Utils;
+using Xunit;
+
+namespace Reown.Sign.Test;
+
+[Trait("Category", "unit")]
+public class CoreUtilsTests
+{
+    [Theory]
+    [InlineData("eip155:1:0xabc", "eip155:1", "0xabc")]
+    [InlineData("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:Abc123", "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", "Abc123")]
+    public void DeconstructAccountId_ValidInput_SplitsOnLastColon(string accountId, string chainId, string address)
+    {
+        var (parsedChainId, parsedAddress) = CoreUtils.DeconstructAccountId(accountId);
+
+        Assert.Equal(chainId, parsedChainId);
+        Assert.Equal(address, parsedAddress);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("noColon")]
+    [InlineData("eip155:1")]
+    public void DeconstructAccountId_InvalidInput_Throws(string accountId)
+    {
+        Assert.Throws<ArgumentException>(() => CoreUtils.DeconstructAccountId(accountId));
+    }
+
+    [Theory]
+    [InlineData("eip155:1:0xabc", true)]
+    [InlineData("eip155:1:", false)]
+    public void IsValidAccountId_ChecksAddressAndChain(string accountId, bool expected)
+    {
+        Assert.Equal(expected, CoreUtils.IsValidAccountId(accountId));
+    }
+
+    [Theory]
+    [InlineData("eip155:1", true)]
+    [InlineData("eip155", false)]
+    [InlineData("EIP155:1", false)]
+    public void IsValidChainId_MatchesPattern(string chainId, bool expected)
+    {
+        Assert.Equal(expected, CoreUtils.IsValidChainId(chainId));
+    }
+
+    [Theory]
+    [InlineData("eip155:1", "1")]
+    [InlineData("noColon", "noColon")]
+    public void ExtractChainReference_ReturnsAfterLastColon(string chainId, string expected)
+    {
+        Assert.Equal(expected, CoreUtils.ExtractChainReference(chainId));
+    }
+
+    [Theory]
+    [InlineData("eip155:1", "eip155")]
+    [InlineData("noColon", "noColon")]
+    public void ExtractChainNamespace_ReturnsBeforeLastColon(string chainId, string expected)
+    {
+        Assert.Equal(expected, CoreUtils.ExtractChainNamespace(chainId));
+    }
+
+    [Theory]
+    [InlineData("https://reown.com", true)]
+    [InlineData("not a url", false)]
+    [InlineData("", false)]
+    public void IsValidUrl_ValidatesUri(string url, bool expected)
+    {
+        Assert.Equal(expected, CoreUtils.IsValidUrl(url));
+    }
+
+    [Theory]
+    [InlineData(100, 50, 200, true)]
+    [InlineData(10, 50, 200, false)]
+    [InlineData(300, 50, 200, false)]
+    public void IsValidRequestExpiry_ChecksRange(long expiry, long min, long max, bool expected)
+    {
+        Assert.Equal(expected, CoreUtils.IsValidRequestExpiry(expiry, min, max));
+    }
+
+    [Fact]
+    public void Batch_SplitsSequenceIntoChunks()
+    {
+        var batches = CoreUtils.Batch(new[] { 1, 2, 3, 4, 5 }, 2).Select(batch => batch.ToArray()).ToArray();
+
+        Assert.Equal(3, batches.Length);
+        Assert.Equal(new[] { 1, 2 }, batches[0]);
+        Assert.Equal(new[] { 5 }, batches[2]);
+    }
+}

--- a/test/Reown.Sign.Test/NamespaceTests.cs
+++ b/test/Reown.Sign.Test/NamespaceTests.cs
@@ -94,4 +94,59 @@ public class NamespaceTests
 
         Assert.False(ns1.Equals(ns2));
     }
+
+    [Fact] [Trait("Category", "unit")]
+    public void NamespaceComparer_EqualNamespaces_ReturnsTrue()
+    {
+        var ns1 = new Namespace { Accounts = new[] { "a" }, Methods = new[] { "m" }, Events = new[] { "e" } };
+        var ns2 = new Namespace { Accounts = new[] { "a" }, Methods = new[] { "m" }, Events = new[] { "e" } };
+
+        Assert.True(Namespace.NamespaceComparer.Equals(ns1, ns2));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void NamespaceComparer_DifferentNamespaces_ReturnsFalse()
+    {
+        var ns1 = new Namespace { Accounts = new[] { "a" }, Methods = new[] { "m1" }, Events = new[] { "e" } };
+        var ns2 = new Namespace { Accounts = new[] { "a" }, Methods = new[] { "m2" }, Events = new[] { "e" } };
+
+        Assert.False(Namespace.NamespaceComparer.Equals(ns1, ns2));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void NamespaceComparer_SameReference_ReturnsTrue()
+    {
+        var ns = new Namespace { Accounts = new[] { "a" }, Methods = new[] { "m" }, Events = new[] { "e" } };
+
+        Assert.True(Namespace.NamespaceComparer.Equals(ns, ns));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void NamespaceComparer_NullOperand_ReturnsFalse()
+    {
+        var ns = new Namespace { Accounts = new[] { "a" }, Methods = new[] { "m" }, Events = new[] { "e" } };
+
+        Assert.False(Namespace.NamespaceComparer.Equals(ns, null));
+        Assert.False(Namespace.NamespaceComparer.Equals(null, ns));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void GetHashCode_EqualContentDifferentArrays_ReturnsSameHash()
+    {
+        var ns1 = new Namespace { Accounts = new[] { "a1", "a2" }, Methods = new[] { "m1", "m2" }, Events = new[] { "e1" } };
+        var ns2 = new Namespace { Accounts = new[] { "a2", "a1" }, Methods = new[] { "m2", "m1" }, Events = new[] { "e1" } };
+
+        Assert.True(ns1.Equals(ns2));
+        Assert.Equal(ns1.GetHashCode(), ns2.GetHashCode());
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void NamespaceComparer_EqualContentDistinctArrays_ProducesEqualHashCodes()
+    {
+        var ns1 = new Namespace { Accounts = new[] { "a" }, Methods = new[] { "m" }, Events = new[] { "e" } };
+        var ns2 = new Namespace { Accounts = new[] { "a" }, Methods = new[] { "m" }, Events = new[] { "e" } };
+
+        Assert.True(Namespace.NamespaceComparer.Equals(ns1, ns2));
+        Assert.Equal(Namespace.NamespaceComparer.GetHashCode(ns1), Namespace.NamespaceComparer.GetHashCode(ns2));
+    }
 }

--- a/test/Reown.Sign.Test/NamespaceTests.cs
+++ b/test/Reown.Sign.Test/NamespaceTests.cs
@@ -149,4 +149,23 @@ public class NamespaceTests
         Assert.True(Namespace.NamespaceComparer.Equals(ns1, ns2));
         Assert.Equal(Namespace.NamespaceComparer.GetHashCode(ns1), Namespace.NamespaceComparer.GetHashCode(ns2));
     }
+
+    [Fact] [Trait("Category", "unit")]
+    public void Equals_DuplicateMultiplicityDiffers_ReturnsFalse()
+    {
+        var ns1 = new Namespace { Accounts = new[] { "a", "a", "b" }, Methods = new[] { "m" }, Events = new[] { "e" } };
+        var ns2 = new Namespace { Accounts = new[] { "a", "b", "b" }, Methods = new[] { "m" }, Events = new[] { "e" } };
+
+        Assert.False(ns1.Equals(ns2));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void GetHashCode_EqualNamespacesWithDuplicates_ReturnsSameHash()
+    {
+        var ns1 = new Namespace { Accounts = new[] { "a", "a", "b" }, Methods = new[] { "m", "m" }, Events = new[] { "e" } };
+        var ns2 = new Namespace { Accounts = new[] { "b", "a", "a" }, Methods = new[] { "m", "m" }, Events = new[] { "e" } };
+
+        Assert.True(ns1.Equals(ns2));
+        Assert.Equal(ns1.GetHashCode(), ns2.GetHashCode());
+    }
 }

--- a/test/Reown.Sign.Test/ProposalStructTests.cs
+++ b/test/Reown.Sign.Test/ProposalStructTests.cs
@@ -1,0 +1,184 @@
+using Reown.Core.Common.Model.Errors;
+using Reown.Core.Models.Relay;
+using Reown.Core.Network.Models;
+using Reown.Sign.Models;
+using Xunit;
+
+namespace Reown.Sign.Test;
+
+[Trait("Category", "unit")]
+public class ProposalStructTests
+{
+    private static ProposalStruct CreateProposal()
+    {
+        var required = new RequiredNamespaces
+        {
+            {
+                "eip155", new ProposedNamespace()
+                    .WithChain("eip155:1")
+                    .WithChain("eip155:10")
+                    .WithMethod("eth_sign")
+                    .WithEvent("chainChanged")
+            }
+        };
+
+        return new ProposalStruct
+        {
+            Id = 123,
+            Relays =
+            [
+                new ProtocolOptions
+                {
+                    Protocol = "irn"
+                }
+            ],
+            RequiredNamespaces = required
+        };
+    }
+
+    [Fact]
+    public void Key_ReturnsId()
+    {
+        var proposal = CreateProposal();
+
+        Assert.Equal(proposal.Id, proposal.Key);
+    }
+
+    [Fact]
+    public void ApproveProposal_SingleAccount_BuildsCaip10AccountPerChain()
+    {
+        var proposal = CreateProposal();
+
+        var approve = proposal.ApproveProposal("0xabc");
+
+        Assert.Equal(123, approve.Id);
+        Assert.Equal("irn", approve.RelayProtocol);
+
+        var ns = approve.Namespaces["eip155"];
+        Assert.Contains("eip155:1:0xabc", ns.Accounts);
+        Assert.Contains("eip155:10:0xabc", ns.Accounts);
+        Assert.Equal(new[]
+        {
+            "eth_sign"
+        }, ns.Methods);
+    }
+
+    [Fact]
+    public void ApproveProposal_MultipleAccounts_BuildsAccountPerChainAccountPair()
+    {
+        var proposal = CreateProposal();
+
+        var approve = proposal.ApproveProposal(["0xabc", "0xdef"]);
+
+        var accounts = approve.Namespaces["eip155"].Accounts;
+        Assert.Equal(4, accounts.Length);
+        Assert.Contains("eip155:1:0xabc", accounts);
+        Assert.Contains("eip155:1:0xdef", accounts);
+        Assert.Contains("eip155:10:0xabc", accounts);
+        Assert.Contains("eip155:10:0xdef", accounts);
+    }
+
+    [Fact]
+    public void ApproveProposal_IncludesOptionalNamespaces()
+    {
+        var proposal = CreateProposal();
+        proposal.OptionalNamespaces = new Dictionary<string, ProposedNamespace>
+        {
+            ["solana"] = new ProposedNamespace().WithChain("solana:mainnet").WithMethod("solana_signMessage")
+        };
+
+        var approve = proposal.ApproveProposal(["0xabc"]);
+
+        Assert.True(approve.Namespaces.ContainsKey("solana"));
+        Assert.Contains("solana:mainnet:0xabc", approve.Namespaces["solana"].Accounts);
+    }
+
+    [Fact]
+    public void ApproveProposal_UsesProvidedProtocolOption()
+    {
+        var proposal = CreateProposal();
+        proposal.Relays =
+        [
+            new ProtocolOptions
+            {
+                Protocol = "irn"
+            },
+            new ProtocolOptions
+            {
+                Protocol = "waku"
+            }
+        ];
+
+        var approve = proposal.ApproveProposal(["0xabc"], new ProtocolOptions
+        {
+            Protocol = "waku"
+        });
+
+        Assert.Equal("waku", approve.RelayProtocol);
+    }
+
+    [Fact]
+    public void ApproveProposal_NoId_Throws()
+    {
+        var proposal = new ProposalStruct
+        {
+            Relays =
+            [
+                new ProtocolOptions
+                {
+                    Protocol = "irn"
+                }
+            ],
+            RequiredNamespaces = new RequiredNamespaces()
+        };
+
+        Assert.Throws<InvalidOperationException>(() => proposal.ApproveProposal("0xabc"));
+    }
+
+    [Fact]
+    public void ApproveProposal_UnknownProtocolOption_Throws()
+    {
+        var proposal = CreateProposal();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            proposal.ApproveProposal(["0xabc"], new ProtocolOptions
+            {
+                Protocol = "unknown"
+            }));
+    }
+
+    [Fact]
+    public void RejectProposal_WithError_ReturnsRejectParams()
+    {
+        var proposal = CreateProposal();
+        var error = new Error
+        {
+            Code = (long)ErrorType.USER_DISCONNECTED,
+            Message = "denied"
+        };
+
+        var reject = proposal.RejectProposal(error);
+
+        Assert.Equal(123, reject.Id);
+        Assert.Equal(error, reject.Reason);
+    }
+
+    [Fact]
+    public void RejectProposal_NullMessage_UsesDefaultReason()
+    {
+        var proposal = CreateProposal();
+
+        var reject = proposal.RejectProposal();
+
+        Assert.Equal((long)ErrorType.USER_DISCONNECTED, reject.Reason.Code);
+        Assert.Equal("Proposal denied by remote host", reject.Reason.Message);
+    }
+
+    [Fact]
+    public void RejectProposal_NoId_Throws()
+    {
+        var proposal = new ProposalStruct();
+
+        Assert.Throws<InvalidOperationException>(() => proposal.RejectProposal("reason"));
+    }
+}

--- a/test/Reown.Sign.Test/ProposedNamespaceTests.cs
+++ b/test/Reown.Sign.Test/ProposedNamespaceTests.cs
@@ -1,0 +1,87 @@
+using Reown.Sign.Models;
+using Xunit;
+
+namespace Reown.Sign.Test;
+
+[Trait("Category", "unit")]
+public class ProposedNamespaceTests
+{
+    [Fact]
+    public void Builders_AppendValues()
+    {
+        var ns = new ProposedNamespace()
+            .WithChain("eip155:1")
+            .WithMethod("eth_sign")
+            .WithEvent("chainChanged");
+
+        Assert.Contains("eip155:1", ns.Chains);
+        Assert.Contains("eth_sign", ns.Methods);
+        Assert.Contains("chainChanged", ns.Events);
+    }
+
+    [Fact]
+    public void WithAccount_ReturnsNamespaceCarryingAccount()
+    {
+        var ns = new ProposedNamespace().WithChain("eip155:1").WithAccount("0xabc");
+
+        Assert.Contains("0xabc", ns.Accounts);
+    }
+
+    [Fact]
+    public void Equals_IgnoresOrder_ReturnsTrue()
+    {
+        var a = new ProposedNamespace().WithChain("c1").WithChain("c2").WithMethod("m");
+        var b = new ProposedNamespace().WithChain("c2").WithChain("c1").WithMethod("m");
+
+        Assert.True(a.Equals(b));
+    }
+
+    [Fact]
+    public void Equals_DifferentContent_ReturnsFalse()
+    {
+        var a = new ProposedNamespace().WithChain("c1");
+        var b = new ProposedNamespace().WithChain("c2");
+
+        Assert.False(a.Equals(b));
+    }
+
+    [Fact]
+    public void RequiredNamespaceComparer_EqualValues_ReturnsTrue()
+    {
+        var a = new ProposedNamespace().WithChain("c").WithMethod("m").WithEvent("e");
+        var b = new ProposedNamespace().WithChain("c").WithMethod("m").WithEvent("e");
+
+        Assert.True(ProposedNamespace.RequiredNamespaceComparer.Equals(a, b));
+    }
+
+    [Fact]
+    public void RequiredNamespaceComparer_NullOperand_ReturnsFalse()
+    {
+        var a = new ProposedNamespace().WithChain("c");
+
+        Assert.False(ProposedNamespace.RequiredNamespaceComparer.Equals(a, null));
+        Assert.False(ProposedNamespace.RequiredNamespaceComparer.Equals(null, a));
+    }
+
+    [Fact]
+    public void GetHashCode_EqualContentDifferentOrder_ReturnsSameHash()
+    {
+        var a = new ProposedNamespace().WithChain("c1").WithChain("c2").WithMethod("m1").WithMethod("m2").WithEvent("e");
+        var b = new ProposedNamespace().WithChain("c2").WithChain("c1").WithMethod("m2").WithMethod("m1").WithEvent("e");
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void RequiredNamespaceComparer_EqualContentDistinctArrays_ProducesEqualHashCodes()
+    {
+        var a = new ProposedNamespace().WithChain("c").WithMethod("m").WithEvent("e");
+        var b = new ProposedNamespace().WithChain("c").WithMethod("m").WithEvent("e");
+
+        Assert.True(ProposedNamespace.RequiredNamespaceComparer.Equals(a, b));
+        Assert.Equal(
+            ProposedNamespace.RequiredNamespaceComparer.GetHashCode(a),
+            ProposedNamespace.RequiredNamespaceComparer.GetHashCode(b));
+    }
+}

--- a/test/Reown.Sign.Test/ProposedNamespaceTests.cs
+++ b/test/Reown.Sign.Test/ProposedNamespaceTests.cs
@@ -84,4 +84,23 @@ public class ProposedNamespaceTests
             ProposedNamespace.RequiredNamespaceComparer.GetHashCode(a),
             ProposedNamespace.RequiredNamespaceComparer.GetHashCode(b));
     }
+
+    [Fact]
+    public void Equals_DuplicateMultiplicityDiffers_ReturnsFalse()
+    {
+        var a = new ProposedNamespace { Chains = new[] { "c1", "c1", "c2" }, Methods = new[] { "m" }, Events = new[] { "e" } };
+        var b = new ProposedNamespace { Chains = new[] { "c1", "c2", "c2" }, Methods = new[] { "m" }, Events = new[] { "e" } };
+
+        Assert.False(a.Equals(b));
+    }
+
+    [Fact]
+    public void GetHashCode_EqualNamespacesWithDuplicates_ReturnsSameHash()
+    {
+        var a = new ProposedNamespace { Chains = new[] { "c1", "c1", "c2" }, Methods = new[] { "m", "m" }, Events = new[] { "e" } };
+        var b = new ProposedNamespace { Chains = new[] { "c2", "c1", "c1" }, Methods = new[] { "m", "m" }, Events = new[] { "e" } };
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
 }

--- a/test/Reown.Sign.Test/RecapTests.cs
+++ b/test/Reown.Sign.Test/RecapTests.cs
@@ -518,4 +518,324 @@ public class RecapTests
 
         _ = ReCap.Decode(mergedRecap);
     }
+
+    private static ReCap CreateEip155Recap()
+    {
+        var (resource, ability, actions, limits) = GetRecapProperties();
+        return new ReCap(resource, ability, actions, limits);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void ValidateRecap_EmptyAtt_ThrowsArgumentException()
+    {
+        var recap = new ReCap(new Dictionary<string, AttValue>());
+
+        var exception = Assert.Throws<ArgumentException>(() => ReCap.Validate(recap));
+
+        Assert.Equal("No resources found in `att` property", exception.Message);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void ValidateRecap_LimitNotAnObject_ThrowsArgumentException()
+    {
+        var recap = new ReCap(new Dictionary<string, AttValue>
+        {
+            {
+                "resource1", new AttValue
+                {
+                    Properties = new Dictionary<string, JToken>
+                    {
+                        { "ability1", new JArray("not-an-object") }
+                    }
+                }
+            }
+        });
+
+        var exception = Assert.Throws<ArgumentException>(() => ReCap.Validate(recap));
+
+        Assert.Contains("must be an object", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AssignAbilityToActions_NullOrWhitespaceAbility_ThrowsArgumentException(string ability)
+    {
+        Assert.Throws<ArgumentException>(() => ReCap.AssignAbilityToActions(ability, new[]
+        {
+            "personal_sign"
+        }));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void AssignAbilityToActions_NullActions_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => ReCap.AssignAbilityToActions("request", null));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void Decode_EmptyAtt_ThrowsArgumentException()
+    {
+        var encoded = "urn:recap:" + Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("{\"att\":{}}")).TrimEnd('=');
+
+        Assert.Throws<ArgumentException>(() => ReCap.Decode(encoded));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void Decode_InvalidBase64_ThrowsFormatException()
+    {
+        Assert.Throws<FormatException>(() => ReCap.Decode("urn:recap:!!!"));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void GetActions_NoEip155Resource_ReturnsEmpty()
+    {
+        var recap = new ReCap("solana", "request", new[]
+        {
+            "sol_signMessage"
+        });
+
+        Assert.Empty(recap.GetActions());
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void TryGetRecapFromResources_NullResources_ReturnsFalse()
+    {
+        var success = ReCap.TryGetRecapFromResources(null, out var recap);
+
+        Assert.False(success);
+        Assert.Null(recap);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void TryGetRecapFromResources_RecapIsLastResource_ReturnsTrue()
+    {
+        var encoded = CreateEip155Recap().Encode();
+        var resources = new[]
+        {
+            "https://example.com",
+            encoded
+        };
+
+        var success = ReCap.TryGetRecapFromResources(resources, out var recap);
+
+        Assert.True(success);
+        Assert.Equal(encoded, recap);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void TryGetRecapFromResources_NoRecap_ReturnsFalse()
+    {
+        var resources = new[]
+        {
+            "https://example.com",
+            "https://other.com"
+        };
+
+        var success = ReCap.TryGetRecapFromResources(resources, out var recap);
+
+        Assert.False(success);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void TryGetDecodedRecapFromResources_RecapIsLastResource_ReturnsDecodedRecap()
+    {
+        var encoded = CreateEip155Recap().Encode();
+        var resources = new[]
+        {
+            "https://example.com",
+            encoded
+        };
+
+        var success = ReCap.TryGetDecodedRecapFromResources(resources, out var recap);
+
+        Assert.True(success);
+        Assert.NotNull(recap);
+        Assert.True(recap.Att.ContainsKey("eip155"));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void TryGetDecodedRecapFromResources_NoRecap_ReturnsFalseAndNull()
+    {
+        var resources = new[]
+        {
+            "https://example.com"
+        };
+
+        var success = ReCap.TryGetDecodedRecapFromResources(resources, out var recap);
+
+        Assert.False(success);
+        Assert.Null(recap);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void GetChainsFromEncodedRecap_ChainsAsStringToken_ReturnsChain()
+    {
+        var recap = new ReCap(new Dictionary<string, AttValue>
+        {
+            {
+                "eip155", new AttValue
+                {
+                    Properties = new Dictionary<string, JToken>
+                    {
+                        {
+                            "request/personal_sign", new JArray(new JObject
+                            {
+                                ["chains"] = "eip155:1"
+                            })
+                        }
+                    }
+                }
+            }
+        });
+
+        var chains = ReCap.GetChainsFromEncodedRecap(recap.Encode());
+
+        Assert.Equal(new[]
+        {
+            "eip155:1"
+        }, chains);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void FormatStatement_CustomStatementContainingBase_ReturnsCustomStatementUnchanged()
+    {
+        var recap = CreateEip155Recap();
+        const string custom = "I further authorize the stated URI to perform the following actions on my behalf: existing.";
+
+        Assert.Equal(custom, recap.FormatStatement(custom));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void FormatStatement_CustomStatementWithoutBase_PrependsCustomStatement()
+    {
+        var recap = CreateEip155Recap();
+
+        var result = recap.FormatStatement("Sign in with Ethereum.");
+
+        Assert.StartsWith("Sign in with Ethereum. I further authorize the stated URI", result);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void AddResources_NullResource_ThrowsArgumentNullException()
+    {
+        var recap = CreateEip155Recap();
+
+        Assert.Throws<ArgumentNullException>(() => recap.AddResources(null, NewActions()));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void AddResources_NullActions_ThrowsArgumentException()
+    {
+        var recap = CreateEip155Recap();
+
+        Assert.Throws<ArgumentException>(() => recap.AddResources("eip155", null));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void AddResources_EmptyActions_ThrowsArgumentException()
+    {
+        var recap = CreateEip155Recap();
+
+        Assert.Throws<ArgumentException>(() => recap.AddResources("eip155", new Dictionary<string, Dictionary<string, object>[]>()));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void AddResources_NullAtt_ThrowsInvalidOperationException()
+    {
+        var recap = new ReCap(null);
+
+        Assert.Throws<InvalidOperationException>(() => recap.AddResources("eip155", NewActions()));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void AddResources_NewResource_AddsResource()
+    {
+        var recap = CreateEip155Recap();
+
+        recap.AddResources("solana", NewActions("request/sol_signMessage"));
+
+        Assert.True(recap.Att.ContainsKey("solana"));
+        Assert.True(recap.Att["solana"].Properties.ContainsKey("request/sol_signMessage"));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void AddResources_ExistingResourceNewAction_AddsAction()
+    {
+        var recap = CreateEip155Recap();
+
+        recap.AddResources("eip155", NewActions("request/eth_sign"));
+
+        Assert.True(recap.Att["eip155"].Properties.ContainsKey("request/eth_sign"));
+        Assert.True(recap.Att["eip155"].Properties.ContainsKey("request/personal_sign"));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void AddResources_ExistingArrayAction_MergesUnion()
+    {
+        var recap = CreateEip155Recap();
+        var extra = new Dictionary<string, Dictionary<string, object>[]>
+        {
+            {
+                "request/personal_sign", new[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        {
+                            "chains", new[]
+                            {
+                                "eip155:99"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        recap.AddResources("eip155", extra);
+
+        var merged = (JArray)recap.Att["eip155"].Properties["request/personal_sign"];
+        Assert.Equal(2, merged.Count);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void AddResources_ExistingNonArrayAction_ThrowsInvalidOperationException()
+    {
+        var recap = new ReCap(new Dictionary<string, AttValue>
+        {
+            {
+                "eip155", new AttValue
+                {
+                    Properties = new Dictionary<string, JToken>
+                    {
+                        { "request/personal_sign", JToken.FromObject("not-an-array") }
+                    }
+                }
+            }
+        });
+
+        Assert.Throws<InvalidOperationException>(() => recap.AddResources("eip155", NewActions("request/personal_sign")));
+    }
+
+    private static Dictionary<string, Dictionary<string, object>[]> NewActions(string key = "request/eth_sign")
+    {
+        return new Dictionary<string, Dictionary<string, object>[]>
+        {
+            {
+                key, new[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        {
+                            "chains", new[]
+                            {
+                                "eip155:1"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
 }

--- a/test/Reown.Sign.Test/SignTests.cs
+++ b/test/Reown.Sign.Test/SignTests.cs
@@ -202,24 +202,24 @@ public class SignTests : IAsyncLifetime
                 {
                     "eip155", new ProposedNamespace
                     {
-                        Methods = new[]
-                        {
+                        Methods =
+                        [
                             "eth_sendTransaction",
                             "eth_signTransaction",
                             "eth_sign",
                             "personal_sign",
                             "eth_signTypedData"
-                        },
-                        Chains = new[]
-                        {
+                        ],
+                        Chains =
+                        [
                             "eip155:1",
                             "eip155:10"
-                        },
-                        Events = new[]
-                        {
+                        ],
+                        Events =
+                        [
                             "chainChanged",
                             "accountsChanged"
-                        }
+                        ]
                     }
                 }
             }
@@ -287,24 +287,24 @@ public class SignTests : IAsyncLifetime
                 {
                     "eip155", new ProposedNamespace
                     {
-                        Methods = new[]
-                        {
+                        Methods =
+                        [
                             "eth_sendTransaction",
                             "eth_signTransaction",
                             "eth_sign",
                             "personal_sign",
                             "eth_signTypedData"
-                        },
-                        Chains = new[]
-                        {
+                        ],
+                        Chains =
+                        [
                             "eip155:1",
                             "eip155:10"
-                        },
-                        Events = new[]
-                        {
+                        ],
+                        Events =
+                        [
                             "chainChanged",
                             "accountsChanged"
-                        }
+                        ]
                     }
                 }
             }
@@ -348,20 +348,20 @@ public class SignTests : IAsyncLifetime
                 {
                     "eip155", new ProposedNamespace
                     {
-                        Methods = new[]
-                        {
+                        Methods =
+                        [
                             testMethod
-                        },
-                        Chains = new[]
-                        {
+                        ],
+                        Chains =
+                        [
                             "eip155:1",
                             "eip155:10"
-                        },
-                        Events = new[]
-                        {
+                        ],
+                        Events =
+                        [
                             "chainChanged",
                             "accountsChanged"
-                        }
+                        ]
                     }
                 }
             }
@@ -463,20 +463,20 @@ public class SignTests : IAsyncLifetime
                 {
                     "eip155", new ProposedNamespace
                     {
-                        Methods = new[]
-                        {
+                        Methods =
+                        [
                             validMethod
-                        },
-                        Chains = new[]
-                        {
+                        ],
+                        Chains =
+                        [
                             "eip155:1",
                             "eip155:10"
-                        },
-                        Events = new[]
-                        {
+                        ],
+                        Events =
+                        [
                             "chainChanged",
                             "accountsChanged"
-                        }
+                        ]
                     }
                 }
             }
@@ -547,21 +547,21 @@ public class SignTests : IAsyncLifetime
                 {
                     "eip155", new ProposedNamespace
                     {
-                        Methods = new[]
-                        {
+                        Methods =
+                        [
                             testMethod,
                             testMethod2
-                        },
-                        Chains = new[]
-                        {
+                        ],
+                        Chains =
+                        [
                             "eip155:1",
                             "eip155:10"
-                        },
-                        Events = new[]
-                        {
+                        ],
+                        Events =
+                        [
                             "chainChanged",
                             "accountsChanged"
-                        }
+                        ]
                     }
                 }
             }
@@ -687,21 +687,21 @@ public class SignTests : IAsyncLifetime
                 {
                     "eip155", new ProposedNamespace
                     {
-                        Methods = new[]
-                        {
+                        Methods =
+                        [
                             testMethod,
                             testMethod2
-                        },
-                        Chains = new[]
-                        {
+                        ],
+                        Chains =
+                        [
                             "eip155:1",
                             "eip155:10"
-                        },
-                        Events = new[]
-                        {
+                        ],
+                        Events =
+                        [
                             "chainChanged",
                             "accountsChanged"
-                        }
+                        ]
                     }
                 }
             }
@@ -831,20 +831,20 @@ public class SignTests : IAsyncLifetime
                     {
                         "eip155", new ProposedNamespace
                         {
-                            Methods = new[]
-                            {
+                            Methods =
+                            [
                                 testMethod,
                                 testMethod2
-                            },
-                            Chains = new[]
-                            {
+                            ],
+                            Chains =
+                            [
                                 "eip155:1"
-                            },
-                            Events = new[]
-                            {
+                            ],
+                            Events =
+                            [
                                 "chainChanged",
                                 "accountsChanged"
-                            }
+                            ]
                         }
                     }
                 }
@@ -981,20 +981,20 @@ public class SignTests : IAsyncLifetime
                 {
                     "eip155", new ProposedNamespace
                     {
-                        Methods = new[]
-                        {
+                        Methods =
+                        [
                             testMethod,
                             testMethod2
-                        },
-                        Chains = new[]
-                        {
+                        ],
+                        Chains =
+                        [
                             "eip155:1"
-                        },
-                        Events = new[]
-                        {
+                        ],
+                        Events =
+                        [
                             "chainChanged",
                             "accountsChanged"
-                        }
+                        ]
                     }
                 }
             }
@@ -1102,20 +1102,20 @@ public class SignTests : IAsyncLifetime
                 {
                     "eip155", new ProposedNamespace
                     {
-                        Methods = new[]
-                        {
+                        Methods =
+                        [
                             testMethod
-                        },
-                        Chains = new[]
-                        {
+                        ],
+                        Chains =
+                        [
                             "eip155:1",
                             "eip155:10"
-                        },
-                        Events = new[]
-                        {
+                        ],
+                        Events =
+                        [
                             "chainChanged",
                             "accountsChanged"
-                        }
+                        ]
                     }
                 }
             }
@@ -1208,20 +1208,20 @@ public class SignTests : IAsyncLifetime
                 {
                     "eip155", new ProposedNamespace
                     {
-                        Methods = new[]
-                        {
+                        Methods =
+                        [
                             testMethod
-                        },
-                        Chains = new[]
-                        {
+                        ],
+                        Chains =
+                        [
                             "eip155:1",
                             "eip155:10"
-                        },
-                        Events = new[]
-                        {
+                        ],
+                        Events =
+                        [
                             "chainChanged",
                             "accountsChanged"
-                        }
+                        ]
                     }
                 }
             }
@@ -1289,5 +1289,89 @@ public class SignTests : IAsyncLifetime
         );
 
         Assert.Equal(ErrorType.GENERIC, exception.CodeType);
+    }
+
+    private async Task<(string sessionTopic, string pairingTopic)> ConnectAndApprove()
+    {
+        const string testAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+        var dappConnectOptions = new ConnectOptions
+        {
+            RequiredNamespaces = new RequiredNamespaces
+            {
+                {
+                    "eip155", new ProposedNamespace
+                    {
+                        Methods = ["eth_sign"],
+                        Chains = ["eip155:1", "eip155:10"],
+                        Events = ["chainChanged", "accountsChanged"]
+                    }
+                }
+            }
+        };
+
+        var connectData = await _dapp.Connect(dappConnectOptions);
+        var pairingTopic = connectData.Uri["wc:".Length..].Split('@')[0];
+
+        _wallet.SessionProposed += async (sender, @event) =>
+        {
+            var approvedNamespaces = new Namespaces(@event.Proposal.RequiredNamespaces);
+            approvedNamespaces["eip155"]
+                .WithAccount($"eip155:1:{testAddress}")
+                .WithAccount($"eip155:10:{testAddress}");
+
+            var approveData = await _wallet.Approve(new ApproveParams
+            {
+                Id = @event.Id,
+                Namespaces = approvedNamespaces
+            });
+            await approveData.Acknowledged();
+        };
+
+        _ = await _wallet.Pair(connectData.Uri);
+        var sessionData = await connectData.Approval;
+
+        return (sessionData.Topic, pairingTopic);
+    }
+
+    [Fact] [Trait("Category", "integration")]
+    public async Task TestSessionPing()
+    {
+        var (sessionTopic, _) = await ConnectAndApprove();
+
+        var pinged = new TaskCompletionSource<string>();
+        _wallet.SessionPinged += (sender, @event) => pinged.TrySetResult(@event.Topic);
+
+        await _dapp.PingAsync(sessionTopic);
+
+        var pingedTopic = await pinged.Task.WithTimeout(TimeSpan.FromSeconds(5));
+        Assert.Equal(sessionTopic, pingedTopic);
+    }
+
+    [Fact] [Trait("Category", "integration")]
+    public async Task TestPairingPing()
+    {
+        var (_, pairingTopic) = await ConnectAndApprove();
+
+        var pinged = new TaskCompletionSource<string>();
+        _wallet.CoreClient.Pairing.PairingPinged += (sender, @event) => pinged.TrySetResult(@event.Topic);
+
+        await _dapp.CoreClient.Pairing.Ping(pairingTopic);
+
+        var pingedTopic = await pinged.Task.WithTimeout(TimeSpan.FromSeconds(5));
+        Assert.Equal(pairingTopic, pingedTopic);
+    }
+
+    [Fact] [Trait("Category", "integration")]
+    public async Task TestPairingDisconnect()
+    {
+        var (_, pairingTopic) = await ConnectAndApprove();
+
+        var deleted = new TaskCompletionSource<string>();
+        _wallet.CoreClient.Pairing.PairingDeleted += (sender, @event) => deleted.TrySetResult(@event.Topic);
+
+        await _dapp.CoreClient.Pairing.Disconnect(pairingTopic);
+
+        var deletedTopic = await deleted.Task.WithTimeout(TimeSpan.FromSeconds(5));
+        Assert.Equal(pairingTopic, deletedTopic);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #279 (already merged). Two changes surfaced by the test-quality audit:

1. **`fix(sign)`: align `GetHashCode` with content-based equality.** `Namespace` and `ProposedNamespace` compare their string arrays by content (order-independent) in `Equals`, but `GetHashCode` used `HashCode.Combine` on the array *references*. Two equal instances backed by distinct arrays produced different hash codes — violating the `Equals`/`GetHashCode` contract and making these types unreliable as dictionary/set keys. Now the array contents are hashed with an order-independent XOR, for both the instance `GetHashCode` and the equality comparers.

2. **`test`: expand unit coverage** across the core and sign layers (Base64, DictionaryComparer, SdkErrors, hex conversions, Base58, CryptoEncoding, network error types, Account, ConnectOptions, CoreUtils, ProposalStruct, additional Recap cases, and session/pairing ping + disconnect integration tests). Also modernizes `SignTests` to collection-expression syntax and renames the Base58 `DIGITS` constant to PascalCase.

## The contract being fixed

```mermaid
flowchart LR
    A["ns1 == ns2 by content<br/>(distinct arrays)"] --> B{Equals}
    B -->|"order-independent<br/>content compare"| C["true"]
    A --> D{GetHashCode}
    D -->|"before: HashCode.Combine(refs)"| E["different hashes ❌<br/>contract broken"]
    D -->|"after: XOR of element hashes"| F["equal hashes ✅<br/>contract honored"]
```

## Test plan

- `dotnet build Reown.NoUnity.slnf` — 0 errors
- `dotnet test Reown.NoUnity.slnf --filter Category=unit` — **347 unit tests pass** across net8.0 / net9.0 / net10.0 (97 Common, 14 Crypto, 4 Storage, 191 Sign, 41 Network)
- Integration tests (`Category=integration`) require `PROJECT_ID` and run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)