### PR TITLE
refactor: process inbound responses through a sequential message pump

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,8 +7,9 @@
         <PackageProjectUrl>https://reown.com/</PackageProjectUrl>
         <RepositoryUrl>https://github.com/reown-com/reown-dotnet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <MSBUildProjectExtensionsPath>..\..\build\$(MSBuildProjectName)\obj\</MSBUildProjectExtensionsPath>
+        <MSBuildProjectExtensionsPath>..\..\build\$(MSBuildProjectName)\obj\</MSBuildProjectExtensionsPath>
         <BaseIntermediateOutputPath>..\..\build\$(MSBuildProjectName)\obj\</BaseIntermediateOutputPath>
+        <BaseOutputPath>..\..\build\$(MSBuildProjectName)\bin\</BaseOutputPath>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <PackageIcon>reown-avatar-positive.png</PackageIcon>
     </PropertyGroup>
@@ -20,12 +21,6 @@
             <Link>walletkit-icon.png</Link>
         </None>
     </ItemGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-        <OutputPath>..\..\build\$(MSBuildProjectName)\bin\Release\</OutputPath>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-        <OutputPath>..\..\build\$(MSBuildProjectName)\bin\Debug\</OutputPath>
-    </PropertyGroup>
     <PropertyGroup Label="C#">
         <LangVersion>9.0</LangVersion>
         <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>

--- a/src/Reown.Core/Runtime/Controllers/Pairing.cs
+++ b/src/Reown.Core/Runtime/Controllers/Pairing.cs
@@ -324,7 +324,7 @@ namespace Reown.Core.Controllers
             if (Store.Keys.Contains(topic))
             {
                 var id = await CoreClient.MessageHandler.SendRequest<PairingPing, bool>(topic, new PairingPing());
-                var done = new TaskCompletionSource<bool>();
+                var done = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 _pairingPingResponseEvents.ListenOnce($"pairing_ping{id}", (sender, args) =>
                 {

--- a/src/Reown.Core/Runtime/Controllers/SequentialMessagePump.cs
+++ b/src/Reown.Core/Runtime/Controllers/SequentialMessagePump.cs
@@ -79,17 +79,34 @@ namespace Reown.Core.Controllers
                     }
                     catch (Exception e)
                     {
-                        ReownLogger.LogError(e);
+                        LogSafely(e);
                     }
                 }
             }
             catch (Exception e)
             {
-                ReownLogger.LogError(e);
                 lock (_lock)
                 {
                     _isProcessing = false;
                 }
+
+                LogSafely(e);
+            }
+        }
+
+        /// <summary>
+        ///     Logs the exception, swallowing logger failures so that a faulty logger can neither stop the pump
+        ///     nor leak an exception into the producer's <c>Enqueue</c> task.
+        /// </summary>
+        /// <param name="e">The exception to log.</param>
+        private static void LogSafely(Exception e)
+        {
+            try
+            {
+                ReownLogger.LogError(e);
+            }
+            catch
+            {
             }
         }
     }

--- a/src/Reown.Core/Runtime/Controllers/SequentialMessagePump.cs
+++ b/src/Reown.Core/Runtime/Controllers/SequentialMessagePump.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Reown.Core.Common.Logging;
+
+namespace Reown.Core.Controllers
+{
+    /// <summary>
+    ///     A single-consumer asynchronous message pump. Items enqueued from any thread are processed one at a
+    ///     time, in FIFO order, by whichever caller first finds the pump idle. Enqueue and the drain lifecycle
+    ///     are synchronized so that concurrent producers can neither corrupt the queue, run the processor
+    ///     concurrently, nor strand an item that arrives while the pump is winding down.
+    /// </summary>
+    /// <typeparam name="T">The type of item processed by the pump.</typeparam>
+    internal sealed class SequentialMessagePump<T>
+    {
+        private readonly object _lock = new();
+        private readonly Func<T, Task> _process;
+        private readonly Queue<T> _queue = new();
+        private bool _isProcessing;
+
+        /// <summary>
+        ///     Creates a pump that feeds each dequeued item to <paramref name="process" />.
+        /// </summary>
+        /// <param name="process">
+        ///     The per-item processor. An exception it throws is logged and does not stop the pump or drop later items.
+        /// </param>
+        public SequentialMessagePump(Func<T, Task> process)
+        {
+            _process = process;
+        }
+
+        /// <summary>
+        ///     Enqueues an item and ensures the pump is draining. The returned task completes when the calling
+        ///     drainer stops; it completes synchronously when another caller is already draining.
+        /// </summary>
+        /// <param name="item">The item to process.</param>
+        public Task Enqueue(T item)
+        {
+            lock (_lock)
+            {
+                _queue.Enqueue(item);
+            }
+
+            return Drain();
+        }
+
+        private async Task Drain()
+        {
+            lock (_lock)
+            {
+                if (_isProcessing)
+                {
+                    return;
+                }
+
+                _isProcessing = true;
+            }
+
+            try
+            {
+                while (true)
+                {
+                    T item;
+                    lock (_lock)
+                    {
+                        if (_queue.Count == 0)
+                        {
+                            _isProcessing = false;
+                            return;
+                        }
+
+                        item = _queue.Dequeue();
+                    }
+
+                    try
+                    {
+                        await _process(item);
+                    }
+                    catch (Exception e)
+                    {
+                        ReownLogger.LogError(e);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                ReownLogger.LogError(e);
+                lock (_lock)
+                {
+                    _isProcessing = false;
+                }
+            }
+        }
+    }
+}

--- a/src/Reown.Core/Runtime/Controllers/SequentialMessagePump.cs.meta
+++ b/src/Reown.Core/Runtime/Controllers/SequentialMessagePump.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9876ec89c78b4cb58e50717b9949e360
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
+++ b/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
@@ -369,6 +369,10 @@ namespace Reown.Core.Controllers
         ///     An override to specify how long this request will live for. If null is given, then expiry will be taken from either T or TR
         ///     attributed options
         /// </param>
+        /// <param name="ct">
+        ///     Cancels the request only before the send begins; the token is not propagated into encoding,
+        ///     history recording, or publishing
+        /// </param>
         /// <typeparam name="T">The request type</typeparam>
         /// <typeparam name="TR">The response type</typeparam>
         /// <returns>The id of the request sent</returns>
@@ -438,24 +442,31 @@ namespace Reown.Core.Controllers
 
         private async void RelayMessageCallback(object sender, MessageEvent e)
         {
-            var topic = e.Topic;
-            var message = e.Message;
-
-            var options = DecodeOptionForTopic(topic);
-
-            var payload = await CoreClient.Crypto.Decode<JsonRpcPayload>(topic, message, options);
-            if (payload.IsRequest)
+            try
             {
-                await _requestPump.Enqueue((payload.Method, e));
-            }
-            else if (payload.IsResponse)
-            {
-                await _responsePump.Enqueue(new DecodedMessageEvent
+                var topic = e.Topic;
+                var message = e.Message;
+
+                var options = DecodeOptionForTopic(topic);
+
+                var payload = await CoreClient.Crypto.Decode<JsonRpcPayload>(topic, message, options);
+                if (payload.IsRequest)
                 {
-                    Topic = topic,
-                    Message = message,
-                    Payload = payload
-                });
+                    await _requestPump.Enqueue((payload.Method, e));
+                }
+                else if (payload.IsResponse)
+                {
+                    await _responsePump.Enqueue(new DecodedMessageEvent
+                    {
+                        Topic = topic,
+                        Message = message,
+                        Payload = payload
+                    });
+                }
+            }
+            catch (Exception exception)
+            {
+                ReownLogger.LogError(exception);
             }
         }
 
@@ -466,6 +477,7 @@ namespace Reown.Core.Controllers
                 return;
             }
 
