### PR TITLE
fix: give appkit-cdn workflow's claude-code-action an explicit token

### DIFF
--- a/.github/workflows/update-appkit-cdn.yml
+++ b/.github/workflows/update-appkit-cdn.yml
@@ -210,6 +210,10 @@ jobs:
         uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Provide a token explicitly so the action does not attempt the default OIDC token exchange
+          # (which would require `id-token: write`). This step's Claude has no gh/Bash tools, so the
+          # token is only used for the action's own setup, never by the model.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 20


### PR DESCRIPTION
## Summary

The `update-appkit-cdn` workflow's enrichment step (`anthropics/claude-code-action`) failed on its first real run ([run](https://github.com/reown-com/reown-dotnet/actions/runs/26952717261/job/79522748023)) with:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

`claude-code-action` defaults to minting a GitHub token via OIDC, which needs `id-token: write`. The action bailed before invoking Claude, so PR #284 got the deterministic fallback body instead of the enriched changelog. `continue-on-error` kept the job green and the apply step correctly skipped — the graceful-degradation path worked as designed.

## Fix

Pass `github_token: ${{ secrets.GITHUB_TOKEN }}` to the action so it skips the OIDC exchange entirely. This is more minimal than granting `id-token: write`: the enrichment step's Claude has no `gh`/`Bash` tools, so the token is used only by the action's own setup, never by the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)