### PR TITLE
ci: warm Unity Library cache on develop to cut cold-build time

### DIFF
--- a/.github/workflows/unity-build-test.yml
+++ b/.github/workflows/unity-build-test.yml
@@ -1,6 +1,14 @@
 name: Build Unity Sample
 
 on:
+  push:
+    branches: [ develop ]
+    paths:
+      - 'src/**'
+      - 'sample/**'
+      - 'playground/**'
+      - 'Reown.slnx'
+      - 'Directory.Packages.props'
   pull_request:
     types: [opened, reopened, synchronize]
     paths:
@@ -20,7 +28,7 @@ concurrency:
 
 jobs:
   buildForAllSupportedPlatforms:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Build for ${{ matrix.targetPlatform }}
     runs-on: ubuntu-latest
     strategy:
@@ -44,8 +52,10 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ${{ matrix.projectPath }}/Library
-          key: Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}
-          restore-keys: Library-
+          key: Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-${{ hashFiles(format('{0}/Assets/**', matrix.projectPath), format('{0}/Packages/**', matrix.projectPath), format('{0}/ProjectSettings/**', matrix.projectPath)) }}
+          restore-keys: |
+            Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-
+            Library-${{ matrix.projectPath }}-
       - uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -63,7 +73,7 @@ jobs:
           name: Build-${{ matrix.targetPlatform }}
           path: Builds/${{ matrix.targetPlatform }}
   testAllModes:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Test in ${{ matrix.testMode }}
     runs-on: ubuntu-latest
     permissions:
@@ -88,8 +98,10 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ${{ matrix.projectPath }}/Library
-          key: Library-${{ matrix.projectPath }}-${{ matrix.testMode }}
-          restore-keys: Library-
+          key: Library-${{ matrix.projectPath }}-${{ matrix.testMode }}-${{ hashFiles(format('{0}/Assets/**', matrix.projectPath), format('{0}/Packages/**', matrix.projectPath), format('{0}/ProjectSettings/**', matrix.projectPath)) }}
+          restore-keys: |
+            Library-${{ matrix.projectPath }}-${{ matrix.testMode }}-
+            Library-${{ matrix.projectPath }}-
       - uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4.3.1
         id: tests
         env:
@@ -114,6 +126,7 @@ jobs:
 
   deployToVercel:
     name: Deploy to Vercel
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: buildForAllSupportedPlatforms
     permissions:

--- a/.github/workflows/unity-build-test.yml
+++ b/.github/workflows/unity-build-test.yml
@@ -9,6 +9,7 @@ on:
       - 'playground/**'
       - 'Reown.slnx'
       - 'Directory.Packages.props'
+      - '!**.md'
   pull_request:
     types: [opened, reopened, synchronize]
     paths:
@@ -17,6 +18,7 @@ on:
       - 'playground/**'
       - 'Reown.slnx'
       - 'Directory.Packages.props'
+      - '!**.md'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

Unity builds swing wildly in duration — Android between ~15m and ~28m, WebGL ~12m–18m, StandaloneWindows64 ~3.8m–7.3m. Step-level logs show the entire swing is the `actions/cache` restore of the Unity `Library` folder:

| Run | Cache restore | Unity step | Total |
|---|---|---|---|
| First push of a PR | 5s (**miss**) | **1520s (25m)** | 27m |
| Re-push to same PR | 36s (**hit**) | 720s (12m) | 15m |

A cold `Library` forces Unity to re-import every asset from scratch. That work is import/IO-bound, so a bigger runner wouldn't meaningfully help — the fix is to stop missing the cache.

## Root cause

Every `Library` cache in the store is scoped to a PR merge ref (`refs/pull/NNN/merge`); **none exist on `refs/heads/develop`**. That's because this workflow only triggered on `pull_request`. GitHub scopes caches to the creating branch plus the base branch, so with no cache on `develop`, **every new PR starts cold** and only goes fast on its second push (when it can read the cache it just saved on its own ref). Single-run PRs (e.g. Dependabot) always pay the full cold cost.

## Fix (free — no runner change)

- **Warm the base-branch cache**: add a `push: [develop]` trigger so each merge saves a `Library` cache on `refs/heads/develop` that all subsequent PRs inherit on their *first* run.
- **Run build/test jobs on push**: a `push` event has no `pull_request.draft`, so the existing `if` would skip them — updated to `github.event_name != 'pull_request' || …`.
- **Vercel stays PR-only**: no PR to comment on for develop pushes.
- **Rotate the cache key** on `Assets`/`Packages`/`ProjectSettings` content (was a static key that never refreshed), with prefix `restore-keys` fallbacks so partial/cross-platform hits still warm-start.
- **Skip Unity builds for markdown-only changes**: the workflow uses an inclusion `paths` filter, so root docs already don't trigger it — but 24 `.md` files nested under `src`/`sample`/`playground` (per-package README/LICENSE) match `src/**` etc. and trigger the full matrix on doc-only edits. Since `paths` and `paths-ignore` can't be combined, excluded via a trailing `!**.md` negative pattern on both triggers.

## Expected impact

First-run Android ~25m→~12–15m and WebGL ~18m→~12m, consistently, plus zero Unity runs for docs-only PRs. On this public repo the added develop runs are free.

> [!NOTE]
> The cache win only becomes visible **after this merges** and one develop run seeds the base-branch cache — that first develop run is still cold by design. Watch the *first* run of the next new PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)