+            // Iterate backwards so a callback disposing its own handler token mid-dispatch does not skip the next callback
             for (var i = callbacks.Count - 1; i >= 0; i--)
             {
                 try

--- a/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
+++ b/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
@@ -19,16 +19,20 @@ namespace Reown.Core.Controllers
     {
         private readonly Dictionary<string, DecodeOptions> _decodeOptionsMap = new();
         private readonly Dictionary<string, List<Func<MessageEvent, Task>>> _requestCallbacksMap = new();
-        private readonly Queue<(string method, MessageEvent messageEvent)> _requestQueue = new();
-        private readonly Dictionary<string, List<Action<MessageEvent>>> _responseCallbacksMap = new();
+        private readonly Dictionary<string, List<Func<MessageEvent, Task>>> _responseCallbacksMap = new();
+        private readonly List<Func<DecodedMessageEvent, Task>> _rawResponseHandlers = new();
+        private readonly object _rawResponseHandlersLock = new();
         private readonly HashSet<string> _typeSafeCache = new();
+        private readonly SequentialMessagePump<(string method, MessageEvent messageEvent)> _requestPump;
+        private readonly SequentialMessagePump<DecodedMessageEvent> _responsePump;
         private bool _initialized;
-        private bool _isRequestQueueProcessing;
         protected bool Disposed;
 
         public TypedMessageHandler(ICoreClient coreClient)
         {
             CoreClient = coreClient;
+            _requestPump = new SequentialMessagePump<(string method, MessageEvent messageEvent)>(ProcessRequest);
+            _responsePump = new SequentialMessagePump<DecodedMessageEvent>(ProcessResponse);
         }
 
         public ICoreClient CoreClient { get; }
@@ -193,6 +197,12 @@ namespace Reown.Core.Controllers
         ///     Handle a specific request / response type and call the given callbacks for requests and responses. The
         ///     response callback is only triggered when it originates from the request of the same type.
         /// </summary>
+        /// <remarks>
+        ///     Callbacks are awaited to completion on a sequential message pump: no other inbound message of the same
+        ///     direction (request or response) is dispatched until the callback's task completes. A callback must
+        ///     therefore not await another round trip on the same client in the same direction — for example, awaiting
+        ///     a response inside a response callback deadlocks, because that response is queued behind the callback.
+        /// </remarks>
         /// <param name="requestCallback">The callback function to invoke when a request is received with the given request type</param>
         /// <param name="responseCallback">The callback function to invoke when a response is received with the given response type</param>
         /// <typeparam name="T">The request type to trigger the requestCallback for</typeparam>
@@ -233,7 +243,7 @@ namespace Reown.Core.Controllers
                 }
             }
 
-            async void ResponseCallback(MessageEvent e)
+            async Task ResponseCallback(MessageEvent e)
             {
                 if (responseCallback == null || Disposed)
                 {
@@ -268,7 +278,7 @@ namespace Reown.Core.Controllers
                 }
             }
 
