### PR TITLE
fix: drop inbound messages when keychain key is missing

### DIFF
--- a/src/Reown.Core.Crypto/Runtime/Interfaces/IKeyChain.cs
+++ b/src/Reown.Core.Crypto/Runtime/Interfaces/IKeyChain.cs
@@ -43,20 +43,20 @@ namespace Reown.Core.Crypto.Interfaces
         Task Set(string tag, string key);
 
         /// <summary>
-        ///     Get a saved key with the given tag. If no tag exists, then a ReownNetworkException will
+        ///     Get a saved key with the given tag. If no tag exists, then a <see cref="KeychainKeyNotFoundException" /> will
         ///     be thrown.
         /// </summary>
         /// <param name="tag">The tag of the key to retrieve</param>
         /// <returns>The key with the given tag</returns>
-        /// <exception cref="ReownNetworkException">Thrown if the given tag does not match any key</exception>
+        /// <exception cref="KeychainKeyNotFoundException">Thrown if the given tag does not match any key</exception>
         Task<string> Get(string tag);
 
         /// <summary>
-        ///     Delete a key with the given tag. If no tag exists, then a ReownNetworkException will
+        ///     Delete a key with the given tag. If no tag exists, then a <see cref="KeychainKeyNotFoundException" /> will
         ///     be thrown.
         /// </summary>
         /// <param name="tag">The tag of the key to delete</param>
-        /// <exception cref="ReownNetworkException">Thrown if the given tag does not match any key</exception>
+        /// <exception cref="KeychainKeyNotFoundException">Thrown if the given tag does not match any key</exception>
         Task Delete(string tag);
     }
 }

--- a/src/Reown.Core.Crypto/Runtime/KeyChain.cs
+++ b/src/Reown.Core.Crypto/Runtime/KeyChain.cs
@@ -132,11 +132,12 @@ namespace Reown.Core.Crypto
         }
 
         /// <summary>
-        ///     Get a saved key with the given tag.
+        ///     Get a saved key with the given tag. If no tag exists, then a <see cref="KeychainKeyNotFoundException" /> will
+        ///     be thrown.
         /// </summary>
         /// <param name="tag">The tag of the key to retrieve</param>
         /// <returns>The key with the given tag</returns>
-        /// <exception cref="InvalidOperationException">Thrown if the given tag does not match any key</exception>
+        /// <exception cref="KeychainKeyNotFoundException">Thrown if the given tag does not match any key</exception>
         public async Task<string> Get(string tag)
         {
             IsInitialized();
@@ -146,11 +147,11 @@ namespace Reown.Core.Crypto
         }
 
         /// <summary>
-        ///     Delete a key with the given tag. If no tag exists, then a ReownNetworkException will
+        ///     Delete a key with the given tag. If no tag exists, then a <see cref="KeychainKeyNotFoundException" /> will
         ///     be thrown.
         /// </summary>
         /// <param name="tag">The tag of the key to delete</param>
-        /// <exception cref="InvalidOperationException">Thrown if the given tag does not match any key</exception>
+        /// <exception cref="KeychainKeyNotFoundException">Thrown if the given tag does not match any key</exception>
         public async Task Delete(string tag)
         {
             IsInitialized();
@@ -164,7 +165,7 @@ namespace Reown.Core.Crypto
         {
             if (!await Has(tag))
             {
-                throw new InvalidOperationException($"Keychain does not contain key with tag: {tag}.");
+                throw new KeychainKeyNotFoundException(tag);
             }
         }
 

--- a/src/Reown.Core.Crypto/Runtime/KeychainKeyNotFoundException.cs
+++ b/src/Reown.Core.Crypto/Runtime/KeychainKeyNotFoundException.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Reown.Core.Crypto
+{
+    /// <summary>
+    ///     The exception that is thrown when the <see cref="KeyChain" /> does not contain a key
+    ///     for the requested tag.
+    /// </summary>
+    /// <remarks>
+    ///     Inherits from <see cref="InvalidOperationException" /> to preserve backward compatibility
+    ///     with callers that catch <see cref="InvalidOperationException" />.
+    /// </remarks>
+    public class KeychainKeyNotFoundException : InvalidOperationException
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="KeychainKeyNotFoundException" /> class for the given tag.
+        /// </summary>
+        /// <param name="tag">The tag that was not found in the keychain.</param>
+        public KeychainKeyNotFoundException(string tag)
+            : base($"Keychain does not contain key with tag: {tag}.")
+        {
+            Tag = tag;
+        }
+
+        /// <summary>
+        ///     The tag that was not found in the keychain.
+        /// </summary>
+        public string Tag { get; }
+    }
+}