-            async void InspectResponseRaw(object sender, DecodedMessageEvent e)
+            async Task InspectResponseRaw(DecodedMessageEvent e)
             {
                 var topic = e.Topic;
                 var message = e.Message;
@@ -295,7 +305,7 @@ namespace Reown.Core.Controllers
                     var callbacksCopy = callbacks.ToList();
                     foreach (var callback in callbacksCopy)
                     {
-                        callback(new MessageEvent
+                        await callback(new MessageEvent
                         {
                             Topic = topic,
                             Message = message
@@ -315,7 +325,7 @@ namespace Reown.Core.Controllers
 
             if (!_responseCallbacksMap.TryGetValue(method, out var responseCallbacks))
             {
-                responseCallbacks = new List<Action<MessageEvent>>();
+                responseCallbacks = new List<Func<MessageEvent, Task>>();
                 _responseCallbacksMap.Add(method, responseCallbacks);
             }
 
@@ -323,11 +333,17 @@ namespace Reown.Core.Controllers
 
             // Handle response_raw in this context
             // This will allow us to examine response_raw in every typed context registered
-            RawMessage += InspectResponseRaw;
+            lock (_rawResponseHandlersLock)
+            {
+                _rawResponseHandlers.Add(InspectResponseRaw);
+            }
 
             return new DisposeHandlerToken(() =>
             {
-                RawMessage -= InspectResponseRaw;
+                lock (_rawResponseHandlersLock)
+                {
+                    _rawResponseHandlers.Remove(InspectResponseRaw);
+                }
 
                 _requestCallbacksMap[method].Remove(RequestCallback);
                 _responseCallbacksMap[method].Remove(ResponseCallback);
@@ -430,56 +446,66 @@ namespace Reown.Core.Controllers
             var payload = await CoreClient.Crypto.Decode<JsonRpcPayload>(topic, message, options);
             if (payload.IsRequest)
             {
-                _requestQueue.Enqueue((payload.Method, e));
-                await ProcessRequestQueue();
+                await _requestPump.Enqueue((payload.Method, e));
             }
             else if (payload.IsResponse)
             {
-                RawMessage?.Invoke(this,
-                    new DecodedMessageEvent
-                    {
-                        Topic = topic,
-                        Message = message,
-                        Payload = payload
-                    });
+                await _responsePump.Enqueue(new DecodedMessageEvent
+                {
+                    Topic = topic,
+                    Message = message,
+                    Payload = payload
+                });
             }
         }
 
-        private async Task ProcessRequestQueue()
+        private async Task ProcessRequest((string method, MessageEvent messageEvent) item)
         {
-            if (_isRequestQueueProcessing)
+            if (!_requestCallbacksMap.TryGetValue(item.method, out var callbacks))
             {
                 return;
             }
 
-            _isRequestQueueProcessing = true;
-
-            try
+            for (var i = callbacks.Count - 1; i >= 0; i--)
             {
-                while (_requestQueue.Count > 0)
+                try
                 {
-                    var (method, messageEvent) = _requestQueue.Dequeue();
-                    if (!_requestCallbacksMap.TryGetValue(method, out var callbacks))
-                    {
-                        continue;
-                    }
-
-                    for (var i = callbacks.Count - 1; i >= 0; i--)
-                    {
-                        try
-                        {
-                            await callbacks[i](messageEvent);
-                        }
-                        catch (Exception e)
-                        {
-                            ReownLogger.LogError(e);
-                        }
-                    }
+                    await callbacks[i](item.messageEvent);
+                }
+                catch (Exception e)
+                {
+                    ReownLogger.LogError(e);
                 }
             }
-            finally
+        }
+
+        private async Task ProcessResponse(DecodedMessageEvent messageEvent)
+        {
+            try
             {
-                _isRequestQueueProcessing = false;
+                RawMessage?.Invoke(this, messageEvent);
+            }
+            catch (Exception e)
+            {
+                ReownLogger.LogError(e);
+            }
+
+            Func<DecodedMessageEvent, Task>[] handlers;
+            lock (_rawResponseHandlersLock)
+            {
+                handlers = _rawResponseHandlers.ToArray();
+            }
+
+            for (var i = handlers.Length - 1; i >= 0; i--)
+            {
+                try
+                {
+                    await handlers[i](messageEvent);
+                }
+                catch (Exception e)
+                {
+                    ReownLogger.LogError(e);
+                }
             }
         }
 

--- a/src/Reown.Core/Runtime/Models/MessageHandler/TypedEventHandler.cs
+++ b/src/Reown.Core/Runtime/Models/MessageHandler/TypedEventHandler.cs
@@ -232,11 +232,51 @@ namespace Reown.Core.Models.MessageHandler
             }
         }
 
+        /// <summary>
+        ///     Dispatches a received response to the <see cref="OnResponse" /> subscribers. Each subscriber is
+        ///     invoked without awaiting its completion so that a subscriber awaiting another round trip cannot
+        ///     block or deadlock the sequential response pump; subscriber exceptions are logged.
+        /// </summary>
+        /// <param name="arg1">The topic the response was received on</param>
+        /// <param name="arg2">The response payload</param>
         protected virtual Task ResponseCallback(string arg1, JsonRpcResponse<TR> arg2)
         {
+            var handlers = _onResponse;
+            if (handlers == null)
+            {
+                return Task.CompletedTask;
+            }
+
             var rea = new ResponseEventArgs<TR>(arg2, arg1);
-            return ResponsePredicate != null && !ResponsePredicate(rea) ? Task.CompletedTask :
-                _onResponse != null ? _onResponse(rea) : Task.CompletedTask;
+            if (ResponsePredicate != null && !ResponsePredicate(rea))
+            {
+                return Task.CompletedTask;
+            }
+
+            foreach (var handler in handlers.GetInvocationList())
+            {
+                _ = InvokeResponseHandler((ResponseMethod<TR>)handler, rea);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        ///     Invokes a single <see cref="OnResponse" /> subscriber detached from the response pump,
+        ///     logging any exception it throws instead of propagating it.
+        /// </summary>
+        /// <param name="handler">The subscriber to invoke</param>
+        /// <param name="args">The response event arguments</param>
+        private static async Task InvokeResponseHandler(ResponseMethod<TR> handler, ResponseEventArgs<TR> args)
+        {
+            try
+            {
+                await handler(args);
+            }
+            catch (Exception e)
+            {
+                ReownLogger.LogError(e);
+            }
         }
 
         protected virtual async Task RequestCallback(string arg1, JsonRpcRequest<T> arg2)
@@ -327,10 +367,7 @@ namespace Reown.Core.Models.MessageHandler
                 }
 
                 DisposeActions.Clear();
-
-                if (Instances.ContainsKey(context))
-                    Instances.Remove(context);
-
+                Instances.Remove(context);
                 Teardown();
             }
 

--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -475,20 +475,28 @@ namespace Reown.Sign
                 if (approvalTask.Task.IsCompleted)
                     return;
 
-                session.Self.PublicKey = publicKey;
-                session.RequiredNamespaces = requiredNamespaces;
-
-                await PrivateThis.SetExpiry(session.Topic, session.Expiry.Value);
-                await Client.Session.Set(session.Topic, session);
-
-                if (!string.IsNullOrWhiteSpace(topic))
+                try
                 {
-                    await Client.CoreClient.Pairing.UpdateMetadata(topic, session.Peer.Metadata);
+                    session.Self.PublicKey = publicKey;
+                    session.RequiredNamespaces = requiredNamespaces;
+
+                    await PrivateThis.SetExpiry(session.Topic, session.Expiry.Value);
+                    await Client.Session.Set(session.Topic, session);
+
+                    if (!string.IsNullOrWhiteSpace(topic))
+                    {
+                        await Client.CoreClient.Pairing.UpdateMetadata(topic, session.Peer.Metadata);
+                    }
+
+                    RemoveConnectionListeners();
+
+                    approvalTask.TrySetResult(session);
                 }
-
-                RemoveConnectionListeners();
-
-                approvalTask.TrySetResult(session);
+                catch (Exception e)
+                {
+                    RemoveConnectionListeners();
+                    approvalTask.TrySetException(e);
+                }
             }
 
             void OnSessionConnectionErrored(object sender, Exception exception)

--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -413,38 +413,59 @@ namespace Reown.Sign
                 SessionProperties = sessionProperties
             };
 
-            var approvalTask = new TaskCompletionSource<Session>();
-
-            SessionConnected += OnSessionConnected;
-            SessionConnectionErrored += OnSessionConnectionErrored;
+            var approvalTask = new TaskCompletionSource<Session>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             if (string.IsNullOrWhiteSpace(topic))
             {
                 throw new InvalidOperationException("The pairing topic is empty");
             }
 
-            var id = await MessageHandler.SendRequest<SessionPropose, SessionProposeResponse>(topic, proposal);
+            CancellationTokenRegistration ctr = default;
 
-            var expiry = Clock.CalculateExpiry(options.Expiry);
+            SessionConnected += OnSessionConnected;
+            SessionConnectionErrored += OnSessionConnectionErrored;
 
-            await PrivateThis.SetProposal(id, new ProposalStruct
+            ctr = ct.Register(() =>
             {
-                Expiry = expiry,
-                Id = id,
-                Proposer = proposal.Proposer,
-                PairingTopic = topic,
-                Relays = proposal.Relays,
-                RequiredNamespaces = proposal.RequiredNamespaces,
-                OptionalNamespaces = proposal.OptionalNamespaces,
-                SessionProperties = proposal.SessionProperties
+                RemoveConnectionListeners();
+                approvalTask.TrySetCanceled(ct);
             });
+
+            try
+            {
+                var id = await MessageHandler.SendRequest<SessionPropose, SessionProposeResponse>(topic, proposal, ct: ct);
+
+                var expiry = Clock.CalculateExpiry(options.Expiry);
+
+                await PrivateThis.SetProposal(id, new ProposalStruct
+                {
+                    Expiry = expiry,
+                    Id = id,
+                    Proposer = proposal.Proposer,
+                    PairingTopic = topic,
+                    Relays = proposal.Relays,
+                    RequiredNamespaces = proposal.RequiredNamespaces,
+                    OptionalNamespaces = proposal.OptionalNamespaces,
+                    SessionProperties = proposal.SessionProperties
+                });
+            }
+            catch
+            {
+                RemoveConnectionListeners();
+                throw;
+            }
 
             return new ConnectedData(uri, topic, approvalTask.Task);
 
+            void RemoveConnectionListeners()
+            {
+                ctr.Dispose();
+                SessionConnected -= OnSessionConnected;
+                SessionConnectionErrored -= OnSessionConnectionErrored;
+            }
+
             async void OnSessionConnected(object sender, Session session)
             {
-                ct.ThrowIfCancellationRequested();
-
                 if (session == null)
                     return;
 
@@ -465,16 +486,13 @@ namespace Reown.Sign
                     await Client.CoreClient.Pairing.UpdateMetadata(topic, session.Peer.Metadata);
                 }
 
-                SessionConnected -= OnSessionConnected;
-                SessionConnectionErrored -= OnSessionConnectionErrored;
+                RemoveConnectionListeners();
 
-                approvalTask.SetResult(session);
+                approvalTask.TrySetResult(session);
             }
 
             void OnSessionConnectionErrored(object sender, Exception exception)
             {
-                ct.ThrowIfCancellationRequested();
-
                 if (approvalTask.Task.IsCompleted)
                 {
                     return;
@@ -485,10 +503,9 @@ namespace Reown.Sign
                     return;
                 }
 
-                SessionConnected -= OnSessionConnected;
-                SessionConnectionErrored -= OnSessionConnectionErrored;
+                RemoveConnectionListeners();
 
-                approvalTask.SetException(exception);
+                approvalTask.TrySetException(exception);
             }
         }
 
@@ -535,9 +552,29 @@ namespace Reown.Sign
             };
 
             await Client.CoreClient.Relayer.Subscribe(sessionTopic);
-            var requestId = await MessageHandler.SendRequest<SessionSettle, bool>(sessionTopic, sessionSettle);
 
-            var acknowledgedTask = new TaskCompletionSource<Session>();
+            long requestId;
+            try
+            {
+                requestId = await MessageHandler.SendRequest<SessionSettle, bool>(sessionTopic, sessionSettle, ct: ct);
+            }
+            catch
+            {
+                try
+                {
+                    await Client.CoreClient.Relayer.Unsubscribe(sessionTopic);
+                    await Client.CoreClient.Crypto.DeleteKeyPair(selfPublicKey);
+                    await Client.CoreClient.Crypto.DeleteSymKey(sessionTopic);
+                }
+                catch (Exception e)
+                {
+                    ReownLogger.LogError(e);
+                }
+
+                throw;
+            }
+
+            var acknowledgedTask = new TaskCompletionSource<Session>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             _sessionEventsHandlerMap.ListenOnce($"session_approve{requestId}", (sender, args) =>
             {
@@ -615,9 +652,9 @@ namespace Reown.Sign
                 new SessionUpdate
                 {
                     Namespaces = namespaces
-                });
+                }, ct: ct);
 
-            var acknowledgedTask = new TaskCompletionSource<bool>();
+            var acknowledgedTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _sessionEventsHandlerMap.ListenOnce($"session_update{id}", (sender, args) =>
             {
                 if (ct.IsCancellationRequested)
@@ -642,9 +679,9 @@ namespace Reown.Sign
             ct.ThrowIfCancellationRequested();
             IsInitialized();
             await PrivateThis.IsValidExtend(topic);
-            var id = await MessageHandler.SendRequest<SessionExtend, bool>(topic, new SessionExtend());
+            var id = await MessageHandler.SendRequest<SessionExtend, bool>(topic, new SessionExtend(), ct: ct);
 
-            var acknowledgedTask = new TaskCompletionSource<bool>();
+            var acknowledgedTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             _sessionEventsHandlerMap.ListenOnce($"session_extend{id}", (sender, args) =>
             {
@@ -685,14 +722,14 @@ namespace Reown.Sign
             var request = new JsonRpcRequest<T>(method, data);
 
             await PrivateThis.IsValidRequest(topic, request, requestChainId);
-            var taskSource = new TaskCompletionSource<TR>();
+            var taskSource = new TaskCompletionSource<TR>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var id = await MessageHandler.SendRequest<SessionRequest<T>, TR>(topic,
                 new SessionRequest<T>
                 {
                     ChainId = requestChainId,
                     Request = request
-                });
+                }, ct: ct);
 
             var responseHandlerInstance = SessionRequestEvents<T, TR>()
                 .FilterResponses(e => e.Topic == topic && e.Response.Id == id);
@@ -776,7 +813,7 @@ namespace Reown.Sign
             if (Client.Session.Keys.Contains(topic))
             {
                 var id = await MessageHandler.SendRequest<SessionPing, bool>(topic, new SessionPing());
-                var done = new TaskCompletionSource<bool>();
+                var done = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 _sessionEventsHandlerMap.ListenOnce($"session_ping{id}", (sender, args) =>
                 {
                     if (args.IsError)
@@ -963,7 +1000,7 @@ namespace Reown.Sign
             long fallbackId = default;
             EventHandler<SessionAuthenticatedEventArgs> sessionAuthHandler = null;
             EventHandler<Session> sessionConnectedHandler = null;
-            var approvalTask = new TaskCompletionSource<Session>();
+            var approvalTask = new TaskCompletionSource<Session>(TaskCreationOptions.RunContinuationsAsynchronously);
             try
             {
                 var ids = await Task.WhenAll(

--- a/src/Reown.Sign/Runtime/Internals/EngineValidator.cs.meta
+++ b/src/Reown.Sign/Runtime/Internals/EngineValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fada1e43cce641be97a7950b9ccd0c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/test/Reown.Core.Network.Test/SequentialMessagePumpTests.cs
+++ b/test/Reown.Core.Network.Test/SequentialMessagePumpTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading.Tasks;
+using Reown.Core.Common.Logging;
+using Reown.Core.Controllers;
+using Xunit;
+
+namespace Reown.Core.Network.Test
+{
+    /// <summary>
+    ///     Tests the failure containment of <see cref="SequentialMessagePump{T}" />: a processor exception must not
+    ///     stop the pump, and a logger that itself throws while reporting that exception must neither fault the
+    ///     producer's <c>Enqueue</c> task nor leave the pump wedged with its processing flag stuck.
+    /// </summary>
+    public class SequentialMessagePumpTests
+    {
+        /// <summary>
+        ///     Ensures that when the item processor throws and the logger throws while reporting it, the exception
+        ///     does not escape to the producer and the pump keeps draining subsequent items.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task ThrowingLogger_DoesNotFaultEnqueueOrWedgePump()
+        {
+            var originalLogger = ReownLogger.Instance;
+            ReownLogger.Instance = new ThrowingLogger();
+
+            try
+            {
+                var secondItemProcessed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var pump = new SequentialMessagePump<int>(item =>
+                {
+                    if (item == 1)
+                    {
+                        throw new InvalidOperationException("processor failure");
+                    }
+
+                    secondItemProcessed.TrySetResult(true);
+                    return Task.CompletedTask;
+                });
+
+                await pump.Enqueue(1);
+                await pump.Enqueue(2);
+
+                var completed = await Task.WhenAny(secondItemProcessed.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+
+                Assert.Same(secondItemProcessed.Task, completed);
+            }
+            finally
+            {
+                ReownLogger.Instance = originalLogger;
+            }
+        }
+
+        private sealed class ThrowingLogger : ILogger
+        {
+            public void Log(string message)
+            {
+                throw new InvalidOperationException("logger failure");
+            }
+
+            public void LogError(string message)
+            {
+                throw new InvalidOperationException("logger failure");
+            }
+
+            public void LogError(Exception e)
+            {
+                throw new InvalidOperationException("logger failure");
+            }
+        }
+    }
+}

--- a/test/Reown.Core.Network.Test/TypedMessageHandlerResponseQueueTests.cs
+++ b/test/Reown.Core.Network.Test/TypedMessageHandlerResponseQueueTests.cs
@@ -1,0 +1,348 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NSubstitute;
+using Reown.Core.Controllers;
+using Reown.Core.Crypto.Interfaces;
+using Reown.Core.Crypto.Models;
+using Reown.Core.Interfaces;
+using Reown.Core.Models.History;
+using Reown.Core.Models.MessageHandler;
+using Reown.Core.Models.Relay;
+using Reown.Core.Network.Models;
+using Xunit;
+
+namespace Reown.Core.Network.Test
+{
+    /// <summary>
+    ///     Tests that inbound responses are routed through the sequential response pump so that the
+    ///     <see cref="TypedMessageHandler.RawMessage" /> event fires once per response, exceptions thrown anywhere in the
+    ///     response path are observed instead of crashing the process, and mid-iteration handler removal does not cause a
+    ///     handler to run twice for the same message.
+    /// </summary>
+    public class TypedMessageHandlerResponseQueueTests
+    {
+        private const string ResponsePayloadJson = "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":true}";
+
+        /// <summary>
+        ///     Ensures a received response raises <see cref="TypedMessageHandler.RawMessage" /> exactly once, that a throwing
+        ///     subscriber is swallowed by the pump, and that the processing guard flag is reset so a subsequent response is
+        ///     still processed.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task ResponseMessage_RaisesRawMessageOnce_AndSurvivesThrowingSubscriber()
+        {
+            var relayer = Substitute.For<IRelayer>();
+            var crypto = Substitute.For<ICrypto>();
+            var coreClient = Substitute.For<ICoreClient>();
+
+            coreClient.Relayer.Returns(relayer);
+            coreClient.Crypto.Returns(crypto);
+
+            var responsePayload = JsonConvert.DeserializeObject<JsonRpcPayload>(ResponsePayloadJson);
+            crypto.Decode<JsonRpcPayload>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DecodeOptions>())
+                .Returns(responsePayload);
+
+            var handler = new TypedMessageHandler(coreClient);
+            await handler.Init();
+
+            var rawMessageCount = 0;
+            handler.RawMessage += (_, _) =>
+            {
+                rawMessageCount++;
+                throw new InvalidOperationException("subscriber failure");
+            };
+
+            RaiseMessageReceived(relayer);
+            Assert.Equal(1, rawMessageCount);
+
+            RaiseMessageReceived(relayer);
+            Assert.Equal(2, rawMessageCount);
+        }
+
+        /// <summary>
+        ///     Ensures an exception thrown by a typed response callback (the location of the original production crash, since
+        ///     the response path was previously <c>async void</c>) is contained by the pump and does not escape the response
+        ///     path.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task ThrowingResponseCallback_IsContainedByPump()
+        {
+            var relayer = Substitute.For<IRelayer>();
+            var crypto = Substitute.For<ICrypto>();
+            var historyFactory = Substitute.For<IJsonRpcHistoryFactory>();
+            var coreClient = Substitute.For<ICoreClient>();
+
+            coreClient.Relayer.Returns(relayer);
+            coreClient.Crypto.Returns(crypto);
+            coreClient.History.Returns(historyFactory);
+
+            var responsePayload = JsonConvert.DeserializeObject<JsonRpcPayload>(ResponsePayloadJson);
+            crypto.Decode<JsonRpcPayload>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DecodeOptions>())
+                .Returns(responsePayload);
+            crypto.Decode<JsonRpcResponse<TestResponse>>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DecodeOptions>())
+                .Returns(new JsonRpcResponse<TestResponse>());
+            crypto.HasKeys(Arg.Any<string>()).Returns(true);
+
+            var method = RpcMethodAttribute.MethodForType<TestRequest>();
+            var history = Substitute.For<IJsonRpcHistory<TestRequest, TestResponse>>();
+            historyFactory.JsonRpcHistoryOfType<TestRequest, TestResponse>().Returns(history);
+            history.Get(Arg.Any<string>(), Arg.Any<long>())
+                .Returns(new JsonRpcRecord<TestRequest, TestResponse>(new JsonRpcRequest<TestRequest>(method, null)));
+            history.Exists(Arg.Any<string>(), Arg.Any<long>()).Returns(true);
+
+            var handler = new TypedMessageHandler(coreClient);
+            await handler.Init();
+
+            var responseCallbackInvoked = false;
+            await handler.HandleMessageType<TestRequest, TestResponse>(
+                (_, _) => Task.CompletedTask,
+                (_, _) =>
+                {
+                    responseCallbackInvoked = true;
+                    throw new InvalidOperationException("response callback failure");
+                });
+
+            RaiseMessageReceived(relayer);
+
+            Assert.True(responseCallbackInvoked);
+        }
+
+        /// <summary>
+        ///     Ensures the pump iterates a snapshot of the raw response handlers so that a handler which removes an earlier
+        ///     handler mid-iteration (e.g. a request unsubscribing from inside its own response callback) does not cause a
+        ///     surviving handler to run twice for the same message.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task RawResponseHandlerRemovedMidIteration_DoesNotDoubleDispatch()
+        {
+            var relayer = Substitute.For<IRelayer>();
+            var crypto = Substitute.For<ICrypto>();
+            var historyFactory = Substitute.For<IJsonRpcHistoryFactory>();
+            var coreClient = Substitute.For<ICoreClient>();
+
+            coreClient.Relayer.Returns(relayer);
+            coreClient.Crypto.Returns(crypto);
+            coreClient.History.Returns(historyFactory);
+
+            var responsePayload = JsonConvert.DeserializeObject<JsonRpcPayload>(ResponsePayloadJson);
+            crypto.Decode<JsonRpcPayload>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DecodeOptions>())
+                .Returns(responsePayload);
+
+            var methodA = RpcMethodAttribute.MethodForType<TestRequestA>();
+            var methodB = RpcMethodAttribute.MethodForType<TestRequestB>();
+
+            var historyA = Substitute.For<IJsonRpcHistory<TestRequestA, TestResponseA>>();
+            var historyB = Substitute.For<IJsonRpcHistory<TestRequestB, TestResponseB>>();
+            historyFactory.JsonRpcHistoryOfType<TestRequestA, TestResponseA>().Returns(historyA);
+            historyFactory.JsonRpcHistoryOfType<TestRequestB, TestResponseB>().Returns(historyB);
+
+            var recordA = new JsonRpcRecord<TestRequestA, TestResponseA>(new JsonRpcRequest<TestRequestA>(methodA, null));
+            var recordB = new JsonRpcRecord<TestRequestB, TestResponseB>(new JsonRpcRequest<TestRequestB>(methodB, null));
+            historyA.Get(Arg.Any<string>(), Arg.Any<long>()).Returns(recordA);
+
+            var handler = new TypedMessageHandler(coreClient);
+            await handler.Init();
+
+            var tokenA = await handler.HandleMessageType<TestRequestA, TestResponseA>(
+                (_, _) => Task.CompletedTask, (_, _) => Task.CompletedTask);
+            await handler.HandleMessageType<TestRequestB, TestResponseB>(
+                (_, _) => Task.CompletedTask, (_, _) => Task.CompletedTask);
+
+            historyB.Get(Arg.Any<string>(), Arg.Any<long>()).Returns(_ =>
+            {
+                tokenA.Dispose();
+                return recordB;
+            });
+
+            RaiseMessageReceived(relayer);
+
+            _ = historyA.Received(1).Get(Arg.Any<string>(), Arg.Any<long>());
+            _ = historyB.Received(1).Get(Arg.Any<string>(), Arg.Any<long>());
+        }
+
+        /// <summary>
+        ///     Ensures the response pump serialises concurrent deliveries: when many responses reach the pump at once,
+        ///     every one is processed exactly once (none dropped or stranded) and the processor never runs for two
+        ///     responses simultaneously. This guards the lock discipline of the shared sequential message pump against
+        ///     both the queue-corruption and the lost-wakeup races.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task ConcurrentResponses_AreEachProcessedOnce_AndNeverOverlap()
+        {
+            var relayer = Substitute.For<IRelayer>();
+            var crypto = Substitute.For<ICrypto>();
+            var coreClient = Substitute.For<ICoreClient>();
+
+            coreClient.Relayer.Returns(relayer);
+            coreClient.Crypto.Returns(crypto);
+
+            var responsePayload = JsonConvert.DeserializeObject<JsonRpcPayload>(ResponsePayloadJson);
+
+            // Park every RelayMessageCallback at the decode await until the gate is released, so releasing it
+            // resumes all continuations at once and they contend on the pump concurrently.
+            var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            crypto.Decode<JsonRpcPayload>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DecodeOptions>())
+                .Returns(_ => WaitForGate(gate, responsePayload));
+
+            var handler = new TypedMessageHandler(coreClient);
+            await handler.Init();
+
+            const int messageCount = 1000;
+            var processed = 0;
+            var inFlight = 0;
+            var concurrentPeak = 0;
+
+            handler.RawMessage += (_, _) =>
+            {
+                var current = Interlocked.Increment(ref inFlight);
+                InterlockedMax(ref concurrentPeak, current);
+                Thread.SpinWait(200);
+                Interlocked.Decrement(ref inFlight);
+                Interlocked.Increment(ref processed);
+            };
+
+            for (var i = 0; i < messageCount; i++)
+            {
+                RaiseMessageReceived(relayer);
+            }
+
+            gate.SetResult(true);
+
+            var stopwatch = Stopwatch.StartNew();
+            while (Volatile.Read(ref processed) < messageCount && stopwatch.Elapsed < TimeSpan.FromSeconds(30))
+            {
+                await Task.Delay(10);
+            }
+
+            Assert.Equal(messageCount, Volatile.Read(ref processed));
+            Assert.Equal(1, Volatile.Read(ref concurrentPeak));
+        }
+
+        /// <summary>
+        ///     Ensures an <see cref="TypedEventHandler{T,TR}.OnResponse" /> subscriber that awaits a later response of the
+        ///     same client cannot deadlock the sequential response pump: subscribers are dispatched detached from the pump,
+        ///     so the later response is still delivered and unblocks the first subscriber.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task ResponseHandlerAwaitingLaterResponse_DoesNotDeadlockPump()
+        {
+            var relayer = Substitute.For<IRelayer>();
+            var crypto = Substitute.For<ICrypto>();
+            var historyFactory = Substitute.For<IJsonRpcHistoryFactory>();
+            var coreClient = Substitute.For<ICoreClient>();
+
+            coreClient.Relayer.Returns(relayer);
+            coreClient.Crypto.Returns(crypto);
+            coreClient.History.Returns(historyFactory);
+            coreClient.Context.Returns($"typed-event-handler-test-{Guid.NewGuid()}");
+
+            var responsePayload = JsonConvert.DeserializeObject<JsonRpcPayload>(ResponsePayloadJson);
+            crypto.Decode<JsonRpcPayload>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DecodeOptions>())
+                .Returns(responsePayload);
+            crypto.Decode<JsonRpcResponse<TestResponse>>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DecodeOptions>())
+                .Returns(new JsonRpcResponse<TestResponse>());
+            crypto.HasKeys(Arg.Any<string>()).Returns(true);
+
+            var method = RpcMethodAttribute.MethodForType<TestRequest>();
+            var history = Substitute.For<IJsonRpcHistory<TestRequest, TestResponse>>();
+            historyFactory.JsonRpcHistoryOfType<TestRequest, TestResponse>().Returns(history);
+            history.Get(Arg.Any<string>(), Arg.Any<long>())
+                .Returns(new JsonRpcRecord<TestRequest, TestResponse>(new JsonRpcRequest<TestRequest>(method, null)));
+            history.Exists(Arg.Any<string>(), Arg.Any<long>()).Returns(true);
+
+            var messageHandler = new TypedMessageHandler(coreClient);
+            await messageHandler.Init();
+            coreClient.MessageHandler.Returns(messageHandler);
+
+            var typedHandler = TypedEventHandler<TestRequest, TestResponse>.GetInstance(coreClient);
+
+            var laterResponseReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var firstHandlerCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var invocationCount = 0;
+
+            typedHandler.OnResponse += async _ =>
+            {
+                if (Interlocked.Increment(ref invocationCount) == 1)
+                {
+                    await laterResponseReceived.Task;
+                    firstHandlerCompleted.TrySetResult(true);
+                }
+                else
+                {
+                    laterResponseReceived.TrySetResult(true);
+                }
+            };
+
+            RaiseMessageReceived(relayer);
+            RaiseMessageReceived(relayer);
+
+            var completed = await Task.WhenAny(firstHandlerCompleted.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+
+            Assert.Same(firstHandlerCompleted.Task, completed);
+        }
+
+        private static async Task<JsonRpcPayload> WaitForGate(TaskCompletionSource<bool> gate, JsonRpcPayload payload)
+        {
+            await gate.Task;
+            return payload;
+        }
+
+        private static void InterlockedMax(ref int target, int value)
+        {
+            int current;
+            do
+            {
+                current = Volatile.Read(ref target);
+                if (value <= current)
+                {
+                    return;
+                }
+            }
+            while (Interlocked.CompareExchange(ref target, value, current) != current);
+        }
+
+        private static void RaiseMessageReceived(IRelayer relayer)
+        {
+            relayer.OnMessageReceived += Raise.Event<EventHandler<MessageEvent>>(relayer, new MessageEvent
+            {
+                Topic = "topic",
+                Message = "encoded"
+            });
+        }
+
+        [RpcMethod("test_method")]
+        public class TestRequest
+        {
+        }
+
+        public class TestResponse
+        {
+        }
+
+        [RpcMethod("test_method_a")]
+        public class TestRequestA
+        {
+        }
+
+        public class TestResponseA
+        {
+        }
+
+        [RpcMethod("test_method_b")]
+        public class TestRequestB
+        {
+        }
+
+        public class TestResponseB
+        {
+        }
+    }
+}

--- a/test/Reown.Core.Network.Test/TypedMessageHandlerResponseQueueTests.cs
+++ b/test/Reown.Core.Network.Test/TypedMessageHandlerResponseQueueTests.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NSubstitute;
+using Reown.Core.Common.Logging;
 using Reown.Core.Controllers;
 using Reown.Core.Crypto.Interfaces;
 using Reown.Core.Crypto.Models;
@@ -289,6 +291,60 @@ namespace Reown.Core.Network.Test
             Assert.Same(firstHandlerCompleted.Task, completed);
         }
 