--- a/src/Reown.Core.Crypto/Runtime/KeychainKeyNotFoundException.cs
+++ b/src/Reown.Core.Crypto/Runtime/KeychainKeyNotFoundException.cs
@@ -19,7 +19,7 @@ namespace Reown.Core.Crypto
         public KeychainKeyNotFoundException(string tag)
             : base($"Keychain does not contain key with tag: {tag}.")
         {
-            Tag = tag;
+            Tag = tag ?? throw new ArgumentNullException(nameof(tag));
         }
 
         /// <summary>

--- a/src/Reown.Core.Crypto/Runtime/KeychainKeyNotFoundException.cs.meta
+++ b/src/Reown.Core.Crypto/Runtime/KeychainKeyNotFoundException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a98a5f7c65e4d97959f1bb86f1dca34
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
+++ b/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
@@ -12,6 +12,7 @@ using Reown.Core.Interfaces;
 using Reown.Core.Models;
 using Reown.Core.Models.History;
 using Reown.Core.Models.Relay;
+using Reown.Core.Network;
 using Reown.Core.Network.Models;
 
 namespace Reown.Core.Controllers
@@ -223,16 +224,8 @@ namespace Reown.Core.Controllers
                         return;
                     }
 
-                    JsonRpcRequest<T> payload;
-                    try
-                    {
-                        payload = await CoreClient.Crypto.Decode<JsonRpcRequest<T>>(topic, message, options);
-                    }
-                    catch (KeychainKeyNotFoundException ex)
-                    {
-                        ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
-                        return;
-                    }
+                    var (decoded, payload) = await TryDecodeOrDrop<JsonRpcRequest<T>>(topic, message, options);
+                    if (!decoded) return;
 
                     (await CoreClient.History.JsonRpcHistoryOfType<T, TR>()).Set(topic, payload, null);
 
@@ -257,32 +250,20 @@ namespace Reown.Core.Controllers
 
                 if (options == null && !await CoreClient.Crypto.HasKeys(topic)) return;
 
-                JsonRpcPayload rawResultPayload;
-                try
-                {
-                    rawResultPayload = await CoreClient.Crypto.Decode<JsonRpcPayload>(topic, message, options);
-                }
-                catch (KeychainKeyNotFoundException ex)
-                {
-                    ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
-                    return;
-                }
+                var (rawDecoded, rawResultPayload) = await TryDecodeOrDrop<JsonRpcPayload>(topic, message, options);
+                if (!rawDecoded) return;
 
                 var history = await CoreClient.History.JsonRpcHistoryOfType<T, TR>();
                 var expectingResult = await history.Exists(topic, rawResultPayload.Id);
 
+                var (resultDecoded, payload) = await TryDecodeOrDrop<JsonRpcResponse<TR>>(topic, message, options);
+                if (!resultDecoded) return;
+
                 try
                 {
-                    var payload = await CoreClient.Crypto.Decode<JsonRpcResponse<TR>>(topic, message, options);
-
                     await history.Resolve(payload);
 
                     await responseCallback(topic, payload);
-                }
-                catch (KeychainKeyNotFoundException ex)
-                {
-                    ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
-                    return;
                 }
                 catch (Exception ex) when (ex is JsonException)
                 {
@@ -444,6 +425,20 @@ namespace Reown.Core.Controllers
             await (await CoreClient.History.JsonRpcHistoryOfType<T, TR>()).Resolve(payload);
         }
 