+        /// <summary>
+        ///     Ensures a message that fails to decode (e.g. the topic's sym key was deleted between delivery and
+        ///     decode) is logged instead of escaping the <c>async void</c> relay callback and crashing the process,
+        ///     and that later messages are still processed.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task DecodeFailure_IsLoggedInsteadOfEscapingRelayCallback_AndLaterMessagesStillProcess()
+        {
+            var relayer = Substitute.For<IRelayer>();
+            var crypto = Substitute.For<ICrypto>();
+            var coreClient = Substitute.For<ICoreClient>();
+
+            coreClient.Relayer.Returns(relayer);
+            coreClient.Crypto.Returns(crypto);
+
+            var responsePayload = JsonConvert.DeserializeObject<JsonRpcPayload>(ResponsePayloadJson);
+            var decodeFailure = new InvalidOperationException("decode failure");
+            var decodeCalls = 0;
+            crypto.Decode<JsonRpcPayload>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DecodeOptions>())
+                .Returns(_ =>
+                {
+                    if (Interlocked.Increment(ref decodeCalls) == 1)
+                    {
+                        throw decodeFailure;
+                    }
+
+                    return responsePayload;
+                });
+
+            var handler = new TypedMessageHandler(coreClient);
+            await handler.Init();
+
+            var rawMessageCount = 0;
+            handler.RawMessage += (_, _) => rawMessageCount++;
+
+            var originalLogger = ReownLogger.Instance;
+            var recordingLogger = new RecordingLogger();
+            ReownLogger.Instance = recordingLogger;
+
+            try
+            {
+                RaiseMessageReceived(relayer);
+                RaiseMessageReceived(relayer);
+            }
+            finally
+            {
+                ReownLogger.Instance = originalLogger;
+            }
+
+            Assert.Contains(decodeFailure, recordingLogger.Exceptions);
+            Assert.Equal(1, rawMessageCount);
+        }
+
         private static async Task<JsonRpcPayload> WaitForGate(TaskCompletionSource<bool> gate, JsonRpcPayload payload)
         {
             await gate.Task;
@@ -316,6 +372,24 @@ namespace Reown.Core.Network.Test
                 Topic = "topic",
                 Message = "encoded"
             });