+        private async Task<(bool success, T payload)> TryDecodeOrDrop<T>(string topic, string message, DecodeOptions options)
+            where T : IJsonRpcPayload
+        {
+            try
+            {
+                return (true, await CoreClient.Crypto.Decode<T>(topic, message, options));
+            }
+            catch (KeychainKeyNotFoundException ex)
+            {
+                ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
+                return (false, default);
+            }
+        }
+
         private async void RelayMessageCallback(object sender, MessageEvent e)
         {
             var topic = e.Topic;
@@ -451,16 +446,8 @@ namespace Reown.Core.Controllers
 
             var options = DecodeOptionForTopic(topic);
 
-            JsonRpcPayload payload;
-            try
-            {
-                payload = await CoreClient.Crypto.Decode<JsonRpcPayload>(topic, message, options);
-            }
-            catch (KeychainKeyNotFoundException ex)
-            {
-                ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
-                return;
-            }
+            var (decoded, payload) = await TryDecodeOrDrop<JsonRpcPayload>(topic, message, options);
+            if (!decoded) return;
 
             if (payload.IsRequest)
             {

--- a/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
+++ b/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Reown.Core.Common.Logging;
 using Reown.Core.Common.Utils;
+using Reown.Core.Crypto;
 using Reown.Core.Crypto.Models;
 using Reown.Core.Interfaces;
 using Reown.Core.Models;
@@ -222,7 +223,16 @@ namespace Reown.Core.Controllers
                         return;
                     }
 
-                    var payload = await CoreClient.Crypto.Decode<JsonRpcRequest<T>>(topic, message, options);
+                    JsonRpcRequest<T> payload;
+                    try
+                    {
+                        payload = await CoreClient.Crypto.Decode<JsonRpcRequest<T>>(topic, message, options);
+                    }
+                    catch (KeychainKeyNotFoundException ex)
+                    {
+                        ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
+                        return;
+                    }
 
                     (await CoreClient.History.JsonRpcHistoryOfType<T, TR>()).Set(topic, payload, null);
 
@@ -247,7 +257,16 @@ namespace Reown.Core.Controllers
 
                 if (options == null && !await CoreClient.Crypto.HasKeys(topic)) return;
 
-                var rawResultPayload = await CoreClient.Crypto.Decode<JsonRpcPayload>(topic, message, options);
+                JsonRpcPayload rawResultPayload;
+                try
+                {
+                    rawResultPayload = await CoreClient.Crypto.Decode<JsonRpcPayload>(topic, message, options);
+                }
+                catch (KeychainKeyNotFoundException ex)
+                {
+                    ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
+                    return;
+                }
 
                 var history = await CoreClient.History.JsonRpcHistoryOfType<T, TR>();
                 var expectingResult = await history.Exists(topic, rawResultPayload.Id);
@@ -259,6 +278,10 @@ namespace Reown.Core.Controllers
                     await history.Resolve(payload);
 
                     await responseCallback(topic, payload);
+                }
+                catch (KeychainKeyNotFoundException ex)
+                {
+                    ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
                 }
                 catch (Exception ex) when (ex is JsonException)
                 {
@@ -427,7 +450,17 @@ namespace Reown.Core.Controllers
 
             var options = DecodeOptionForTopic(topic);
 
-            var payload = await CoreClient.Crypto.Decode<JsonRpcPayload>(topic, message, options);
+            JsonRpcPayload payload;
+            try
+            {
+                payload = await CoreClient.Crypto.Decode<JsonRpcPayload>(topic, message, options);
+            }
+            catch (KeychainKeyNotFoundException ex)
+            {
+                ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
+                return;
+            }
+
             if (payload.IsRequest)
             {
                 _requestQueue.Enqueue((payload.Method, e));

--- a/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
+++ b/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
@@ -256,14 +256,17 @@ namespace Reown.Core.Controllers
                 var history = await CoreClient.History.JsonRpcHistoryOfType<T, TR>();
                 var expectingResult = await history.Exists(topic, rawResultPayload.Id);
 
-                var (resultDecoded, payload) = await TryDecodeOrDrop<JsonRpcResponse<TR>>(topic, message, options);
-                if (!resultDecoded) return;
-
                 try
                 {
+                    var payload = await CoreClient.Crypto.Decode<JsonRpcResponse<TR>>(topic, message, options);
+
                     await history.Resolve(payload);
 
                     await responseCallback(topic, payload);
+                }
+                catch (KeychainKeyNotFoundException ex)
+                {
+                    ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
                 }
                 catch (Exception ex) when (ex is JsonException)
                 {

--- a/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
+++ b/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
@@ -282,6 +282,7 @@ namespace Reown.Core.Controllers
                 catch (KeychainKeyNotFoundException ex)
                 {
                     ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
+                    return;
                 }
                 catch (Exception ex) when (ex is JsonException)
                 {

--- a/test/Reown.Core.Crypto.Test/KeyChainTests.cs
+++ b/test/Reown.Core.Crypto.Test/KeyChainTests.cs
@@ -55,4 +55,10 @@ public class KeyChainTests
         Assert.Equal(tag, exception.Tag);
         Assert.Equal($"Keychain does not contain key with tag: {tag}.", exception.Message);
     }
+
+    [Fact, Trait("Category", "unit")]
+    public void KeychainKeyNotFoundExceptionThrowsForNullTag()
+    {
+        Assert.Throws<ArgumentNullException>(() => new KeychainKeyNotFoundException(null!));
+    }
 }

--- a/test/Reown.Core.Crypto.Test/KeyChainTests.cs
+++ b/test/Reown.Core.Crypto.Test/KeyChainTests.cs
@@ -41,7 +41,7 @@ public class KeyChainTests
 
         var exception = await Assert.ThrowsAsync<KeychainKeyNotFoundException>(() => keyChain.Get("unknown-tag"));
 
-        Assert.IsAssignableFrom<InvalidOperationException>(exception);
+        Assert.IsType<InvalidOperationException>(exception, exactMatch: false);
     }
 
     [Fact, Trait("Category", "unit")]

--- a/test/Reown.Core.Crypto.Test/KeyChainTests.cs
+++ b/test/Reown.Core.Crypto.Test/KeyChainTests.cs
@@ -1,0 +1,58 @@
+using Reown.Core.Storage;
+using Xunit;
+
+namespace Reown.Core.Crypto.Test;
+
+public class KeyChainTests
+{
+    private static async Task<KeyChain> CreateInitializedKeyChainAsync()
+    {
+        var storage = new InMemoryStorage();
+        await storage.Init();
+
+        var keyChain = new KeyChain(storage);
+        await keyChain.Init();
+        return keyChain;
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task GetWithUnknownTagThrowsKeychainKeyNotFoundException()
+    {
+        var keyChain = await CreateInitializedKeyChainAsync();
+
+        await Assert.ThrowsAsync<KeychainKeyNotFoundException>(() => keyChain.Get("unknown-tag"));
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task DeleteWithUnknownTagThrowsKeychainKeyNotFoundException()
+    {
+        const string tag = "unknown-tag";
+        var keyChain = await CreateInitializedKeyChainAsync();
+
+        var exception = await Assert.ThrowsAsync<KeychainKeyNotFoundException>(() => keyChain.Delete(tag));
+
+        Assert.Equal(tag, exception.Tag);
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task KeychainKeyNotFoundExceptionIsAssignableToInvalidOperationException()
+    {
+        var keyChain = await CreateInitializedKeyChainAsync();
+
+        var exception = await Assert.ThrowsAsync<KeychainKeyNotFoundException>(() => keyChain.Get("unknown-tag"));
+
+        Assert.IsAssignableFrom<InvalidOperationException>(exception);
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task KeychainKeyNotFoundExceptionCarriesMissingTag()
+    {
+        const string tag = "missing-tag";
+        var keyChain = await CreateInitializedKeyChainAsync();
+
+        var exception = await Assert.ThrowsAsync<KeychainKeyNotFoundException>(() => keyChain.Get(tag));
+
+        Assert.Equal(tag, exception.Tag);
+        Assert.Equal($"Keychain does not contain key with tag: {tag}.", exception.Message);
+    }
+}

--- a/test/Reown.Core.Network.Test/TypedMessageHandlerTests.cs
+++ b/test/Reown.Core.Network.Test/TypedMessageHandlerTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NSubstitute;
+using Reown.Core.Common.Logging;
+using Reown.Core.Controllers;
+using Reown.Core.Crypto;
+using Reown.Core.Crypto.Models;
+using Reown.Core.Interfaces;
+using Reown.Core.Models.Relay;
+using Reown.Core.Network.Models;
+using Xunit;
+
+namespace Reown.Core.Network.Test
+{
+    /// <summary>
+    ///     Tests that <see cref="TypedMessageHandler" /> silently drops inbound messages when the
+    ///     keychain no longer contains the key required to decode them.
+    /// </summary>
+    public class TypedMessageHandlerTests : IDisposable
+    {
+        private readonly ILogger _previousLogger = ReownLogger.Instance;
+        private readonly CapturingLogger _logger = new();
+
+        public TypedMessageHandlerTests()
+        {
+            ReownLogger.Instance = _logger;
+        }
+
+        public void Dispose()
+        {
+            ReownLogger.Instance = _previousLogger;
+        }
+
+        /// <summary>
+        ///     A relayed message whose decode fails with <see cref="KeychainKeyNotFoundException" /> is dropped
+        ///     without surfacing an exception or triggering downstream processing.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task RelayMessageCallback_DropsMessage_WhenKeychainKeyMissing()
+        {
+            const string topic = "missing-key-topic";
+            var coreClient = CreateCoreClient();
+            coreClient.Crypto
+                .Decode<JsonRpcPayload>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DecodeOptions>())
+                .Returns<Task<JsonRpcPayload>>(_ => throw new KeychainKeyNotFoundException(topic));
+
+            var handler = new TypedMessageHandler(coreClient);
+            await handler.Init();
+
+            var rawMessageRaised = false;
+            handler.RawMessage += (_, _) => rawMessageRaised = true;
+
+            coreClient.Relayer.OnMessageReceived += Raise.Event<EventHandler<MessageEvent>>(
+                this, new MessageEvent { Topic = topic, Message = "encrypted" });
+
+            Assert.False(rawMessageRaised);
+            Assert.Contains(_logger.Messages, m => m.Contains($"Dropping message on topic {topic}"));
+        }
+
+        /// <summary>
+        ///     A typed request whose payload decodes but whose typed decode fails with
+        ///     <see cref="KeychainKeyNotFoundException" /> (the key was removed mid-flight) is dropped.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task RequestCallback_DropsMessage_WhenKeychainKeyMissing()
+        {
+            const string topic = "missing-key-request-topic";
+            var method = RpcMethodAttribute.MethodForType<TestRequest>();
+
+            var coreClient = CreateCoreClient();
+            coreClient.Crypto.HasKeys(topic).Returns(true);
+            coreClient.History.JsonRpcHistoryOfType<TestRequest, TestResponse>()
+                .Returns(Task.FromResult(Substitute.For<IJsonRpcHistory<TestRequest, TestResponse>>()));
+
+            var requestPayload = JsonConvert.DeserializeObject<JsonRpcPayload>(
+                $"{{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"{method}\"}}");
+            coreClient.Crypto
+                .Decode<JsonRpcPayload>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DecodeOptions>())
+                .Returns(Task.FromResult(requestPayload)!);
+            coreClient.Crypto
+                .Decode<JsonRpcRequest<TestRequest>>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DecodeOptions>())
+                .Returns<Task<JsonRpcRequest<TestRequest>>>(_ => throw new KeychainKeyNotFoundException(topic));
+
+            var handler = new TypedMessageHandler(coreClient);
+            await handler.Init();
+            await handler.HandleMessageType<TestRequest, TestResponse>(
+                (_, _) => Task.CompletedTask, (_, _) => Task.CompletedTask);
+
+            coreClient.Relayer.OnMessageReceived += Raise.Event<EventHandler<MessageEvent>>(
+                this, new MessageEvent { Topic = topic, Message = "encrypted" });
+
+            Assert.Contains(_logger.Messages, m => m.Contains($"Dropping message on topic {topic}"));
+        }
+
+        private static ICoreClient CreateCoreClient()
+        {
+            var coreClient = Substitute.For<ICoreClient>();
+            coreClient.Name.Returns("test");
+            return coreClient;
+        }
+
+        private sealed class CapturingLogger : ILogger
+        {
+            public List<string> Messages { get; } = new();
+
+            public void Log(string message)
+            {
+                Messages.Add(message);
+            }
+
+            public void LogError(string message)
+            {
+                Messages.Add(message);
+            }
+
+            public void LogError(Exception e)
+            {
+                Messages.Add(e.ToString());
+            }
+        }
+
+        [RpcMethod("test_keychain_drop")]
+        public sealed class TestRequest
+        {
+        }
+
+        public sealed class TestResponse
+        {
+        }
+    }
+}

--- a/test/Reown.Core.Network.Test/TypedMessageHandlerTests.cs
+++ b/test/Reown.Core.Network.Test/TypedMessageHandlerTests.cs
@@ -18,7 +18,7 @@ namespace Reown.Core.Network.Test
     ///     Tests that <see cref="TypedMessageHandler" /> silently drops inbound messages when the
     ///     keychain no longer contains the key required to decode them.
     /// </summary>
-    public class TypedMessageHandlerTests : IDisposable
+    public sealed class TypedMessageHandlerTests : IDisposable
     {
         private readonly ILogger _previousLogger = ReownLogger.Instance;
         private readonly CapturingLogger _logger = new();


### PR DESCRIPTION
## Summary

Missing keychain entries previously surfaced as a generic `InvalidOperationException` from `KeyChain.Get`/`Delete`, which in `TypedMessageHandler` could bubble up as an unhandled error while processing inbound relay messages (e.g. a message arriving on a topic whose key was already removed).

This PR:

- Adds a dedicated **`KeychainKeyNotFoundException`** (in `Reown.Core.Crypto`) that carries the missing `Tag`. It inherits from `InvalidOperationException` to preserve backward compatibility with any callers already catching that type.
- `KeyChain` now throws `KeychainKeyNotFoundException` instead of a raw `InvalidOperationException`.
- **`TypedMessageHandler`** catches this exception around every `Crypto.Decode` path and **drops the affected inbound message** with a log entry, instead of letting a missing key break message processing.
- Updates `IKeyChain`/`KeyChain` XML docs to reference the new exception type (previously they inconsistently mentioned `ReownNetworkException` / `InvalidOperationException`).

## Tests

New `KeyChainTests` (unit) covering:
- `Get`/`Delete` with an unknown tag throw `KeychainKeyNotFoundException`
- The exception carries the missing tag and expected message
- The exception is assignable to `InvalidOperationException` (backward compatibility)

All 4 tests pass across net8.0 / net9.0 / net10.0. Full `Reown.NoUnity.slnf` build is green (0 errors).

## Notes

`KeychainKeyNotFoundException` inheriting from `InvalidOperationException` means existing broad catches keep working while new code can catch the specific type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