+        }
+
+        private sealed class RecordingLogger : ILogger
+        {
+            public List<Exception> Exceptions { get; } = new();
+
+            public void Log(string message)
+            {
+            }
+
+            public void LogError(string message)
+            {
+            }
+
+            public void LogError(Exception e)
+            {
+                Exceptions.Add(e);
+            }
         }
 
         [RpcMethod("test_method")]


### PR DESCRIPTION
## Summary

Inbound relay messages were dispatched from `async void` callbacks: unsynchronized queue state allowed concurrent relay callbacks to corrupt the response queue or run handlers concurrently (the keychain TOCTOU race that crashed the test host), and any handler exception escaped the `async void` chain and killed the process.

- **`SequentialMessagePump<T>`** (new): a lock-guarded, single-consumer FIFO pump shared by the request and response paths. Enqueue and the drain lifecycle are synchronized, so producers can neither corrupt the queue, run the processor concurrently, nor strand an item during wind-down. Handler exceptions are logged and contained.
- **`TypedMessageHandler`**: responses now flow through the pump as awaited `Task`s instead of `async void`; the raw response handler list is lock-guarded and snapshotted, so mid-iteration unsubscription no longer double-dispatches.
- **`TypedEventHandler`**: `OnResponse` subscribers are dispatched detached from the pump (each invoked independently with fault logging). A subscriber awaiting another round trip on the same client can no longer deadlock response processing; SDK-internal handlers registered via `HandleMessageType` stay fully serialized on purpose (documented in XML remarks).
- **`Engine`/`Pairing`**: `TaskCompletionSource`s completed from pump-dispatched handlers use `RunContinuationsAsynchronously`, so caller continuations never run inline on the pump thread. `CancellationToken` is propagated into session request sending; `ConnectAsync` now unsubscribes its event handlers on failure/cancellation (previously a cancelled token detonated an unhandled exception inside a leaked `async void` handler), and `ApproveAsync` rolls back the relay subscription and keychain entries when the settle send aborts.

## Testing

- New unit tests cover: exactly-once `RawMessage` dispatch with a throwing subscriber, exception containment in typed response callbacks, mid-iteration handler removal, 1000-message concurrent serialization (exactly-once, never-overlapping), and the `OnResponse` nested-round-trip deadlock (verified to fail when the fix is reverted).
- All unit tests pass on net8.0/net9.0/net10.0.
- Integration tests (live relay, full session lifecycle) pass on all three frameworks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)