### PR TITLE
fix(core): restore relay subscriptions after an interrupted transport restart

### DIFF
--- a/src/Reown.Core.Common/Runtime/Utils/Extensions.cs
+++ b/src/Reown.Core.Common/Runtime/Utils/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Net;
 
@@ -68,12 +69,30 @@ namespace Reown.Core.Common.Utils
         ///     an <see cref="AggregateException" /> — either way callers could neither see the failure
         ///     nor match on its message, and a task that failed instantly looked like success.
         /// </remarks>
+        /// <summary>
+        ///     Takes the exception off a task nobody is waiting for any more.
+        /// </summary>
+        /// <remarks>
+        ///     A timed-out task keeps running and may still fail. Nothing observes it by then, so its
+        ///     exception resurfaces on the finalizer thread as an UnobservedTaskException — noise at
+        ///     best, and a process kill wherever that event is left unhandled.
+        /// </remarks>
+        private static void ObserveAbandoned(Task task)
+        {
+            _ = task.ContinueWith(
+                static abandoned => _ = abandoned.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+
         public static async Task<T> WithTimeout<T>(this Task<T> task, int timeout = 1000,
             string message = "Timeout of %t exceeded")
         {
             var resultT = await Task.WhenAny(task, Task.Delay(timeout));
             if (resultT != task)
             {
+                ObserveAbandoned(task);
                 throw new TimeoutException(message.Replace("%t", timeout.ToString()));
             }
 
@@ -93,6 +112,7 @@ namespace Reown.Core.Common.Utils
             var resultT = await Task.WhenAny(task, Task.Delay(timeout));
             if (resultT != task)
             {
+                ObserveAbandoned(task);
                 throw new TimeoutException(message.Replace("%t", timeout.ToString()));
             }
 
@@ -112,6 +132,7 @@ namespace Reown.Core.Common.Utils
             var resultT = await Task.WhenAny(task, Task.Delay(timeout));
             if (resultT != task)
             {
+                ObserveAbandoned(task);
                 throw new TimeoutException(message.Replace("%t", timeout.ToString()));
             }
 
@@ -131,6 +152,7 @@ namespace Reown.Core.Common.Utils
             var resultT = await Task.WhenAny(task, Task.Delay(timeout));
             if (resultT != task)
             {
+                ObserveAbandoned(task);
                 throw new TimeoutException(message.Replace("%t", timeout.ToString()));
             }
 

--- a/src/Reown.Core.Common/Runtime/Utils/Extensions.cs
+++ b/src/Reown.Core.Common/Runtime/Utils/Extensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Net;
@@ -61,6 +61,13 @@ namespace Reown.Core.Common.Utils
                    + "=" + WebUtility.UrlEncode(value);
         }
 
+        /// <remarks>
+        ///     The task is awaited once <see cref="Task.WhenAny(Task[])" /> picks it, so a fault
+        ///     surfaces as the original exception. Returning without awaiting dropped it silently on
+        ///     the non-generic overloads, and reading <c>.Result</c> on the generic ones wrapped it in
+        ///     an <see cref="AggregateException" /> — either way callers could neither see the failure
+        ///     nor match on its message, and a task that failed instantly looked like success.
+        /// </remarks>
         public static async Task<T> WithTimeout<T>(this Task<T> task, int timeout = 1000,
             string message = "Timeout of %t exceeded")
         {
@@ -70,9 +77,16 @@ namespace Reown.Core.Common.Utils
                 throw new TimeoutException(message.Replace("%t", timeout.ToString()));
             }
 
-            return ((Task<T>)resultT).Result;
+            return await task;
         }
 
+        /// <remarks>
+        ///     The task is awaited once <see cref="Task.WhenAny(Task[])" /> picks it, so a fault
+        ///     surfaces as the original exception. Returning without awaiting dropped it silently on
+        ///     the non-generic overloads, and reading <c>.Result</c> on the generic ones wrapped it in
+        ///     an <see cref="AggregateException" /> — either way callers could neither see the failure
+        ///     nor match on its message, and a task that failed instantly looked like success.
+        /// </remarks>
         public static async Task WithTimeout(this Task task, int timeout = 1000,
             string message = "Timeout of %t exceeded")
         {
@@ -81,8 +95,17 @@ namespace Reown.Core.Common.Utils
             {
                 throw new TimeoutException(message.Replace("%t", timeout.ToString()));
             }
+
+            await task;
         }
 
+        /// <remarks>
+        ///     The task is awaited once <see cref="Task.WhenAny(Task[])" /> picks it, so a fault
+        ///     surfaces as the original exception. Returning without awaiting dropped it silently on
+        ///     the non-generic overloads, and reading <c>.Result</c> on the generic ones wrapped it in
+        ///     an <see cref="AggregateException" /> — either way callers could neither see the failure
+        ///     nor match on its message, and a task that failed instantly looked like success.
+        /// </remarks>
         public static async Task<T> WithTimeout<T>(this Task<T> task, TimeSpan timeout,
             string message = "Timeout of %t exceeded")
         {
@@ -92,9 +115,16 @@ namespace Reown.Core.Common.Utils
                 throw new TimeoutException(message.Replace("%t", timeout.ToString()));
             }
 
-            return ((Task<T>)resultT).Result;
+            return await task;
         }
 
+        /// <remarks>
+        ///     The task is awaited once <see cref="Task.WhenAny(Task[])" /> picks it, so a fault
+        ///     surfaces as the original exception. Returning without awaiting dropped it silently on
+        ///     the non-generic overloads, and reading <c>.Result</c> on the generic ones wrapped it in
+        ///     an <see cref="AggregateException" /> — either way callers could neither see the failure
+        ///     nor match on its message, and a task that failed instantly looked like success.
+        /// </remarks>
         public static async Task WithTimeout(this Task task, TimeSpan timeout,
             string message = "Timeout of %t exceeded")
         {
@@ -103,6 +133,8 @@ namespace Reown.Core.Common.Utils
             {
                 throw new TimeoutException(message.Replace("%t", timeout.ToString()));
             }
+
+            await task;
         }
 
         public static bool SetEquals<T>(this IEnumerable<T> first, IEnumerable<T> second,

--- a/src/Reown.Core.Common/Runtime/Utils/Extensions.cs
+++ b/src/Reown.Core.Common/Runtime/Utils/Extensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -62,21 +62,6 @@ namespace Reown.Core.Common.Utils
                    + "=" + WebUtility.UrlEncode(value);
         }
 
-        /// <remarks>
-        ///     The task is awaited once <see cref="Task.WhenAny(Task[])" /> picks it, so a fault
-        ///     surfaces as the original exception. Returning without awaiting dropped it silently on
-        ///     the non-generic overloads, and reading <c>.Result</c> on the generic ones wrapped it in
-        ///     an <see cref="AggregateException" /> — either way callers could neither see the failure
-        ///     nor match on its message, and a task that failed instantly looked like success.
-        /// </remarks>
-        /// <summary>
-        ///     Takes the exception off a task nobody is waiting for any more.
-        /// </summary>
-        /// <remarks>
-        ///     A timed-out task keeps running and may still fail. Nothing observes it by then, so its
-        ///     exception resurfaces on the finalizer thread as an UnobservedTaskException — noise at
-        ///     best, and a process kill wherever that event is left unhandled.
-        /// </remarks>
         /// <summary>
         ///     Retrieves a task's exception so a failure nobody awaits cannot resurface later.
         /// </summary>
@@ -91,6 +76,14 @@ namespace Reown.Core.Common.Utils
             ObserveAbandoned(task);
         }
 
+        /// <summary>
+        ///     Takes the exception off a task nobody is waiting for any more.
+        /// </summary>
+        /// <remarks>
+        ///     A timed-out task keeps running and may still fail. Nothing observes it by then, so its
+        ///     exception resurfaces on the finalizer thread as an UnobservedTaskException — noise at
+        ///     best, and a process kill wherever that event is left unhandled.
+        /// </remarks>
         private static void ObserveAbandoned(Task task)
         {
             _ = task.ContinueWith(
@@ -100,6 +93,13 @@ namespace Reown.Core.Common.Utils
                 TaskScheduler.Default);
         }
 
+        /// <remarks>
+        ///     The task is awaited once <see cref="Task.WhenAny(Task[])" /> picks it, so a fault
+        ///     surfaces as the original exception. Returning without awaiting dropped it silently on
+        ///     the non-generic overloads, and reading <c>.Result</c> on the generic ones wrapped it in
+        ///     an <see cref="AggregateException" /> — either way callers could neither see the failure
+        ///     nor match on its message, and a task that failed instantly looked like success.
+        /// </remarks>
         public static async Task<T> WithTimeout<T>(this Task<T> task, int timeout = 1000,
             string message = "Timeout of %t exceeded")
         {

--- a/src/Reown.Core.Common/Runtime/Utils/Extensions.cs
+++ b/src/Reown.Core.Common/Runtime/Utils/Extensions.cs
@@ -77,6 +77,20 @@ namespace Reown.Core.Common.Utils
         ///     exception resurfaces on the finalizer thread as an UnobservedTaskException — noise at
         ///     best, and a process kill wherever that event is left unhandled.
         /// </remarks>
+        /// <summary>
+        ///     Retrieves a task's exception so a failure nobody awaits cannot resurface later.
+        /// </summary>
+        /// <remarks>
+        ///     For the fan-out case: when a failure is both stored in a <see cref="TaskCompletionSource{T}" />
+        ///     for concurrent callers and thrown to the one that started the work, the stored copy is
+        ///     left unobserved whenever there are no concurrent callers. Observing does not swallow it —
+        ///     awaiting the task afterwards still throws.
+        /// </remarks>
+        public static void ObserveFault(this Task task)
+        {
+            ObserveAbandoned(task);
+        }
+
         private static void ObserveAbandoned(Task task)
         {
             _ = task.ContinueWith(

--- a/src/Reown.Core.Network.WebSocket/Internal/ClientWebSocketTransport.cs
+++ b/src/Reown.Core.Network.WebSocket/Internal/ClientWebSocketTransport.cs
@@ -27,7 +27,15 @@ namespace Reown.Core.Network.Websocket.Internal
 
         private readonly CancellationTokenSource _cts = new();
         private readonly object _gate = new();
+        /// <summary>
+        ///     How long a PONG may be outstanding before the connection is treated as dead. Without
+        ///     it the keep-alive PINGs are advisory only and a silently severed link stays
+        ///     <see cref="WebSocketState.Open" /> indefinitely.
+        /// </summary>
+        private static readonly TimeSpan DefaultKeepAliveTimeout = TimeSpan.FromSeconds(15);
+
         private readonly TimeSpan _keepAlive;
+        private readonly TimeSpan _keepAliveTimeout;
         private readonly ILogger _logger;
         private readonly TimeSpan _openTimeout;
 
@@ -51,11 +59,13 @@ namespace Reown.Core.Network.Websocket.Internal
         private volatile bool _serverInitiatedClose;
         private volatile bool _shutdownRequested;
 
-        public ClientWebSocketTransport(Uri uri, TimeSpan openTimeout, TimeSpan keepAlive, ILogger logger = null)
+        public ClientWebSocketTransport(Uri uri, TimeSpan openTimeout, TimeSpan keepAlive, ILogger logger = null,
+            TimeSpan? keepAliveTimeout = null)
         {
             _uri = uri ?? throw new ArgumentNullException(nameof(uri));
             _openTimeout = openTimeout;
             _keepAlive = keepAlive;
+            _keepAliveTimeout = keepAliveTimeout ?? DefaultKeepAliveTimeout;
             _logger = logger;
         }
 
@@ -200,6 +210,18 @@ namespace Reown.Core.Network.Websocket.Internal
 
             var client = new ClientWebSocket();
             client.Options.KeepAliveInterval = _keepAlive;
+
+// ClientWebSocketOptions.KeepAliveTimeout exists from .NET 9 on; earlier targets have no way to
+// require a PONG and stay exposed to the silent break described below.
+#if NET9_0_OR_GREATER
+            // Without this the PING frames sent on KeepAliveInterval never require a PONG:
+            // ClientWebSocketOptions.KeepAliveTimeout defaults to Timeout.InfiniteTimeSpan. A link
+            // that dies silently — no FIN, no RST, as when a phone sleeps or a network vanishes —
+            // then stays WebSocketState.Open forever: ReceiveAsync keeps waiting, Closed never
+            // fires, and the reconnect path is never entered. The client believes it is connected
+            // while the relay stopped reaching it long ago.
+            client.Options.KeepAliveTimeout = _keepAliveTimeout;
+#endif
 
             using (var connectCts = CancellationTokenSource.CreateLinkedTokenSource(externalToken, _cts.Token))
             {

--- a/src/Reown.Core.Network.WebSocket/WebsocketConnection.cs
+++ b/src/Reown.Core.Network.WebSocket/WebsocketConnection.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Reown.Core.Common;
 using Reown.Core.Common.Logging;
+using Reown.Core.Common.Utils;
 using Reown.Core.Network.Models;
 using Reown.Core.Network.Websocket.Internal;
 
@@ -382,6 +383,7 @@ namespace Reown.Core.Network.Websocket
                 {
                     var disposedException = new ObjectDisposedException(nameof(WebsocketConnection));
                     tcs.TrySetException(disposedException);
+                    tcs.Task.ObserveFault();
                     throw disposedException;
                 }
 
@@ -389,6 +391,7 @@ namespace Reown.Core.Network.Websocket
                 RegisterErrored?.Invoke(this, mapped);
                 Closed?.Invoke(this, EventArgs.Empty);
                 tcs.TrySetException(mapped);
+                tcs.Task.ObserveFault();
 
                 if (!ReferenceEquals(mapped, e))
                     throw mapped;
@@ -426,6 +429,7 @@ namespace Reown.Core.Network.Websocket
                     ? new ObjectDisposedException(nameof(WebsocketConnection))
                     : new IOException("WebSocket connection closed before registration completed.");
                 tcs.TrySetException(abortException);
+                tcs.Task.ObserveFault();
                 throw abortException;
             }
 
@@ -551,6 +555,7 @@ namespace Reown.Core.Network.Websocket
                 }
 
                 pendingRegister?.TrySetException(new ObjectDisposedException(nameof(WebsocketConnection)));
+                pendingRegister?.Task.ObserveFault();
 
                 return;
             }

--- a/src/Reown.Core.Network.WebSocket/WebsocketConnection.cs
+++ b/src/Reown.Core.Network.WebSocket/WebsocketConnection.cs
@@ -20,6 +20,12 @@ namespace Reown.Core.Network.Websocket
     {
         private static readonly TimeSpan DefaultKeepAliveInterval = TimeSpan.FromSeconds(30);
 
+        /// <summary>
+        ///     Preserves the value this connection used before <see cref="OpenTimeout" /> became
+        ///     settable, so callers that do not set it keep the previous behaviour.
+        /// </summary>
+        public static readonly TimeSpan DefaultOpenTimeout = TimeSpan.FromSeconds(60);
+
         private readonly string _context;
         private readonly ILogger _logger;
         private readonly object _registerGate = new object();
@@ -54,12 +60,20 @@ namespace Reown.Core.Network.Websocket
         public bool IsPaused { get; internal set; }
 
         /// <summary>
-        ///     The Open timeout
+        ///     How long a single connect attempt may run before the socket gives up.
         /// </summary>
-        public TimeSpan OpenTimeout
-        {
-            get => TimeSpan.FromSeconds(60);
-        }
+        /// <remarks>
+        ///     This is what actually paces reconnection, so it is settable rather than fixed. A
+        ///     relayer that abandons its connect on its own <c>ConnectionTimeout</c> does not cancel
+        ///     the attempt underneath: the socket keeps trying until this timeout,
+        ///     <see cref="Connecting" /> stays true for that whole stretch, and
+        ///     <c>RestartTransport</c> refuses to start a new attempt while it does. Measured on the
+        ///     relay lab — with the former hardcoded 60 s, a 10 s relayer timeout still produced
+        ///     attempts exactly 60 s apart, and connectivity restored just after an attempt began
+        ///     went unnoticed for the rest of that minute. Keep it at or below the relayer's
+        ///     <c>ConnectionTimeout</c>.
+        /// </remarks>
+        public TimeSpan OpenTimeout { get; set; } = DefaultOpenTimeout;
 
         public event EventHandler<string> PayloadReceived;
         public event EventHandler Closed;

--- a/src/Reown.Core.Network.WebSocket/WebsocketConnection.cs
+++ b/src/Reown.Core.Network.WebSocket/WebsocketConnection.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Net.Sockets;
 using System.Net.WebSockets;
@@ -63,17 +63,23 @@ namespace Reown.Core.Network.Websocket
         ///     How long a single connect attempt may run before the socket gives up.
         /// </summary>
         /// <remarks>
-        ///     This is what actually paces reconnection, so it is settable rather than fixed. A
-        ///     relayer that abandons its connect on its own <c>ConnectionTimeout</c> does not cancel
-        ///     the attempt underneath: the socket keeps trying until this timeout,
-        ///     <see cref="Connecting" /> stays true for that whole stretch, and
-        ///     <c>RestartTransport</c> refuses to start a new attempt while it does. Measured on the
-        ///     relay lab — with the former hardcoded 60 s, a 10 s relayer timeout still produced
-        ///     attempts exactly 60 s apart, and connectivity restored just after an attempt began
-        ///     went unnoticed for the rest of that minute. Keep it at or below the relayer's
-        ///     <c>ConnectionTimeout</c>.
+        ///     Keep at or below the relayer's <c>ConnectionTimeout</c>: it stops waiting there but
+        ///     does not cancel this attempt, and <see cref="Connecting" /> stays true until this
+        ///     timeout expires, blocking restarts for the difference.
         /// </remarks>
         public TimeSpan OpenTimeout { get; set; } = DefaultOpenTimeout;
+
+        /// <summary>
+        ///     How long a PONG may be outstanding before the socket is treated as dead, or
+        ///     <see langword="null" /> to keep the transport default.
+        /// </summary>
+        /// <remarks>
+        ///     Requiring a PONG is what stops a silently severed link from staying
+        ///     <see cref="WebSocketState.Open" /> forever. It assumes something answers the PINGs:
+        ///     the relay does, but an intermediary that swallows them would abort healthy idle
+        ///     connections, so the requirement is settable rather than fixed.
+        /// </remarks>
+        public TimeSpan? KeepAliveTimeout { get; set; }
 
         public event EventHandler<string> PayloadReceived;
         public event EventHandler Closed;
@@ -336,7 +342,7 @@ namespace Reown.Core.Network.Websocket
 
         private async Task<ClientWebSocketTransport> RegisterCore(string url, TaskCompletionSource<ClientWebSocketTransport> tcs)
         {
-            var transport = new ClientWebSocketTransport(new Uri(url), OpenTimeout, DefaultKeepAliveInterval, _logger);
+            var transport = new ClientWebSocketTransport(new Uri(url), OpenTimeout, DefaultKeepAliveInterval, _logger, KeepAliveTimeout);
 
             lock (_registerGate)
             {

--- a/src/Reown.Core.Network.WebSocket/WebsocketConnection.cs
+++ b/src/Reown.Core.Network.WebSocket/WebsocketConnection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net.Sockets;
 using System.Net.WebSockets;

--- a/src/Reown.Core.Network.WebSocket/WebsocketConnectionBuilder.cs
+++ b/src/Reown.Core.Network.WebSocket/WebsocketConnectionBuilder.cs
@@ -13,11 +13,15 @@ namespace Reown.Core.Network.Websocket
         /// </summary>
         public TimeSpan OpenTimeout { get; set; } = WebsocketConnection.DefaultOpenTimeout;
 
+        /// <inheritdoc cref="WebsocketConnection.KeepAliveTimeout" />
+        public TimeSpan? KeepAliveTimeout { get; set; }
+
         public Task<IJsonRpcConnection> CreateConnection(string url, string context = null)
         {
             WebsocketConnection connection = new WebsocketConnection(url, context)
             {
-                OpenTimeout = OpenTimeout
+                OpenTimeout = OpenTimeout,
+                KeepAliveTimeout = KeepAliveTimeout
             };
 
             return Task.FromResult<IJsonRpcConnection>(connection);

--- a/src/Reown.Core.Network.WebSocket/WebsocketConnectionBuilder.cs
+++ b/src/Reown.Core.Network.WebSocket/WebsocketConnectionBuilder.cs
@@ -1,13 +1,26 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Reown.Core.Network.Interfaces;
 
 namespace Reown.Core.Network.Websocket
 {
     public class WebsocketConnectionBuilder : IConnectionBuilder
     {
+        /// <summary>
+        ///     Applied to every connection this builder creates. See
+        ///     <see cref="WebsocketConnection.OpenTimeout" /> for why it is worth setting: it, not the
+        ///     relayer's own timeout, is what paces reconnection attempts.
+        /// </summary>
+        public TimeSpan OpenTimeout { get; set; } = WebsocketConnection.DefaultOpenTimeout;
+
         public Task<IJsonRpcConnection> CreateConnection(string url, string context = null)
         {
-            return Task.FromResult<IJsonRpcConnection>(new WebsocketConnection(url, context));
+            WebsocketConnection connection = new WebsocketConnection(url, context)
+            {
+                OpenTimeout = OpenTimeout
+            };
+
+            return Task.FromResult<IJsonRpcConnection>(connection);
         }
     }
 }

--- a/src/Reown.Core.Network/Runtime/JsonRpcProvider.cs
+++ b/src/Reown.Core.Network/Runtime/JsonRpcProvider.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using Reown.Core.Common.Utils;
 using Newtonsoft.Json;
 using Reown.Core.Common.Events;
 using Reown.Core.Common.Logging;
@@ -127,6 +128,9 @@ namespace Reown.Core.Network
                 }
 
                 _connecting.SetException(e);
+
+                // Open() may throw before the await below is reached, leaving this copy unobserved.
+                _connecting.Task.ObserveFault();
             }
 
             connection.Opened += OnConnectionOnOpened;

--- a/src/Reown.Core.Network/Runtime/JsonRpcProvider.cs
+++ b/src/Reown.Core.Network/Runtime/JsonRpcProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Reown.Core.Common.Utils;

--- a/src/Reown.Core/Runtime/Controllers/Relayer.cs
+++ b/src/Reown.Core/Runtime/Controllers/Relayer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Net.WebSockets;
 using System.Threading;
@@ -92,6 +92,18 @@ namespace Reown.Core.Controllers
         private int _restarting;
 
         private int _reconnectLoop;
+
+        /// <summary>
+        ///     Whether the subscriptions have been replayed onto the transport that is up now.
+        ///     Cleared wherever <see cref="OnDisconnected" /> is raised, set by the replay itself.
+        ///     See <see cref="ConnectedAndReplayed" />.
+        /// </summary>
+        /// <remarks>
+        ///     Starts true: before the first disconnect the subscriptions are whatever
+        ///     <c>Init</c> established, and demanding a replay that has already happened would have
+        ///     the reconnect loop restart a healthy transport on its first pass.
+        /// </remarks>
+        private volatile bool _subscriptionsReplayed = true;
 
         /// <summary>
         ///     Counts how many reconnect loops have actually started, latch included.
@@ -284,20 +296,50 @@ namespace Reown.Core.Controllers
 
             var task1 = new TaskCompletionSource<string>();
 
-            EventUtils.ListenOnce<ActiveSubscription>(
-                (sender, subscription) =>
-                {
-                    if (subscription.Topic == topic)
-                        task1.TrySetResult("");
-                },
-                h => Subscriber.Created += h,
-                h => Subscriber.Created -= h
-            );
+            // Deliberately not ListenOnce: it detaches on the first Created of ANY topic, before the
+            // filter below has looked at it, so a Created for a neighbouring topic — the heartbeat
+            // sweep, or a session topic subscribed alongside a pairing one — would take this
+            // listener away and the Created for `topic` would then arrive with nobody waiting.
+            // Task.WhenAll would wait on task1 forever, and the callers in Engine have no timeout.
+            EventHandler<ActiveSubscription> onCreated = null;
+            onCreated = (_, subscription) =>
+            {
+                if (subscription.Topic == topic)
+                    task1.TrySetResult("");
+            };
+            Subscriber.Created += onCreated;
 
-            return (await Task.WhenAll(
-                task1.Task,
-                Subscriber.Subscribe(topic, opts)
-            ))[1];
+            var subscribeTask = Subscriber.Subscribe(topic, opts);
+
+            // Released when the subscribe fails, because Created is then never raised and
+            // Task.WhenAll only completes once every task has. Without this the caller waits — with
+            // no timeout of its own at Engine.cs:585, 1224 and 1526 — until the heartbeat sweep
+            // re-subscribes the topic and raises Created, and is then handed the failure from the
+            // attempt before it: an error for a subscription that by that point exists.
+            //
+            // The result put here is discarded; WhenAll takes the id from the subscribe task, and a
+            // faulted one surfaces its exception through WhenAll as it did before.
+            _ = subscribeTask.ContinueWith(
+                static (_, state) => ((TaskCompletionSource<string>)state).TrySetResult(string.Empty),
+                task1,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            try
+            {
+                return (await Task.WhenAll(
+                    task1.Task,
+                    subscribeTask
+                ))[1];
+            }
+            finally
+            {
+                // The handler stays attached until here on every path: it is not self-detaching, and
+                // on the failure path Created never fires at all — so without this every subscribe
+                // would leave one more handler on the event for the life of the process.
+                Subscriber.Created -= onCreated;
+            }
         }
 
         /// <summary>
@@ -422,6 +464,12 @@ namespace Reown.Core.Controllers
 
         private async Task TransportOpenCore(string relayUrl)
         {
+            // Taken before any of the early returns below. A caller passing a URL is telling this
+            // relayer where to connect from now on, and that outlives the question of whether an
+            // open is needed right now: dropped here, the URL was silently ignored whenever the
+            // socket happened to be up, and the next reconnect went back to the old one.
+            _relayUrl = relayUrl ?? _relayUrl;
+
             // Read here rather than at the caller: a restart passes its own check long before it
             // reaches this point, and a close arriving in between has to win.
             if (TransportExplicitlyClosed)
@@ -449,7 +497,6 @@ namespace Reown.Core.Controllers
                 return;
             }
 
-            _relayUrl = relayUrl ?? _relayUrl;
             _reconnecting = true;
 
             // ListenOnce detaches only the handler whose event fired, and exactly one of these two
@@ -707,6 +754,7 @@ namespace Reown.Core.Controllers
             if (closeAbandoned)
             {
                 _logger.Log("Close was abandoned, reporting the disconnect so subscriptions get rebuilt");
+                _subscriptionsReplayed = false;
                 OnDisconnected?.Invoke(this, EventArgs.Empty);
             }
 
@@ -800,6 +848,7 @@ namespace Reown.Core.Controllers
         {
             if (Disposed) return;
 
+            _subscriptionsReplayed = false;
             OnDisconnected?.Invoke(this, EventArgs.Empty);
 
             if (TransportExplicitlyClosed)
@@ -851,7 +900,7 @@ namespace Reown.Core.Controllers
                 // the state the loop exited on once more now that the latch is free: without this
                 // the latch turns a lost wakeup into a transport that stays down for good, which is
                 // worse than the loops it was added to stop.
-                if (Disposed || TransportExplicitlyClosed || Connected)
+                if (Disposed || TransportExplicitlyClosed || ConnectedAndReplayed)
                 {
                     return;
                 }
@@ -860,11 +909,18 @@ namespace Reown.Core.Controllers
             }
         }
 
+        /// <remarks>
+        ///     The loop ends on <see cref="ConnectedAndReplayed" /> rather than on
+        ///     <see cref="Connected" />. A socket that came up on its own — re-registered by a send
+        ///     rather than opened here — leaves the topic map cleared, and exiting on it would hand
+        ///     back a connection the relay delivers nothing on, with nothing left retrying. Going
+        ///     round again costs one restart and ends with the subscriptions in place.
+        /// </remarks>
         private async Task ReconnectWithBackoffUnsafe()
         {
             TimeSpan delay = ReconnectInitialDelay;
 
-            while (!Disposed && !TransportExplicitlyClosed && !Connected)
+            while (!Disposed && !TransportExplicitlyClosed && !ConnectedAndReplayed)
             {
                 try
                 {
@@ -875,7 +931,7 @@ namespace Reown.Core.Controllers
                     _logger.Log($"Reconnect attempt failed: {e.Message}");
                 }
 
-                if (Connected || Disposed || TransportExplicitlyClosed)
+                if (ConnectedAndReplayed || Disposed || TransportExplicitlyClosed)
                     return;
 
                 await Task.Delay(delay);
@@ -900,6 +956,39 @@ namespace Reown.Core.Controllers
         protected virtual void RegisterEventListeners()
         {
             OnConnectionStalled += OnConnectionStalledHandler;
+
+            Subscriber.Resubscribed += OnSubscriberResubscribed;
+        }
+
+        /// <summary>
+        ///     Records which connection the subscriber has replayed its subscriptions onto.
+        /// </summary>
+        /// <remarks>
+        ///     Read by the reconnect loop, which cannot use <see cref="Connected" /> alone: a socket
+        ///     can come up without a replay behind it. <c>WebsocketConnection.SendRequest</c>
+        ///     re-registers the transport when it finds none, and that path raises <c>Opened</c>
+        ///     rather than the provider's <c>Connected</c>, so <c>Subscriber.OnConnect</c> never runs
+        ///     — leaving the loop to exit on a connection whose topic map is still empty.
+        /// </remarks>
+        private void OnSubscriberResubscribed(object sender, EventArgs e)
+        {
+            _subscriptionsReplayed = true;
+        }
+
+        /// <summary>
+        ///     Whether the transport is up <i>and</i> carrying the subscriptions that belong to it.
+        /// </summary>
+        /// <remarks>
+        ///     The flag tracks the replay rather than the identity of <see cref="Provider" />: the
+        ///     socket can come back up on the very same provider object. <c>SendRequest</c>
+        ///     re-registers the transport in place when it finds none, so <see cref="Provider" /> is
+        ///     unchanged and a check comparing it against the one last replayed onto would hold —
+        ///     exiting the loop on a connection whose topic map is empty, with nothing left to
+        ///     rebuild it.
+        /// </remarks>
+        protected bool ConnectedAndReplayed
+        {
+            get => Connected && _subscriptionsReplayed;
         }
 
         private async void OnConnectionStalledHandler(object sender, EventArgs e)

--- a/src/Reown.Core/Runtime/Controllers/Relayer.cs
+++ b/src/Reown.Core/Runtime/Controllers/Relayer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net.WebSockets;
 using System.Threading;
@@ -46,30 +46,22 @@ namespace Reown.Core.Controllers
         private static readonly TimeSpan DefaultConnectionTimeout = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        ///     How much longer than <see cref="ConnectionTimeout" /> a whole <see cref="TransportOpen" />
-        ///     may take before it is abandoned — the room left for the resubscribe that follows the
-        ///     connect.
-        /// </summary>
-        /// <remarks>
-        ///     The resulting bound is the backstop that breaks a stuck reconnect: the flag
-        ///     <c>TransportOpen</c> raises is cleared only in its own finally, so an open that never
-        ///     returns disables every subsequent restart. Observed on a real client — the transport
-        ///     stayed down until this bound fired and released it, which also makes the bound the
-        ///     dominant term in how long recovery takes. Hence it tracks
-        ///     <see cref="ConnectionTimeout" /> instead of being a fixed, generous constant.
-        /// </remarks>
-        /// <summary>
         ///     Upper bound for <c>Subscriber.Resubscribed</c> after a socket comes up.
         /// </summary>
         /// <remarks>
         ///     Sized to the resubscribe path rather than the connect: the event fires only once every
         ///     batch has been answered, and <c>RpcBatchSubscribe</c> allows a minute per batch of 500
-        ///     topics. This is a backstop for a resubscription that never reports at all — a failed
-        ///     restart raises the event immediately, so the common failure does not wait it out.
+        ///     topics. Only a backstop for a resubscription that never reports either way — a restart
+        ///     that fails reports it, and the open fails with it, so no ordinary failure waits it out.
         /// </remarks>
-        private static readonly TimeSpan ResubscribeBudget = TimeSpan.FromMinutes(3);
+        private static readonly TimeSpan DefaultResubscribeBudget = TimeSpan.FromMinutes(3);
 
         private static readonly TimeSpan DefaultReconnectInitialDelay = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        ///     Upper bound for the resubscription, overridable so tests need not wait out the real one.
+        /// </summary>
+        protected virtual TimeSpan ResubscribeBudget => DefaultResubscribeBudget;
 
         /// <remarks>Overridable so the backoff loop can be tested without waiting out real delays.</remarks>
         protected virtual TimeSpan ReconnectInitialDelay => DefaultReconnectInitialDelay;
@@ -90,12 +82,26 @@ namespace Reown.Core.Controllers
         /// <remarks>Overridable so the backoff loop can be tested without waiting out real delays.</remarks>
         protected virtual TimeSpan ReconnectMaxDelay => DefaultReconnectMaxDelay;
 
+        private readonly Subscriber _subscriber;
+
         private bool _reconnecting;
 
         /// <summary>
         ///     Mutual exclusion for <see cref="RestartTransport" />: 1 while a restart is in flight.
         /// </summary>
         private int _restarting;
+
+        private int _reconnectLoop;
+
+        /// <summary>
+        ///     Counts how many reconnect loops have actually started, latch included.
+        /// </summary>
+        /// <remarks>
+        ///     Internal, and only so a test can assert that repeated disconnects produce one loop and
+        ///     not one per disconnect. The alternative was inferring it from attempt timings, which
+        ///     is exactly the kind of assertion that passes on a fast machine and fails on CI.
+        /// </remarks>
+        internal int ReconnectLoopsStarted;
         private string _relayUrl;
         protected bool Disposed;
 
@@ -110,7 +116,11 @@ namespace Reown.Core.Controllers
         {
             CoreClient = opts.CoreClient;
             Messages = new MessageTracker(CoreClient);
-            Subscriber = new Subscriber(this);
+
+            // Kept as the concrete type as well: the failure of a resubscribe is reported over an
+            // internal event, deliberately not on ISubscriber.
+            _subscriber = new Subscriber(this);
+            Subscriber = _subscriber;
             Publisher = new Publisher(this);
 
             _relayUrl = opts.RelayUrl;
@@ -138,7 +148,9 @@ namespace Reown.Core.Controllers
 
         /// <summary>
         ///     How long the <see cref="IRelayer" /> should wait before throwing a <see cref="TimeoutException" /> during
-        ///     the connection phase. If this field is null, then the timeout will be infinite.
+        ///     the connection phase. Null falls back to 30 seconds; it no longer means an unbounded
+        ///     wait, because this await holds <c>_reconnecting</c> raised and a stuck flag disables
+        ///     every later reconnect.
         /// </summary>
         public TimeSpan? ConnectionTimeout { get; set; }
 
@@ -348,20 +360,52 @@ namespace Reown.Core.Controllers
         ///     flag stays raised and every later reconnect attempt, the SDK's own included, returns
         ///     on its first line while the client reports itself connected.
         /// </remarks>
-        private async Task TransportCloseInternal(bool explicitClose)
+        /// <param name="attempt">
+        ///     Carries whether the caller gave up waiting for this close. <c>null</c> when nobody can.
+        /// </param>
+        private async Task TransportCloseInternal(bool explicitClose, CloseAttempt attempt = null)
         {
             _logger.Log($"Close transport. Connected: {Connected}, explicit: {explicitClose}");
-            if (Connected)
-            {
-                if (explicitClose)
-                {
-                    TransportExplicitlyClosed = true;
-                }
 
-                await Provider.Disconnect();
-                OnTransportClosed?.Invoke(this, EventArgs.Empty);
-                _logger.Log("Transport closed");
+            // Outside the Connected check on purpose. The flag means "do not reconnect", and the
+            // moment a caller most needs it is when the transport is already down and the reconnect
+            // loop is working to bring it back: gating it on Connected made TransportClose a no-op
+            // in exactly that state, leaving the loop to reopen a transport the caller closed.
+            if (explicitClose)
+            {
+                TransportExplicitlyClosed = true;
             }
+
+            if (!Connected)
+            {
+                return;
+            }
+
+            await Provider.Disconnect();
+
+            // Disconnect can return long after the caller stopped waiting — a dead network keeps the
+            // socket in retransmission for minutes. By then the reopen is normally in flight, and
+            // OnTransportClosed is what RejectTransportOpen listens to, so reporting this close now
+            // would tear down the healthy connection that replaced it.
+            if (attempt is { Abandoned: true })
+            {
+                _logger.Log("Abandoned close finished; not reporting it against the transport that replaced it");
+                return;
+            }
+
+            OnTransportClosed?.Invoke(this, EventArgs.Empty);
+            _logger.Log("Transport closed");
+        }
+
+        /// <summary>
+        ///     Tracks whether a close is still the one its caller is waiting for.
+        /// </summary>
+        private sealed class CloseAttempt
+        {
+            /// <summary>
+            ///     Gets or sets a value indicating whether the caller stopped waiting for this close.
+            /// </summary>
+            public volatile bool Abandoned;
         }
 
         public async Task TransportOpen(string relayUrl = null)
@@ -370,6 +414,12 @@ namespace Reown.Core.Controllers
             if (_reconnecting) return;
             _relayUrl = relayUrl ?? _relayUrl;
             _reconnecting = true;
+
+            // ListenOnce detaches only the handler whose event fired, and exactly one of these two
+            // ever does. Dropping the other left it subscribed for good, one more on every reconnect
+            // for the life of the process.
+            Action stopWaitingForResubscribe = null;
+            Action stopWaitingForResubscribeFailure = null;
             try
             {
                 var task1 = new TaskCompletionSource<bool>();
@@ -379,23 +429,40 @@ namespace Reown.Core.Controllers
                 }
                 else
                 {
-                    EventUtils.ListenOnce((_, _) => task1.TrySetResult(true),
+                    stopWaitingForResubscribe = EventUtils.ListenOnce((_, _) => task1.TrySetResult(true),
                         h => Subscriber.Resubscribed += h,
                         h => Subscriber.Resubscribed -= h);
+
+                    // A replay that failed has to fail the open. The socket is up, but it carries no
+                    // subscriptions, and reporting that as success lets the reconnect loop exit on
+                    // Connected and leaves the client deaf until an unrelated disconnect.
+                    stopWaitingForResubscribeFailure = EventUtils.ListenOnce<Exception>(
+                        (_, error) => task1.TrySetException(error),
+                        h => _subscriber.ResubscribeFailed += h,
+                        h => _subscriber.ResubscribeFailed -= h);
                 }
 
                 var task2 = new TaskCompletionSource<bool>();
 
                 void RejectTransportOpen(object sender, EventArgs @event)
                 {
-                    task2.TrySetException(
-                        new IOException("The transport was closed before the connection was established.")
-                    );
+                    var closed = new IOException("The transport was closed before the connection was established.");
+
+                    // Both, not just task2: a transport closed while the connect neither completes
+                    // nor faults would otherwise leave task1 waiting out its whole budget, holding
+                    // _reconnecting — and a raised _reconnecting disables every later restart.
+                    task2.TrySetException(closed);
+                    task1.TrySetException(closed);
                 }
 
                 async void Task2()
                 {
-                    var cleanupEvent = OnTransportClosed.ListenOnce(RejectTransportOpen);
+                    // Through the subscribe/unsubscribe pair, not the ListenOnce extension on the
+                    // event: that overload takes the delegate by value, so its "+=" lands on a local
+                    // copy and the event field is never touched. This handler had never once run.
+                    var cleanupEvent = EventUtils.ListenOnce(RejectTransportOpen,
+                        h => OnTransportClosed += h,
+                        h => OnTransportClosed -= h);
                     try
                     {
                         var connectionTask = Provider.Connect();
@@ -438,8 +505,8 @@ namespace Reown.Core.Controllers
                 //
                 // Neither may be left unbounded: this await holds _reconnecting raised (cleared only
                 // in the finally below), and a stuck _reconnecting silently disables every later
-                // reconnect. Timing out into the "socket stalled" path reports the transport closed
-                // and lets the reconnect loop try again.
+                // reconnect. Timing out closes whatever came up, and that close is what the reconnect
+                // loop watches — OnTransportClosed has no listener outside this method.
                 await Task.WhenAll(
                     task2.Task.WithTimeout(ConnectionTimeout ?? DefaultConnectionTimeout, "socket stalled"),
                     task1.Task.WithTimeout(ResubscribeBudget, "socket stalled"));
@@ -449,13 +516,41 @@ namespace Reown.Core.Controllers
             catch (Exception e)
             {
                 // TODO Check for system socket hang up message
-                if (e.Message != "socket stalled")
-                    throw;
 
-                OnTransportClosed?.Invoke(this, EventArgs.Empty);
+                // Whatever failed, a socket left connected without its subscriptions is the worst of
+                // the outcomes: every reconnect loop here stops on Connected, so nothing retries and
+                // the client stays deaf. This is not only the rethrown case — the connect can succeed
+                // and the resubscription time out, and that used to return from here reporting
+                // success, with the socket up and not one relay-side subscription behind it.
+                if (Connected)
+                {
+                    // Guarded: Close throws when the transport went away between the check above and
+                    // the call, and letting that out would replace the failure the caller needs with
+                    // the incidental one — including on the stalled path, which swallows by design.
+                    try
+                    {
+                        await TransportCloseInternal(false);
+                    }
+                    catch (Exception closeFailure)
+                    {
+                        _logger.Log($"Closing the failed transport failed too: {closeFailure.Message}");
+                    }
+                }
+                else if (e.Message == "socket stalled")
+                {
+                    // Nothing was closed, so say so: the closing above reports itself.
+                    OnTransportClosed?.Invoke(this, EventArgs.Empty);
+                }
+
+                if (e.Message != "socket stalled")
+                {
+                    throw;
+                }
             }
             finally
             {
+                stopWaitingForResubscribe?.Invoke();
+                stopWaitingForResubscribeFailure?.Invoke();
                 _reconnecting = false;
             }
         }
@@ -495,6 +590,7 @@ namespace Reown.Core.Controllers
         private async Task RestartTransportUnsafe(string relayUrl)
         {
             _relayUrl = relayUrl ?? _relayUrl;
+            bool closeAbandoned = false;
             if (Connected)
             {
                 _logger.Log("Already connected. Closing transport");
@@ -508,15 +604,25 @@ namespace Reown.Core.Controllers
                 // retransmitting, and Provider.Disconnected may never arrive at all. The provider is
                 // replaced immediately below, so a close that did not finish must not hold up the
                 // reopen — otherwise RestartTransport never returns and the caller sees a hang.
-                bool closeReported = true;
+                var attempt = new CloseAttempt();
+
+                // Held and observed separately. WhenAll folds a child's failure in only once every
+                // child has finished, and task1 waits for a Disconnected that a close which threw
+                // will never raise — so the failed close would sit there with nobody to fold it in
+                // and come back on the finalizer thread. Closing an already-gone transport throws
+                // exactly that way.
+                Task closing = TransportCloseInternal(false, attempt);
+                closing.ObserveFault();
+
                 try
                 {
-                    await Task.WhenAll(task1.Task, TransportCloseInternal(false))
+                    await Task.WhenAll(task1.Task, closing)
                         .WithTimeout(TransportCloseTimeout, "transport close stalled");
                 }
                 catch (TimeoutException)
                 {
-                    closeReported = false;
+                    closeAbandoned = true;
+                    attempt.Abandoned = true;
                     _logger.Log("Close did not finish in time, reopening anyway");
                 }
 
@@ -524,18 +630,25 @@ namespace Reown.Core.Controllers
                 // OnDisconnected, which OnProviderDisconnected raises once the close is reported.
                 // Abandoning the close without it leaves Subscriber holding the dead socket's topic
                 // map: OnDisable never runs, so nothing is cached for Reset to re-subscribe, and
-                // Restore then throws on the non-empty map straight into _restartTask, where the
-                // exception is never observed. The outcome is a live socket with no relay-side
-                // subscriptions at all and a local map that still claims every one of them —
-                // invisible to any check that trusts that map.
-                if (!closeReported)
-                {
-                    _logger.Log("Close was abandoned, reporting the disconnect so subscriptions get rebuilt");
-                    OnDisconnected?.Invoke(this, EventArgs.Empty);
-                }
+                // Restore then throws on the non-empty map. That throw is reported now rather than
+                // buried, so the open fails and the loop retries — but retrying a socket that was
+                // never going to carry subscriptions is still a wasted round, and without this the
+                // local map goes on claiming every topic the dead socket held.
             }
 
+            // Detaches the old provider before anything else, which is why the compensation below
+            // waits for it: an abandoned close can still finish and report itself through
+            // Provider.Disconnected, and arriving alongside the compensating event it would raise
+            // OnDisconnected twice. The second one caches an already empty topic map, so Reset
+            // resubscribes to nothing and reports success.
             await CreateProvider();
+
+            if (closeAbandoned)
+            {
+                _logger.Log("Close was abandoned, reporting the disconnect so subscriptions get rebuilt");
+                OnDisconnected?.Invoke(this, EventArgs.Empty);
+            }
+
             await TransportOpen();
         }
 
@@ -647,6 +760,46 @@ namespace Reown.Core.Controllers
         ///     messages it can no longer deliver.
         /// </remarks>
         private async Task ReconnectWithBackoff()
+        {
+            // One loop at a time. Every failed attempt closes the socket it managed to open, and that
+            // close is itself a disconnect arriving here: without this latch each failure started
+            // another loop while the earlier ones kept running — they only exit on Connected — and
+            // every newcomer restarted the delay at its initial value, so the backoff never grew and
+            // a long outage was met with a steady stream of attempts instead of a widening one.
+            while (true)
+            {
+                if (Interlocked.CompareExchange(ref _reconnectLoop, 1, 0) != 0)
+                {
+                    _logger.Log("A reconnect loop is already running, not starting another");
+                    return;
+                }
+
+                Interlocked.Increment(ref ReconnectLoopsStarted);
+
+                try
+                {
+                    await ReconnectWithBackoffUnsafe();
+                }
+                finally
+                {
+                    Interlocked.Exchange(ref _reconnectLoop, 0);
+                }
+
+                // A disconnect arriving while this loop was on its way out found the latch still
+                // taken and returned without starting anything, and nothing else is watching. Read
+                // the state the loop exited on once more now that the latch is free: without this
+                // the latch turns a lost wakeup into a transport that stays down for good, which is
+                // worse than the loops it was added to stop.
+                if (Disposed || TransportExplicitlyClosed || Connected)
+                {
+                    return;
+                }
+
+                _logger.Log("A disconnect arrived as the reconnect loop was leaving; going round again");
+            }
+        }
+
+        private async Task ReconnectWithBackoffUnsafe()
         {
             TimeSpan delay = ReconnectInitialDelay;
 

--- a/src/Reown.Core/Runtime/Controllers/Relayer.cs
+++ b/src/Reown.Core/Runtime/Controllers/Relayer.cs
@@ -408,10 +408,47 @@ namespace Reown.Core.Controllers
             public volatile bool Abandoned;
         }
 
-        public async Task TransportOpen(string relayUrl = null)
+        /// <remarks>
+        ///     Asking for the transport to open is the counterpart of asking for it to close, so this
+        ///     clears the flag a close raised. The reconnect path deliberately does not come through
+        ///     here: an open it started before the caller closed would otherwise clear the flag on
+        ///     that caller's behalf and bring the socket back up.
+        /// </remarks>
+        public Task TransportOpen(string relayUrl = null)
         {
             TransportExplicitlyClosed = false;
+            return TransportOpenCore(relayUrl);
+        }
+
+        private async Task TransportOpenCore(string relayUrl)
+        {
+            // Read here rather than at the caller: a restart passes its own check long before it
+            // reaches this point, and a close arriving in between has to win.
+            if (TransportExplicitlyClosed)
+            {
+                _logger.Log("The transport was explicitly closed while this open was on its way; not opening");
+                return;
+            }
+
             if (_reconnecting) return;
+
+            // Nothing here to open, and waiting anyway is worse than doing nothing. The wait below
+            // is for Subscriber.Resubscribed, which comes out of a restart driven by the provider's
+            // Connected event — and a provider that is already connected never raises it, so the
+            // wait is doomed from its first millisecond. It then sat out the whole resubscribe
+            // budget and, since a failed open closes what it finds, tore down a healthy connection
+            // carrying live subscriptions. Upstream fares worse: there the wait has no bound at
+            // all, so one such call parks _reconnecting for good and every later reconnect returns
+            // on its first line, this class's own loop included.
+            //
+            // Changing the relay URL still works: RestartTransport closes first, so it does not
+            // arrive here with a live socket.
+            if (Connected)
+            {
+                _logger.Log("The transport is already open; nothing to do");
+                return;
+            }
+
             _relayUrl = relayUrl ?? _relayUrl;
             _reconnecting = true;
 
@@ -510,6 +547,30 @@ namespace Reown.Core.Controllers
                 await Task.WhenAll(
                     task2.Task.WithTimeout(ConnectionTimeout ?? DefaultConnectionTimeout, "socket stalled"),
                     task1.Task.WithTimeout(ResubscribeBudget, "socket stalled"));
+
+                // Checked again, not only on the way in: a connect runs for as long as its whole
+                // timeout, and a close arriving inside that window had nothing to tear down — the
+                // socket was still down, so it left behind nothing but the flag. Handing the
+                // finished connection over anyway answers a caller who asked for the transport to
+                // go away by bringing it back, and the reconnect loop then exits on Connected and
+                // leaves it up.
+                if (TransportExplicitlyClosed)
+                {
+                    _logger.Log("The transport was explicitly closed while this open was in flight; closing what it opened");
+
+                    // Guarded for the same reason as the failure path below: a close that throws
+                    // here would replace a well-defined outcome with an incidental exception.
+                    try
+                    {
+                        await TransportCloseInternal(false);
+                    }
+                    catch (Exception closeFailure)
+                    {
+                        _logger.Log($"Closing an unwanted transport failed: {closeFailure.Message}");
+                    }
+
+                    return;
+                }
 
                 _logger.Log("Transport opened");
             }
@@ -649,7 +710,7 @@ namespace Reown.Core.Controllers
                 OnDisconnected?.Invoke(this, EventArgs.Empty);
             }
 
-            await TransportOpen();
+            await TransportOpenCore(null);
         }
 
         protected virtual async Task CreateProvider()

--- a/src/Reown.Core/Runtime/Controllers/Relayer.cs
+++ b/src/Reown.Core/Runtime/Controllers/Relayer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Net.WebSockets;
 using System.Threading;
@@ -31,7 +31,13 @@ namespace Reown.Core.Controllers
         /// <summary>
         ///     Upper bound for the close that <see cref="RestartTransport" /> does before reopening.
         /// </summary>
-        private static readonly TimeSpan TransportCloseTimeout = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan DefaultTransportCloseTimeout = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        ///     How long a restart waits for the close it started to be reported before moving on.
+        /// </summary>
+        /// <remarks>Overridable so the recovery paths can be tested without waiting out real timeouts.</remarks>
+        protected virtual TimeSpan TransportCloseTimeout => DefaultTransportCloseTimeout;
 
         /// <summary>
         ///     Fallback when <see cref="ConnectionTimeout" /> was left unset; matches the value
@@ -52,9 +58,21 @@ namespace Reown.Core.Controllers
         ///     dominant term in how long recovery takes. Hence it tracks
         ///     <see cref="ConnectionTimeout" /> instead of being a fixed, generous constant.
         /// </remarks>
-        private static readonly TimeSpan TransportOpenGrace = TimeSpan.FromSeconds(10);
+        /// <summary>
+        ///     Upper bound for <c>Subscriber.Resubscribed</c> after a socket comes up.
+        /// </summary>
+        /// <remarks>
+        ///     Sized to the resubscribe path rather than the connect: the event fires only once every
+        ///     batch has been answered, and <c>RpcBatchSubscribe</c> allows a minute per batch of 500
+        ///     topics. This is a backstop for a resubscription that never reports at all — a failed
+        ///     restart raises the event immediately, so the common failure does not wait it out.
+        /// </remarks>
+        private static readonly TimeSpan ResubscribeBudget = TimeSpan.FromMinutes(3);
 
-        private static readonly TimeSpan ReconnectInitialDelay = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan DefaultReconnectInitialDelay = TimeSpan.FromSeconds(1);
+
+        /// <remarks>Overridable so the backoff loop can be tested without waiting out real delays.</remarks>
+        protected virtual TimeSpan ReconnectInitialDelay => DefaultReconnectInitialDelay;
 
         /// <summary>
         ///     Ceiling for the pause between reconnect attempts.
@@ -67,7 +85,10 @@ namespace Reown.Core.Controllers
         ///     connectivity restored just after an attempt began went unnoticed for the best part of
         ///     a minute. Pausing longer costs latency and buys no relief for the relay.
         /// </remarks>
-        private static readonly TimeSpan ReconnectMaxDelay = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan DefaultReconnectMaxDelay = TimeSpan.FromSeconds(5);
+
+        /// <remarks>Overridable so the backoff loop can be tested without waiting out real delays.</remarks>
+        protected virtual TimeSpan ReconnectMaxDelay => DefaultReconnectMaxDelay;
 
         private bool _reconnecting;
 
@@ -407,14 +428,21 @@ namespace Reown.Core.Controllers
 
                 Task2();
 
-                // task1 waits for Subscriber.Resubscribed, which nothing guarantees will ever be
-                // raised — Subscriber.Restore can throw, or the batch can be empty. Left unbounded
-                // this await keeps _reconnecting raised forever (it is only cleared in the finally
-                // below), and a raised _reconnecting silently disables every future reconnect.
-                // Time it out into the "socket stalled" path so the transport is reported closed and
-                // the reconnect loop gets to try again.
-                await Task.WhenAll(task1.Task, task2.Task)
-                    .WithTimeout((ConnectionTimeout ?? DefaultConnectionTimeout) + TransportOpenGrace, "socket stalled");
+                // The two waits are bounded separately because they are waiting for different work.
+                // task2 is the connect; task1 is the resubscription, which only completes once
+                // BatchSubscribe has worked through every batch, each with its own one-minute bound
+                // in RpcBatchSubscribe. One connect-sized budget over both declared a healthy
+                // connection stalled whenever an account simply had more topics than a single
+                // connect takes, and tore it down while the batch loop kept running against the
+                // provider that had already been replaced.
+                //
+                // Neither may be left unbounded: this await holds _reconnecting raised (cleared only
+                // in the finally below), and a stuck _reconnecting silently disables every later
+                // reconnect. Timing out into the "socket stalled" path reports the transport closed
+                // and lets the reconnect loop try again.
+                await Task.WhenAll(
+                    task2.Task.WithTimeout(ConnectionTimeout ?? DefaultConnectionTimeout, "socket stalled"),
+                    task1.Task.WithTimeout(ResubscribeBudget, "socket stalled"));
 
                 _logger.Log("Transport opened");
             }
@@ -513,16 +541,40 @@ namespace Reown.Core.Controllers
 
         protected virtual async Task CreateProvider()
         {
-            var auth = await CoreClient.Crypto.SignJwt(_relayUrl);
-
-            // The provider being replaced keeps its handlers otherwise, and a socket abandoned by a
-            // restart still reports its close later on. That late Disconnected reaches the live
-            // relayer: it wipes the fresh subscription map into Subscriber's cache and starts a
-            // reconnect loop over a connection that is perfectly healthy.
+            // Detached before the first await, not after it: a socket abandoned by a restart still
+            // reports its close later on, and anything arriving in that window reaches the live
+            // relayer — wiping the fresh subscription map into Subscriber's cache and starting a
+            // reconnect over a connection that is perfectly healthy.
+            IJsonRpcProvider previous = Provider;
             UnregisterProviderEventListeners();
+
+            var auth = await CoreClient.Crypto.SignJwt(_relayUrl);
 
             Provider = await CreateProvider(auth);
             RegisterProviderEventListeners();
+
+            // Detaching only stops the events. Without disposing, the abandoned transport keeps its
+            // receive loop, its socket and its rented buffer alive for the life of the process, and
+            // a reconnecting client leaks one of each per attempt.
+            DisposeProviderFireAndForget(previous);
+        }
+
+        private void DisposeProviderFireAndForget(IJsonRpcProvider provider)
+        {
+            if (provider == null || ReferenceEquals(provider, Provider))
+                return;
+
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    (provider as IDisposable)?.Dispose();
+                }
+                catch (Exception e)
+                {
+                    _logger.Log($"Disposing the replaced provider failed: {e.Message}");
+                }
+            });
         }
 
         protected virtual async Task<IJsonRpcProvider> CreateProvider(string auth)
@@ -641,7 +693,21 @@ namespace Reown.Core.Controllers
             if (Provider.Connection.IsPaused)
                 return;
 
-            await RestartTransport();
+            // async void: anything escaping here goes straight to the thread pool and takes the
+            // process with it. TransportOpen rethrows every failure that is not its own timeout, so
+            // a connect that fails outright — no network, refused socket — would arrive here.
+            try
+            {
+                await RestartTransport();
+            }
+            catch (Exception ex)
+            {
+                _logger.Log($"Restart after a stalled connection failed: {ex.Message}");
+
+                // A stall that could not be restarted still needs the retry loop, otherwise the
+                // transport stays down until something else happens to poke it.
+                await ReconnectWithBackoff();
+            }
         }
 
         protected virtual async void OnProviderPayload(string payloadJson)

--- a/src/Reown.Core/Runtime/Controllers/Relayer.cs
+++ b/src/Reown.Core/Runtime/Controllers/Relayer.cs
@@ -28,7 +28,53 @@ namespace Reown.Core.Controllers
         private readonly string _projectId;
         private readonly ILogger _logger;
         private bool _initialized;
+        /// <summary>
+        ///     Upper bound for the close that <see cref="RestartTransport" /> does before reopening.
+        /// </summary>
+        private static readonly TimeSpan TransportCloseTimeout = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        ///     Fallback when <see cref="ConnectionTimeout" /> was left unset; matches the value
+        ///     <c>CoreOptions</c> and <c>RelayerOptions</c> default to.
+        /// </summary>
+        private static readonly TimeSpan DefaultConnectionTimeout = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        ///     How much longer than <see cref="ConnectionTimeout" /> a whole <see cref="TransportOpen" />
+        ///     may take before it is abandoned — the room left for the resubscribe that follows the
+        ///     connect.
+        /// </summary>
+        /// <remarks>
+        ///     The resulting bound is the backstop that breaks a stuck reconnect: the flag
+        ///     <c>TransportOpen</c> raises is cleared only in its own finally, so an open that never
+        ///     returns disables every subsequent restart. Observed on a real client — the transport
+        ///     stayed down until this bound fired and released it, which also makes the bound the
+        ///     dominant term in how long recovery takes. Hence it tracks
+        ///     <see cref="ConnectionTimeout" /> instead of being a fixed, generous constant.
+        /// </remarks>
+        private static readonly TimeSpan TransportOpenGrace = TimeSpan.FromSeconds(10);
+
+        private static readonly TimeSpan ReconnectInitialDelay = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        ///     Ceiling for the pause between reconnect attempts.
+        /// </summary>
+        /// <remarks>
+        ///     Deliberately small. A connect attempt to an unreachable relay cannot fail early — the
+        ///     blackhole case has nobody to send a refusal — so it already occupies a full
+        ///     <see cref="ConnectionTimeout" /> window, which is the backoff. Measured on the relay
+        ///     lab with a 30 s window: attempts landed exactly 60 s apart, half of it idle, so
+        ///     connectivity restored just after an attempt began went unnoticed for the best part of
+        ///     a minute. Pausing longer costs latency and buys no relief for the relay.
+        /// </remarks>
+        private static readonly TimeSpan ReconnectMaxDelay = TimeSpan.FromSeconds(5);
+
         private bool _reconnecting;
+
+        /// <summary>
+        ///     Mutual exclusion for <see cref="RestartTransport" />: 1 while a restart is in flight.
+        /// </summary>
+        private int _restarting;
         private string _relayUrl;
         protected bool Disposed;
 
@@ -261,12 +307,36 @@ namespace Reown.Core.Controllers
             return result;
         }
 
-        public async Task TransportClose()
+        public Task TransportClose()
         {
-            _logger.Log($"Close transport. Connected: {Connected}");
+            return TransportCloseInternal(true);
+        }
+
+        /// <summary>
+        ///     Closes the transport, optionally marking it as closed on purpose.
+        /// </summary>
+        /// <param name="explicitClose">
+        ///     <c>true</c> when the caller wants the transport to stay down. <c>false</c> for the
+        ///     close that <see cref="RestartTransport" /> performs on its way to reopening.
+        /// </param>
+        /// <remarks>
+        ///     <see cref="TransportExplicitlyClosed" /> means "do not reconnect": it short-circuits
+        ///     <see cref="RestartTransport" /> and makes <see cref="OnProviderDisconnected" /> give
+        ///     up. Setting it from inside a restart is therefore a latch — if anything between the
+        ///     close and <see cref="TransportOpen" /> (which is what clears it) throws or hangs, the
+        ///     flag stays raised and every later reconnect attempt, the SDK's own included, returns
+        ///     on its first line while the client reports itself connected.
+        /// </remarks>
+        private async Task TransportCloseInternal(bool explicitClose)
+        {
+            _logger.Log($"Close transport. Connected: {Connected}, explicit: {explicitClose}");
             if (Connected)
             {
-                TransportExplicitlyClosed = true;
+                if (explicitClose)
+                {
+                    TransportExplicitlyClosed = true;
+                }
+
                 await Provider.Disconnect();
                 OnTransportClosed?.Invoke(this, EventArgs.Empty);
                 _logger.Log("Transport closed");
@@ -314,6 +384,21 @@ namespace Reown.Core.Controllers
                         await connectionTask;
                         task2.TrySetResult(true);
                     }
+                    catch (Exception e)
+                    {
+                        // This is an async void: an escaping exception goes straight to the thread
+                        // pool and terminates the process. It also never reaches the handler that
+                        // was written for it — the catch below looks for "socket stalled" and
+                        // raises OnTransportClosed — because that handler observes task2, not this
+                        // method. Hand the failure over instead of letting it escape.
+                        task2.TrySetException(e);
+
+                        // task1 waits for Subscriber.Resubscribed, which can only fire once the
+                        // connection is up. Failing task2 alone is not enough: Task.WhenAll below
+                        // would keep waiting for an event that can no longer happen, so the open
+                        // would hang forever instead of surfacing the failure.
+                        task1.TrySetException(e);
+                    }
                     finally
                     {
                         cleanupEvent();
@@ -322,7 +407,15 @@ namespace Reown.Core.Controllers
 
                 Task2();
 
-                await Task.WhenAll(task1.Task, task2.Task);
+                // task1 waits for Subscriber.Resubscribed, which nothing guarantees will ever be
+                // raised — Subscriber.Restore can throw, or the batch can be empty. Left unbounded
+                // this await keeps _reconnecting raised forever (it is only cleared in the finally
+                // below), and a raised _reconnecting silently disables every future reconnect.
+                // Time it out into the "socket stalled" path so the transport is reported closed and
+                // the reconnect loop gets to try again.
+                await Task.WhenAll(task1.Task, task2.Task)
+                    .WithTimeout((ConnectionTimeout ?? DefaultConnectionTimeout) + TransportOpenGrace, "socket stalled");
+
                 _logger.Log("Transport opened");
             }
             catch (Exception e)
@@ -348,6 +441,31 @@ namespace Reown.Core.Controllers
                 return;
             }
 
+            // The guard above is not mutual exclusion: _reconnecting is only raised later, inside
+            // TransportOpen, so two callers arriving together — typically a caller-driven restart and
+            // the one OnProviderDisconnected fires when that restart closes the socket — both pass it,
+            // both replace Provider, and one of them then returns early on TransportOpen's own
+            // _reconnecting check without ever clearing it. The flag stays raised for good and every
+            // later restart, this class's own reconnect loop included, returns on its first line while
+            // the transport is down. Take an explicit latch so only one restart is ever in flight.
+            if (Interlocked.CompareExchange(ref _restarting, 1, 0) != 0)
+            {
+                _logger.Log("Another restart is already in flight, skipping this one");
+                return;
+            }
+
+            try
+            {
+                await RestartTransportUnsafe(relayUrl);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _restarting, 0);
+            }
+        }
+
+        private async Task RestartTransportUnsafe(string relayUrl)
+        {
             _relayUrl = relayUrl ?? _relayUrl;
             if (Connected)
             {
@@ -358,7 +476,35 @@ namespace Reown.Core.Controllers
                     h => Provider.Disconnected += h,
                     h => Provider.Disconnected -= h);
 
-                await Task.WhenAll(task1.Task, TransportClose());
+                // Closing a socket whose network is gone blocks for as long as the OS keeps
+                // retransmitting, and Provider.Disconnected may never arrive at all. The provider is
+                // replaced immediately below, so a close that did not finish must not hold up the
+                // reopen — otherwise RestartTransport never returns and the caller sees a hang.
+                bool closeReported = true;
+                try
+                {
+                    await Task.WhenAll(task1.Task, TransportCloseInternal(false))
+                        .WithTimeout(TransportCloseTimeout, "transport close stalled");
+                }
+                catch (TimeoutException)
+                {
+                    closeReported = false;
+                    _logger.Log("Close did not finish in time, reopening anyway");
+                }
+
+                // Subscriber learns that its subscriptions died with the socket only from
+                // OnDisconnected, which OnProviderDisconnected raises once the close is reported.
+                // Abandoning the close without it leaves Subscriber holding the dead socket's topic
+                // map: OnDisable never runs, so nothing is cached for Reset to re-subscribe, and
+                // Restore then throws on the non-empty map straight into _restartTask, where the
+                // exception is never observed. The outcome is a live socket with no relay-side
+                // subscriptions at all and a local map that still claims every one of them —
+                // invisible to any check that trusts that map.
+                if (!closeReported)
+                {
+                    _logger.Log("Close was abandoned, reporting the disconnect so subscriptions get rebuilt");
+                    OnDisconnected?.Invoke(this, EventArgs.Empty);
+                }
             }
 
             await CreateProvider();
@@ -368,6 +514,13 @@ namespace Reown.Core.Controllers
         protected virtual async Task CreateProvider()
         {
             var auth = await CoreClient.Crypto.SignJwt(_relayUrl);
+
+            // The provider being replaced keeps its handlers otherwise, and a socket abandoned by a
+            // restart still reports its close later on. That late Disconnected reaches the live
+            // relayer: it wipes the fresh subscription map into Subscriber's cache and starts a
+            // reconnect loop over a connection that is perfectly healthy.
+            UnregisterProviderEventListeners();
+
             Provider = await CreateProvider(auth);
             RegisterProviderEventListeners();
         }
@@ -399,6 +552,17 @@ namespace Reown.Core.Controllers
             Provider.ErrorReceived += OnProviderErrorReceived;
         }
 
+        private void UnregisterProviderEventListeners()
+        {
+            if (Provider == null)
+                return;
+
+            Provider.RawMessageReceived -= OnProviderRawMessageReceived;
+            Provider.Connected -= OnProviderConnected;
+            Provider.Disconnected -= OnProviderDisconnected;
+            Provider.ErrorReceived -= OnProviderErrorReceived;
+        }
+
         private void OnProviderErrorReceived(object sender, Exception e)
         {
             if (Disposed) return;
@@ -415,7 +579,42 @@ namespace Reown.Core.Controllers
             if (TransportExplicitlyClosed)
                 return;
 
-            await RestartTransport();
+            await ReconnectWithBackoff();
+        }
+
+        /// <summary>
+        ///     Keeps trying to bring the transport back until it succeeds, the transport is closed
+        ///     on purpose, or the relayer is disposed.
+        /// </summary>
+        /// <remarks>
+        ///     A single <see cref="RestartTransport" /> is not enough. A dropped link is detected a
+        ///     keep-alive cycle after it actually died, so at that moment the network is normally
+        ///     still down: <c>TransportOpen</c> fails with "socket stalled", raises
+        ///     <c>OnTransportClosed</c>, and nothing retries. The client then stays disconnected
+        ///     indefinitely — long after connectivity is back — while the relay keeps queueing
+        ///     messages it can no longer deliver.
+        /// </remarks>
+        private async Task ReconnectWithBackoff()
+        {
+            TimeSpan delay = ReconnectInitialDelay;
+
+            while (!Disposed && !TransportExplicitlyClosed && !Connected)
+            {
+                try
+                {
+                    await RestartTransport();
+                }
+                catch (Exception e)
+                {
+                    _logger.Log($"Reconnect attempt failed: {e.Message}");
+                }
+
+                if (Connected || Disposed || TransportExplicitlyClosed)
+                    return;
+
+                await Task.Delay(delay);
+                delay = TimeSpan.FromTicks(Math.Min(delay.Ticks * 2, ReconnectMaxDelay.Ticks));
+            }
         }
 
         private void OnProviderConnected(object sender, IJsonRpcConnection e)

--- a/src/Reown.Core/Runtime/Controllers/Subscriber.cs
+++ b/src/Reown.Core/Runtime/Controllers/Subscriber.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -129,6 +129,16 @@ namespace Reown.Core.Controllers
 
         public event EventHandler Sync;
         public event EventHandler Resubscribed;
+
+        /// <summary>
+        ///     Raised when a restart could not rebuild the subscriptions, carrying the failure.
+        /// </summary>
+        /// <remarks>
+        ///     Internal on purpose: this is the contract between the subscriber and the relayer that
+        ///     drives it, and both live in this assembly. Putting it on <see cref="ISubscriber" />
+        ///     would grow a public interface for a detail no implementer outside needs.
+        /// </remarks>
+        internal event EventHandler<Exception> ResubscribeFailed;
         public event EventHandler<ActiveSubscription> Created;
         public event EventHandler<DeletedSubscription> Deleted;
 
@@ -268,11 +278,15 @@ namespace Reown.Core.Controllers
                 _logger.LogError($"Restart failed, subscriptions were not rebuilt: {e.Message}");
                 _restartTask.SetException(e);
 
-                // Resubscribed means "the attempt is over", not "it succeeded". TransportOpen waits
-                // on this event, so leaving it unraised after a failure left the open hanging until
-                // its own backstop expired — for the one failure that matters most, a Restore that
-                // threw and left the socket with no subscriptions at all.
-                Resubscribed?.Invoke(this, EventArgs.Empty);
+                // Nothing awaits _restartTask unless a Subscribe happens to race the restart, so
+                // without this the failure resurfaces on the finalizer thread.
+                _restartTask.Task.ObserveFault();
+
+                // Reported rather than passed off as completion. Raising Resubscribed here would
+                // unblock TransportOpen, but it would also present a socket carrying no
+                // subscriptions as a successful open: the reconnect loop exits on Connected and the
+                // client stays deaf until some unrelated disconnect wakes it.
+                ResubscribeFailed?.Invoke(this, e);
             }
         }
 

--- a/src/Reown.Core/Runtime/Controllers/Subscriber.cs
+++ b/src/Reown.Core/Runtime/Controllers/Subscriber.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -304,6 +304,25 @@ namespace Reown.Core.Controllers
             }
 
             OnSubscribe(id, @params);
+
+            // Checked once more, because the two steps above are not one. A swap landing between
+            // the check and the record stamps the entry with the provider that replaced the one it
+            // was made on, and OnSubscribe has already taken the topic out of _pending — so
+            // DiscardMapBuiltOnAnotherProvider keeps an entry the new connection never subscribed,
+            // and no sweep is left to notice. Putting the topic back is what makes it recoverable.
+            if (!ReferenceEquals(provider, _relayer.Provider) || Volatile.Read(ref _connectionEpoch) != epoch)
+            {
+                lock (_sync)
+                {
+                    _pending[topic] = @params;
+                }
+
+                _logger.LogError(
+                    $"Subscription to {topic} was recorded as its socket went away; queued for the sweep");
+
+                throw new IOException($"The transport was replaced while subscribing to {topic}.");
+            }
+
             return id;
         }
 
@@ -903,10 +922,12 @@ namespace Reown.Core.Controllers
 
             var provider = _relayer.Provider;
             var epoch = Volatile.Read(ref _connectionEpoch);
-            var batches = subscriptions.Batch(BatchSubscribeTopicsLimit);
-            foreach (var batch in batches)
+            // Materialised so the batches still waiting can be recorded when one of them has to bail
+            // out: dropping the remainder would leave those topics in no collection at all.
+            var batches = subscriptions.Batch(BatchSubscribeTopicsLimit).Select(b => b.ToArray()).ToArray();
+            for (var batchIndex = 0; batchIndex < batches.Length; batchIndex++)
             {
-                var batchSubscriptions = batch.ToArray();
+                var batchSubscriptions = batches[batchIndex];
                 if (batchSubscriptions.Length == 0) continue;
 
                 var topics = batchSubscriptions.Select(s => s.Topic).ToArray();
@@ -919,6 +940,17 @@ namespace Reown.Core.Controllers
                 }
                 catch (TimeoutException)
                 {
+                    // Recorded before moving on for the same reason as the discard below: a replay's
+                    // batches come from _cached, which OnEnabled has already cleared, so a batch that
+                    // is merely skipped here exists nowhere afterwards.
+                    lock (_sync)
+                    {
+                        foreach (var timedOut in batchSubscriptions)
+                        {
+                            _pending[timedOut.Topic] = timedOut;
+                        }
+                    }
+
                     _relayer.TriggerConnectionStalled();
                     continue;
                 }
@@ -926,10 +958,33 @@ namespace Reown.Core.Controllers
                 // Same rule as in Subscribe: a batch answered after its socket went away describes
                 // subscriptions the current connection does not have. Dropped rather than thrown —
                 // this runs from the restart and from the pending sweep, neither of which has a
-                // caller waiting to hear about it; the topics stay pending and are picked up again.
+                // caller waiting to hear about it.
                 if (!ReferenceEquals(provider, _relayer.Provider) || Volatile.Read(ref _connectionEpoch) != epoch)
                 {
                     _logger.LogError($"Batch subscribe to {topics.Length} topic(s) was answered after its socket went away; discarding it");
+
+                    // Put back as pending on the way out, and that is not tidiness. Only the sweep's
+                    // batches come from _pending; a replay's come from _cached, which OnEnabled
+                    // clears the moment Reset raises Resubscribed. Dropping those without recording
+                    // them anywhere leaves the topics in no collection at all — the open reports
+                    // success, the relay holds no subscription for them, and nothing remains to
+                    // notice. Recorded here, the sweep picks them up whatever the source was.
+                    // Every batch still queued behind this one goes back too. They were never sent,
+                    // and each batch that already succeeded has overwritten storage with a
+                    // Values snapshot that does not contain them — so without this they are gone
+                    // from _cached, from _subscriptions and from storage alike, and Restore would
+                    // not find them either.
+                    lock (_sync)
+                    {
+                        for (var i = batchIndex; i < batches.Length; i++)
+                        {
+                            foreach (var dropped in batches[i])
+                            {
+                                _pending[dropped.Topic] = dropped;
+                            }
+                        }
+                    }
+
                     return;
                 }
 

--- a/src/Reown.Core/Runtime/Controllers/Subscriber.cs
+++ b/src/Reown.Core/Runtime/Controllers/Subscriber.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -267,6 +267,12 @@ namespace Reown.Core.Controllers
                 // Reset never ran and this socket carries no relay-side subscriptions at all.
                 _logger.LogError($"Restart failed, subscriptions were not rebuilt: {e.Message}");
                 _restartTask.SetException(e);
+
+                // Resubscribed means "the attempt is over", not "it succeeded". TransportOpen waits
+                // on this event, so leaving it unraised after a failure left the open hanging until
+                // its own backstop expired — for the one failure that matters most, a Restore that
+                // threw and left the socket with no subscriptions at all.
+                Resubscribed?.Invoke(this, EventArgs.Empty);
             }
         }
 

--- a/src/Reown.Core/Runtime/Controllers/Subscriber.cs
+++ b/src/Reown.Core/Runtime/Controllers/Subscriber.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,6 +30,12 @@ namespace Reown.Core.Controllers
         private readonly TopicMap _topicMap = new();
         private ActiveSubscription[] _cached = Array.Empty<ActiveSubscription>();
         private string _clientId;
+
+        /// <summary>
+        ///     Bumped every time the socket goes away, so an answer that outlived its socket
+        ///     can be told apart from one that belongs to the connection in use now.
+        /// </summary>
+        private int _connectionEpoch;
         private bool _initialized;
         private TaskCompletionSource<bool> _restartTask;
 
@@ -195,8 +202,33 @@ namespace Reown.Core.Controllers
                 Topic = topic
             };
 
+            var epoch = Volatile.Read(ref _connectionEpoch);
+
             _pending.Add(topic, @params);
             var id = await RpcSubscribe(topic, @params.Relay);
+
+            // A relay-side subscription belongs to the socket it was made on. If that socket went
+            // away while this call was in flight, recording the answer now would leave the map
+            // claiming a topic the new connection never subscribed to: nothing is delivered on it,
+            // and every local check — including the caller's own idea of what is missing — reports
+            // it as healthy.
+            //
+            // The topic stays pending on purpose: OnSubscribe, which is what normally clears it, did
+            // not run, so leaving it there lets the heartbeat sweep subscribe it again on the
+            // connection that is up. Reported as well, so a caller waiting on this call learns that
+            // it did not take effect rather than holding an id for a subscription nobody has.
+            //
+            // The retry inside RpcSubscribe restarts the transport itself, which raises the epoch,
+            // so a subscribe that survived a timeout lands here too even though the relay accepted
+            // it on the live socket. That costs one duplicate subscription on the relay until the
+            // sweep re-subscribes; keeping a subscription nobody can see costs delivery.
+            if (Volatile.Read(ref _connectionEpoch) != epoch)
+            {
+                _logger.LogError($"Subscription to {topic} was answered after its socket went away; discarding it");
+
+                throw new IOException($"The transport was replaced while subscribing to {topic}.");
+            }
+
             OnSubscribe(id, @params);
             return id;
         }
@@ -355,13 +387,55 @@ namespace Reown.Core.Controllers
 
             if (Subscriptions.Count > 0)
             {
-                throw new InvalidOperationException($"Restoring will override existing data in {Name}.");
+                // The topics are named because this is the only place they can be: the map is
+                // cleared on the way out of the connection, so anything found here arrived after
+                // that and points at a subscription that outlived its socket. Without them the
+                // failure says a restart did not happen but not what stopped it.
+                //
+                // Capped: this message is logged, carried on ResubscribeFailed and may reach a crash
+                // reporter, and an account with a few dozen pairings would otherwise turn one line
+                // into a wall of hashes. The first few plus the count is what makes it findable.
+                const int namedTopicsLimit = 10;
+                var stillInMap = Topics;
+                var named = string.Join(", ", stillInMap.Take(namedTopicsLimit));
+                var rest = stillInMap.Length > namedTopicsLimit
+                    ? $" and {stillInMap.Length - namedTopicsLimit} more"
+                    : string.Empty;
+
+                throw new InvalidOperationException(
+                    $"Restoring will override existing data in {Name}. Still in the map ({stillInMap.Length}): {named}{rest}");
             }
 
             _cached = persisted;
         }
 
+        /// <remarks>
+        ///     async void because the heartbeat calls it: anything escaping lands on the thread pool
+        ///     and takes the process with it. BatchSubscribe handles only TimeoutException, so a
+        ///     transport that cannot connect at all — the ordinary state during an outage, and
+        ///     exactly when there are pending topics to sweep — throws IOException straight through
+        ///     here. Observed on the lab: the process dies on the first heartbeat after the network
+        ///     goes away.
+        /// </remarks>
         protected virtual async void CheckPending()
+        {
+            try
+            {
+                await CheckPendingAsync();
+            }
+            catch (Exception e)
+            {
+                _logger.LogError($"Sweeping the pending subscriptions failed: {e.Message}");
+            }
+        }
+
+        /// <summary>
+        ///     Subscribes whatever is still waiting to be subscribed.
+        /// </summary>
+        /// <remarks>
+        ///     Internal so a test can await the sweep rather than the fire-and-forget wrapper.
+        /// </remarks>
+        internal async Task CheckPendingAsync()
         {
             if (_relayer.TransportExplicitlyClosed)
                 return;
@@ -451,6 +525,10 @@ namespace Reown.Core.Controllers
 
         protected virtual void OnDisable()
         {
+            // Bumped before the map is emptied: anything still waiting on the relay belongs to the
+            // socket being torn down here, and its answer must not put an entry back afterwards.
+            Interlocked.Increment(ref _connectionEpoch);
+
             _cached = Values;
             _subscriptions.Clear();
             _topicMap.Clear();
@@ -667,6 +745,8 @@ namespace Reown.Core.Controllers
         protected virtual async Task BatchSubscribe(PendingSubscription[] subscriptions)
         {
             if (subscriptions.Length == 0) return;
+
+            var epoch = Volatile.Read(ref _connectionEpoch);
             var batches = subscriptions.Batch(BatchSubscribeTopicsLimit);
             foreach (var batch in batches)
             {
@@ -685,6 +765,16 @@ namespace Reown.Core.Controllers
                 {
                     _relayer.TriggerConnectionStalled();
                     continue;
+                }
+
+                // Same rule as in Subscribe: a batch answered after its socket went away describes
+                // subscriptions the current connection does not have. Dropped rather than thrown —
+                // this runs from the restart and from the pending sweep, neither of which has a
+                // caller waiting to hear about it; the topics stay pending and are picked up again.
+                if (Volatile.Read(ref _connectionEpoch) != epoch)
+                {
+                    _logger.LogError($"Batch subscribe to {topics.Length} topic(s) was answered after its socket went away; discarding it");
+                    return;
                 }
 
                 OnBatchSubscribe(result

--- a/src/Reown.Core/Runtime/Controllers/Subscriber.cs
+++ b/src/Reown.Core/Runtime/Controllers/Subscriber.cs
@@ -156,7 +156,11 @@ namespace Reown.Core.Controllers
             {
                 _clientId = await _relayer.CoreClient.Crypto.GetClientId();
 
-                await Restart();
+                // Enabled even when the restart rebuilt nothing, which OnConnect deliberately does
+                // not do. There is nothing cached to protect on a first run, and leaving the flag
+                // down would make every public method on this subscriber throw for the rest of the
+                // process — an app started with no network would never recover.
+                _ = await Restart();
                 RegisterEventListeners();
                 OnEnabled();
             }
@@ -261,14 +265,30 @@ namespace Reown.Core.Controllers
             return false;
         }
         
-        private async Task Restart()
+        /// <summary>
+        ///     Rebuilds the subscriptions this socket is supposed to carry.
+        /// </summary>
+        /// <returns><c>true</c> when they were rebuilt; <c>false</c> when the restart failed.</returns>
+        /// <remarks>
+        ///     Returned rather than read back off <see cref="_restartTask" />: the field is replaced by
+        ///     whichever restart starts last, so a caller reading it after its own await can be told
+        ///     about someone else's restart.
+        /// </remarks>
+        private async Task<bool> Restart()
         {
-            _restartTask = new TaskCompletionSource<bool>();
+            // Held locally as well: the field belongs to whichever restart started last, so
+            // completing through it lets two overlapping restarts complete each other's latch —
+            // and the second SetResult on an already completed one throws out of this method,
+            // leaving both Resubscribed and ResubscribeFailed unraised.
+            var latch = new TaskCompletionSource<bool>();
+            _restartTask = latch;
+
             try
             {
                 await Restore();
                 await Reset();
-                _restartTask.SetResult(true);
+                latch.SetResult(true);
+                return true;
             }
             catch (Exception e)
             {
@@ -276,17 +296,19 @@ namespace Reown.Core.Controllers
                 // without this a failed Restore is completely silent — and a failed Restore means
                 // Reset never ran and this socket carries no relay-side subscriptions at all.
                 _logger.LogError($"Restart failed, subscriptions were not rebuilt: {e.Message}");
-                _restartTask.SetException(e);
+                latch.SetException(e);
 
-                // Nothing awaits _restartTask unless a Subscribe happens to race the restart, so
+                // Nothing awaits the latch unless a Subscribe happens to race the restart, so
                 // without this the failure resurfaces on the finalizer thread.
-                _restartTask.Task.ObserveFault();
+                latch.Task.ObserveFault();
 
                 // Reported rather than passed off as completion. Raising Resubscribed here would
                 // unblock TransportOpen, but it would also present a socket carrying no
                 // subscriptions as a successful open: the reconnect loop exits on Connected and the
                 // client stays deaf until some unrelated disconnect wakes it.
                 ResubscribeFailed?.Invoke(this, e);
+
+                return false;
             }
         }
 
@@ -434,11 +456,41 @@ namespace Reown.Core.Controllers
             _topicMap.Clear();
         }
 
+        /// <remarks>
+        ///     async void because it is an event handler: anything escaping it lands on the thread
+        ///     pool and takes the process with it, so the work lives in an awaitable body and the
+        ///     failure stops here.
+        /// </remarks>
         protected virtual async void OnConnect()
+        {
+            try
+            {
+                await OnConnectAsync();
+            }
+            catch (Exception e)
+            {
+                _logger.LogError($"Handling a connect failed: {e.Message}");
+            }
+        }
+
+        /// <summary>
+        ///     Rebuilds the subscriptions for a socket that just came up.
+        /// </summary>
+        /// <remarks>
+        ///     Internal so a test can await the whole handler instead of guessing how long its
+        ///     continuation needs.
+        /// </remarks>
+        internal async Task OnConnectAsync()
         {
             if (RestartInProgress) return;
 
-            await Restart();
+            // A restart that rebuilt nothing leaves this socket carrying no relay-side
+            // subscriptions, and OnEnabled would drop the cache the next restart rebuilds from.
+            // Unlike Init above there is no client waiting to be made usable here, so the honest
+            // move is to leave the subscriber as it was and let the transport fail the open.
+            if (!await Restart())
+                return;
+
             OnEnabled();
         }
 

--- a/src/Reown.Core/Runtime/Controllers/Subscriber.cs
+++ b/src/Reown.Core/Runtime/Controllers/Subscriber.cs
@@ -262,6 +262,10 @@ namespace Reown.Core.Controllers
             }
             catch (Exception e)
             {
+                // Nothing observes _restartTask unless a Subscribe happens to race the restart, so
+                // without this a failed Restore is completely silent — and a failed Restore means
+                // Reset never ran and this socket carries no relay-side subscriptions at all.
+                _logger.LogError($"Restart failed, subscriptions were not rebuilt: {e.Message}");
                 _restartTask.SetException(e);
             }
         }

--- a/src/Reown.Core/Runtime/Controllers/Subscriber.cs
+++ b/src/Reown.Core/Runtime/Controllers/Subscriber.cs
@@ -8,6 +8,7 @@ using Reown.Core.Common.Logging;
 using Reown.Core.Common.Model.Relay;
 using Reown.Core.Common.Utils;
 using Reown.Core.Interfaces;
+using Reown.Core.Network;
 using Reown.Core.Models.Relay;
 using Reown.Core.Models.Subscriber;
 using Reown.Core.Network.Models;
@@ -44,9 +45,28 @@ namespace Reown.Core.Controllers
         private string _clientId;
 
         /// <summary>
-        ///     Bumped every time the socket goes away, so an answer that outlived its socket
-        ///     can be told apart from one that belongs to the connection in use now.
+        ///     The provider the entries in the map were made on.
         /// </summary>
+        /// <remarks>
+        ///     A relay-side subscription belongs to a connection, so the connection itself is what
+        ///     tells a live entry from a stale one. Watching for the disconnect event instead is not
+        ///     enough: a socket can go away without one being raised, and then nothing clears the
+        ///     map, nothing marks the answers still in flight as stale, and the map goes on claiming
+        ///     topics the new connection never subscribed to. Seen on a device — the map kept
+        ///     growing after the transport had already errored out, Restore refused to run against
+        ///     it, and the wallet reported every topic subscribed while the relay delivered nothing.
+        /// </remarks>
+        private IJsonRpcProvider _mapProvider;
+
+        /// <summary>
+        ///     Bumped every time the socket is reported gone.
+        /// </summary>
+        /// <remarks>
+        ///     Kept alongside the provider because neither signal covers the other. A disconnect
+        ///     without a new provider still invalidates every relay-side subscription, and a
+        ///     provider replaced without a disconnect ever being raised leaves the map claiming
+        ///     topics the new connection never subscribed to. Both were seen on real devices.
+        /// </remarks>
         private int _connectionEpoch;
         private bool _initialized;
         private TaskCompletionSource<bool> _restartTask;
@@ -248,6 +268,7 @@ namespace Reown.Core.Controllers
                 Topic = topic
             };
 
+            var provider = _relayer.Provider;
             var epoch = Volatile.Read(ref _connectionEpoch);
 
             // Indexer, not Add: a subscribe whose answer was discarded leaves its topic here on
@@ -271,11 +292,11 @@ namespace Reown.Core.Controllers
             // connection that is up. Reported as well, so a caller waiting on this call learns that
             // it did not take effect rather than holding an id for a subscription nobody has.
             //
-            // The retry inside RpcSubscribe restarts the transport itself, which raises the epoch,
-            // so a subscribe that survived a timeout lands here too even though the relay accepted
-            // it on the live socket. That costs one duplicate subscription on the relay until the
-            // sweep re-subscribes; keeping a subscription nobody can see costs delivery.
-            if (Volatile.Read(ref _connectionEpoch) != epoch)
+            // The retry inside RpcSubscribe restarts the transport itself, which replaces the
+            // provider, so a subscribe that survived a timeout lands here too even though the relay
+            // accepted it on the live socket. That costs one duplicate subscription on the relay
+            // until the sweep re-subscribes; keeping a subscription nobody can see costs delivery.
+            if (!ReferenceEquals(provider, _relayer.Provider) || Volatile.Read(ref _connectionEpoch) != epoch)
             {
                 _logger.LogError($"Subscription to {topic} was answered after its socket went away; discarding it");
 
@@ -367,6 +388,8 @@ namespace Reown.Core.Controllers
         /// </remarks>
         private async Task<bool> Restart()
         {
+            DiscardMapBuiltOnAnotherProvider();
+
             // Held locally as well: the field belongs to whichever restart started last, so
             // completing through it lets two overlapping restarts complete each other's latch —
             // and the second SetResult on an already completed one throws out of this method,
@@ -436,6 +459,36 @@ namespace Reown.Core.Controllers
         protected virtual async Task SetRelayerSubscriptions(ActiveSubscription[] subscriptions)
         {
             await _relayer.CoreClient.Storage.SetItem(StorageKey, subscriptions);
+        }
+
+        /// <summary>
+        ///     Drops entries that belong to a connection this subscriber no longer has.
+        /// </summary>
+        /// <remarks>
+        ///     Restore refuses to run against a non-empty map, and rightly so — it would overwrite
+        ///     live state. But entries left over from a replaced provider are not live state: the
+        ///     relay has no such subscriptions, and keeping them turns the refusal into a permanent
+        ///     one. Every restart then ends without a batch subscribe, while the map goes on
+        ///     reporting the topics as present, so nothing repairs them and nothing is delivered.
+        /// </remarks>
+        private void DiscardMapBuiltOnAnotherProvider()
+        {
+            ActiveSubscription[] discarded;
+
+            lock (_sync)
+            {
+                if (_subscriptions.Count == 0) return;
+                if (ReferenceEquals(_mapProvider, _relayer.Provider)) return;
+
+                discarded = _subscriptions.Values.ToArray();
+
+                _cached = discarded;
+                _subscriptions.Clear();
+                _topicMap.Clear();
+            }
+
+            _logger.LogError(
+                $"Dropped {discarded.Length} subscription(s) recorded on a connection that has been replaced");
         }
 
         protected virtual async Task Restore()
@@ -590,7 +643,7 @@ namespace Reown.Core.Controllers
 
         protected virtual void OnDisable()
         {
-            // Bumped before the map is emptied: anything still waiting on the relay belongs to the
+            // Raised before the map is emptied: anything still waiting on the relay belongs to the
             // socket being torn down here, and its answer must not put an entry back afterwards.
             Interlocked.Increment(ref _connectionEpoch);
 
@@ -712,6 +765,8 @@ namespace Reown.Core.Controllers
         {
             lock (_sync)
             {
+                _mapProvider = _relayer.Provider;
+
                 _subscriptions.Remove(id);
 
                 _subscriptions.Add(id, subscription);
@@ -846,6 +901,7 @@ namespace Reown.Core.Controllers
         {
             if (subscriptions.Length == 0) return;
 
+            var provider = _relayer.Provider;
             var epoch = Volatile.Read(ref _connectionEpoch);
             var batches = subscriptions.Batch(BatchSubscribeTopicsLimit);
             foreach (var batch in batches)
@@ -871,7 +927,7 @@ namespace Reown.Core.Controllers
                 // subscriptions the current connection does not have. Dropped rather than thrown —
                 // this runs from the restart and from the pending sweep, neither of which has a
                 // caller waiting to hear about it; the topics stay pending and are picked up again.
-                if (Volatile.Read(ref _connectionEpoch) != epoch)
+                if (!ReferenceEquals(provider, _relayer.Provider) || Volatile.Read(ref _connectionEpoch) != epoch)
                 {
                     _logger.LogError($"Batch subscribe to {topics.Length} topic(s) was answered after its socket went away; discarding it");
                     return;

--- a/src/Reown.Core/Runtime/Controllers/Subscriber.cs
+++ b/src/Reown.Core/Runtime/Controllers/Subscriber.cs
@@ -28,6 +28,18 @@ namespace Reown.Core.Controllers
         private readonly Dictionary<string, ActiveSubscription> _subscriptions = new();
 
         private readonly TopicMap _topicMap = new();
+
+        /// <summary>
+        ///     Guards the three collections below.
+        /// </summary>
+        /// <remarks>
+        ///     They are reached from two directions at once: the heartbeat sweeps the pending set
+        ///     while application threads subscribe and unsubscribe, and the relayer's own events
+        ///     clear the map from the thread pool. Enumerating a Dictionary being written to throws,
+        ///     and two concurrent writes corrupt it outright. Events are raised outside the lock —
+        ///     handlers persist the whole set and are free to call back in.
+        /// </remarks>
+        private readonly object _sync = new();
         private ActiveSubscription[] _cached = Array.Empty<ActiveSubscription>();
         private string _clientId;
 
@@ -73,9 +85,19 @@ namespace Reown.Core.Controllers
         /// <summary>
         ///     A dictionary of active subscriptions where the key is the id of the Subscription
         /// </summary>
+        /// <remarks>
+        ///     A snapshot, not the live map: handing out the dictionary itself lets a caller
+        ///     enumerate it while the relayer's events are clearing it.
+        /// </remarks>
         public IReadOnlyDictionary<string, ActiveSubscription> Subscriptions
         {
-            get => _subscriptions;
+            get
+            {
+                lock (_sync)
+                {
+                    return new Dictionary<string, ActiveSubscription>(_subscriptions);
+                }
+            }
         }
 
         /// <summary>
@@ -107,7 +129,13 @@ namespace Reown.Core.Controllers
         /// </summary>
         public int Length
         {
-            get => _subscriptions.Count;
+            get
+            {
+                lock (_sync)
+                {
+                    return _subscriptions.Count;
+                }
+            }
         }
 
         /// <summary>
@@ -115,7 +143,13 @@ namespace Reown.Core.Controllers
         /// </summary>
         public string[] Ids
         {
-            get => _subscriptions.Keys.ToArray();
+            get
+            {
+                lock (_sync)
+                {
+                    return _subscriptions.Keys.ToArray();
+                }
+            }
         }
 
         /// <summary>
@@ -123,7 +157,13 @@ namespace Reown.Core.Controllers
         /// </summary>
         public ActiveSubscription[] Values
         {
-            get => _subscriptions.Values.ToArray();
+            get
+            {
+                lock (_sync)
+                {
+                    return _subscriptions.Values.ToArray();
+                }
+            }
         }
 
         /// <summary>
@@ -131,7 +171,13 @@ namespace Reown.Core.Controllers
         /// </summary>
         public string[] Topics
         {
-            get => _topicMap.Topics;
+            get
+            {
+                lock (_sync)
+                {
+                    return _topicMap.Topics;
+                }
+            }
         }
 
         public event EventHandler Sync;
@@ -204,7 +250,14 @@ namespace Reown.Core.Controllers
 
             var epoch = Volatile.Read(ref _connectionEpoch);
 
-            _pending.Add(topic, @params);
+            // Indexer, not Add: a subscribe whose answer was discarded leaves its topic here on
+            // purpose, and the retry that follows would otherwise throw on the duplicate key —
+            // failing exactly the call the entry was kept for.
+            lock (_sync)
+            {
+                _pending[topic] = @params;
+            }
+
             var id = await RpcSubscribe(topic, @params.Relay);
 
             // A relay-side subscription belongs to the socket it was made on. If that socket went
@@ -275,7 +328,13 @@ namespace Reown.Core.Controllers
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    if (!_pending.ContainsKey(topic) && Topics.Contains(topic))
+                    bool settled;
+                    lock (_sync)
+                    {
+                        settled = !_pending.ContainsKey(topic) && _topicMap.Topics.Contains(topic);
+                    }
+
+                    if (settled)
                     {
                         return true;
                     }
@@ -385,7 +444,7 @@ namespace Reown.Core.Controllers
 
             if (persisted.Length == 0) return;
 
-            if (Subscriptions.Count > 0)
+            if (Length > 0)
             {
                 // The topics are named because this is the only place they can be: the map is
                 // cleared on the way out of the connection, so anything found here arrived after
@@ -440,7 +499,13 @@ namespace Reown.Core.Controllers
             if (_relayer.TransportExplicitlyClosed)
                 return;
 
-            await BatchSubscribe(_pending.Values.ToArray());
+            PendingSubscription[] pending;
+            lock (_sync)
+            {
+                pending = _pending.Values.ToArray();
+            }
+
+            await BatchSubscribe(pending);
         }
 
         protected virtual async Task Reset()
@@ -529,9 +594,12 @@ namespace Reown.Core.Controllers
             // socket being torn down here, and its answer must not put an entry back afterwards.
             Interlocked.Increment(ref _connectionEpoch);
 
-            _cached = Values;
-            _subscriptions.Clear();
-            _topicMap.Clear();
+            lock (_sync)
+            {
+                _cached = _subscriptions.Values.ToArray();
+                _subscriptions.Clear();
+                _topicMap.Clear();
+            }
         }
 
         /// <remarks>
@@ -588,7 +656,10 @@ namespace Reown.Core.Controllers
                 Topic = @params.Topic
             });
 
-            _ = _pending.Remove(@params.Topic);
+            lock (_sync)
+            {
+                _ = _pending.Remove(@params.Topic);
+            }
         }
 
         protected virtual void OnResubscribe(string id, PendingSubscription @params)
@@ -600,7 +671,10 @@ namespace Reown.Core.Controllers
                 Topic = @params.Topic
             });
 
-            _ = _pending.Remove(@params.Topic);
+            lock (_sync)
+            {
+                _ = _pending.Remove(@params.Topic);
+            }
         }
 
         protected virtual async Task OnUnsubscribe(string topic, string id, Error reason)
@@ -616,19 +690,36 @@ namespace Reown.Core.Controllers
             await _relayer.Messages.Delete(topic);
         }
 
+        /// <remarks>
+        ///     The check and the write are deliberately not one atomic step: making them so would
+        ///     mean either calling the overridable AddSubscription while holding the lock — and with
+        ///     it raising Created, whose handlers write back through this class — or bypassing that
+        ///     override entirely and quietly changing what a subclass sees. Two callers racing here
+        ///     end up recording the same subscription twice, which AddSubscription tolerates and
+        ///     which was equally possible before the lock existed.
+        /// </remarks>
         protected virtual void SetSubscription(string id, ActiveSubscription subscription)
         {
-            if (_subscriptions.ContainsKey(id)) return;
+            lock (_sync)
+            {
+                if (_subscriptions.ContainsKey(id)) return;
+            }
 
             AddSubscription(id, subscription);
         }
 
         protected virtual void AddSubscription(string id, ActiveSubscription subscription)
         {
-            _subscriptions.Remove(id);
+            lock (_sync)
+            {
+                _subscriptions.Remove(id);
 
-            _subscriptions.Add(id, subscription);
-            _topicMap.Set(subscription.Topic, id);
+                _subscriptions.Add(id, subscription);
+                _topicMap.Set(subscription.Topic, id);
+            }
+
+            // Outside the lock: handlers persist the whole set, which reads back through the
+            // properties above.
             Created?.Invoke(this, subscription);
         }
 
@@ -654,9 +745,15 @@ namespace Reown.Core.Controllers
 
         protected virtual void DeleteSubscription(string id, Error reason)
         {
-            var subscription = GetSubscription(id);
-            _subscriptions.Remove(id);
-            _topicMap.Delete(subscription.Topic, id);
+            ActiveSubscription subscription;
+
+            lock (_sync)
+            {
+                subscription = GetSubscription(id);
+                _subscriptions.Remove(id);
+                _topicMap.Delete(subscription.Topic, id);
+            }
+
             Deleted?.Invoke(this,
                 new DeletedSubscription
                 {
@@ -688,12 +785,15 @@ namespace Reown.Core.Controllers
 
         protected virtual ActiveSubscription GetSubscription(string id)
         {
-            if (!_subscriptions.TryGetValue(id, out var subscription))
+            lock (_sync)
             {
-                throw new KeyNotFoundException($"No subscription found with id: {id}.");
-            }
+                if (!_subscriptions.TryGetValue(id, out var subscription))
+                {
+                    throw new KeyNotFoundException($"No subscription found with id: {id}.");
+                }
 
-            return subscription;
+                return subscription;
+            }
         }
 
         protected virtual bool HasSubscription(string id, string topic)

--- a/src/Reown.Core/Runtime/Controllers/TopicMap.cs
+++ b/src/Reown.Core/Runtime/Controllers/TopicMap.cs
@@ -13,11 +13,28 @@ namespace Reown.Core.Controllers
         private readonly Dictionary<string, List<string>> _topicMap = new();
 
         /// <summary>
+        ///     Guards the map.
+        /// </summary>
+        /// <remarks>
+        ///     Held here rather than left to the owner because this object is handed out through
+        ///     <c>Subscriber.TopicMap</c>: a reader outside the subscriber cannot take the
+        ///     subscriber's lock, and enumerating this map while the relayer's events clear it
+        ///     throws. The lists are never handed out either — every accessor copies.
+        /// </remarks>
+        private readonly object _sync = new();
+
+        /// <summary>
         ///     An array of topics in this mapping
         /// </summary>
         public string[] Topics
         {
-            get => _topicMap.Keys.ToArray();
+            get
+            {
+                lock (_sync)
+                {
+                    return _topicMap.Keys.ToArray();
+                }
+            }
         }
 
         /// <summary>
@@ -27,13 +44,16 @@ namespace Reown.Core.Controllers
         /// <param name="id">The subscription id to add</param>
         public void Set(string topic, string id)
         {
-            if (Exists(topic, id)) return;
+            lock (_sync)
+            {
+                if (ExistsUnsafe(topic, id)) return;
 
-            if (!_topicMap.ContainsKey(topic))
-                _topicMap.Add(topic, new List<string>());
+                if (!_topicMap.ContainsKey(topic))
+                    _topicMap.Add(topic, new List<string>());
 
-            var ids = _topicMap[topic];
-            ids.Add(id);
+                var ids = _topicMap[topic];
+                ids.Add(id);
+            }
         }
 
         /// <summary>
@@ -43,10 +63,13 @@ namespace Reown.Core.Controllers
         /// <returns>An array of subscription ids in a given topic</returns>
         public string[] Get(string topic)
         {
-            if (!_topicMap.ContainsKey(topic))
-                return Array.Empty<string>();
+            lock (_sync)
+            {
+                if (!_topicMap.ContainsKey(topic))
+                    return Array.Empty<string>();
 
-            return _topicMap[topic].ToArray();
+                return _topicMap[topic].ToArray();
+            }
         }
 
         /// <summary>
@@ -57,8 +80,21 @@ namespace Reown.Core.Controllers
         /// <returns>True if the subscription id is in the topic, false otherwise</returns>
         public bool Exists(string topic, string id)
         {
-            var ids = Get(topic);
-            return ids.Contains(id);
+            lock (_sync)
+            {
+                return ExistsUnsafe(topic, id);
+            }
+        }
+
+        /// <summary>
+        ///     Determines whether a subscription id exists in a given topic. Callers hold the lock.
+        /// </summary>
+        /// <param name="topic">The topic to check in</param>
+        /// <param name="id">The subscription id to check for</param>
+        /// <returns>True if the subscription id is in the topic, false otherwise</returns>
+        private bool ExistsUnsafe(string topic, string id)
+        {
+            return _topicMap.TryGetValue(topic, out var ids) && ids.Contains(id);
         }
 
         /// <summary>
@@ -69,21 +105,24 @@ namespace Reown.Core.Controllers
         /// <param name="id">The subscription id to remove, if set to null then all ids are removed from the topic</param>
         public void Delete(string topic, string id = null)
         {
-            if (!_topicMap.TryGetValue(topic, out var ids))
+            lock (_sync)
             {
-                return;
-            }
+                if (!_topicMap.TryGetValue(topic, out var ids))
+                {
+                    return;
+                }
 
-            if (id == null)
-            {
-                _topicMap.Remove(topic);
-            }
-            else
-            {
-                ids.Remove(id);
-                if (ids.Count == 0)
+                if (id == null)
                 {
                     _topicMap.Remove(topic);
+                }
+                else
+                {
+                    ids.Remove(id);
+                    if (ids.Count == 0)
+                    {
+                        _topicMap.Remove(topic);
+                    }
                 }
             }
         }
@@ -93,7 +132,10 @@ namespace Reown.Core.Controllers
         /// </summary>
         public void Clear()
         {
-            _topicMap.Clear();
+            lock (_sync)
+            {
+                _topicMap.Clear();
+            }
         }
     }
 }

--- a/src/Reown.Sign/Runtime/SignClient.cs
+++ b/src/Reown.Sign/Runtime/SignClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Reown.Sign/Runtime/SignClient.cs
+++ b/src/Reown.Sign/Runtime/SignClient.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -85,7 +85,14 @@ namespace Reown.Sign
             }
 
 #if !UNITY_2021_1_OR_NEWER
-            options.ConnectionBuilder ??= new Reown.Core.Network.Websocket.WebsocketConnectionBuilder();
+            // OpenTimeout has to track ConnectionTimeout. The relayer stops waiting at
+            // ConnectionTimeout but does not cancel the socket underneath, so a longer socket window
+            // keeps Connecting raised for the difference — and RestartTransport returns on its first
+            // line while Connecting is raised, which silently suppresses reconnects for that stretch.
+            options.ConnectionBuilder ??= new Reown.Core.Network.Websocket.WebsocketConnectionBuilder
+            {
+                OpenTimeout = options.ConnectionTimeout
+            };
 #endif
 
             CoreClient = options.CoreClient ?? new CoreClient(options);

--- a/test/Reown.Core.Common.Test/WithTimeoutTests.cs
+++ b/test/Reown.Core.Common.Test/WithTimeoutTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Reown.Core.Common.Utils;
+using Xunit;
+
+namespace Reown.Core.Common.Test
+{
+    /// <summary>
+    ///     Tests that <c>WithTimeout</c> reports the outcome of the task it wraps.
+    /// </summary>
+    /// <remarks>
+    ///     It used to check only which task <c>WhenAny</c> returned. The non-generic overloads then
+    ///     returned without observing the task, so a failure vanished and an instant failure looked
+    ///     like success; the generic ones read <c>.Result</c>, which re-wrapped the failure in an
+    ///     <see cref="AggregateException" /> that callers could not match on.
+    /// </remarks>
+    public class WithTimeoutTests
+    {
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task NonGeneric_propagates_the_original_exception()
+        {
+            Task faulted = Task.FromException(new IOException("boom"));
+
+            IOException error = await Assert.ThrowsAsync<IOException>(
+                () => faulted.WithTimeout(TimeSpan.FromSeconds(2), "transport close stalled"));
+
+            Assert.Equal("boom", error.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task Generic_propagates_the_original_exception_unwrapped()
+        {
+            // WhenAll over Task<T> yields Task<T[]>, which binds to the generic overload — the shape
+            // TransportOpen relies on to recognise its own timeout by message.
+            var first = new TaskCompletionSource<bool>();
+            var second = new TaskCompletionSource<bool>();
+            Task<bool[]> whenAll = Task.WhenAll(first.Task, second.Task);
+
+            first.TrySetException(new TimeoutException("socket stalled"));
+            second.TrySetException(new TimeoutException("socket stalled"));
+
+            TimeoutException error = await Assert.ThrowsAsync<TimeoutException>(
+                () => whenAll.WithTimeout(TimeSpan.FromSeconds(5), "socket stalled"));
+
+            Assert.Equal("socket stalled", error.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_task_that_fails_instantly_does_not_wait_out_the_timeout()
+        {
+            // The reason a failed connect used to cost a full attempt window instead of milliseconds.
+            Task faulted = Task.FromException(new InvalidOperationException("no network"));
+            DateTime started = DateTime.UtcNow;
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => faulted.WithTimeout(TimeSpan.FromSeconds(30), "socket stalled"));
+
+            Assert.True(DateTime.UtcNow - started < TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task Timeout_still_wins_when_the_task_never_completes()
+        {
+            Task never = new TaskCompletionSource<bool>().Task;
+
+            TimeoutException error = await Assert.ThrowsAsync<TimeoutException>(
+                () => never.WithTimeout(TimeSpan.FromMilliseconds(50), "socket stalled"));
+
+            Assert.Equal("socket stalled", error.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task Successful_results_are_returned_unchanged()
+        {
+            Assert.Equal(42, await Task.FromResult(42).WithTimeout(TimeSpan.FromSeconds(5)));
+            await Task.CompletedTask.WithTimeout(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(7, await Task.FromResult(7).WithTimeout(5000));
+            await Task.CompletedTask.WithTimeout(5000);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task Cancellation_surfaces_as_cancellation_not_as_a_timeout()
+        {
+            Task cancelled = Task.FromCanceled(new System.Threading.CancellationToken(true));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => cancelled.WithTimeout(TimeSpan.FromSeconds(5), "socket stalled"));
+        }
+    }
+}

--- a/test/Reown.Core.Common.Test/WithTimeoutTests.cs
+++ b/test/Reown.Core.Common.Test/WithTimeoutTests.cs
@@ -39,13 +39,18 @@ namespace Reown.Core.Common.Test
             var second = new TaskCompletionSource<bool>();
             Task<bool[]> whenAll = Task.WhenAll(first.Task, second.Task);
 
-            first.TrySetException(new TimeoutException("socket stalled"));
-            second.TrySetException(new TimeoutException("socket stalled"));
+            // Deliberately not the wrapper's own message: giving both the same text lets an
+            // implementation that swallows the fault and waits out its timeout pass on the strength
+            // of a TimeoutException it raised itself.
+            first.TrySetException(new TimeoutException("the socket underneath died"));
+            second.TrySetException(new TimeoutException("the socket underneath died"));
 
+            var started = DateTime.UtcNow;
             TimeoutException error = await Assert.ThrowsAsync<TimeoutException>(
                 () => whenAll.WithTimeout(TimeSpan.FromSeconds(5), "socket stalled"));
 
-            Assert.Equal("socket stalled", error.Message);
+            Assert.Equal("the socket underneath died", error.Message);
+            Assert.True(DateTime.UtcNow - started < TimeSpan.FromSeconds(4), "the fault was waited out, not propagated");
         }
 
         [Fact]

--- a/test/Reown.Core.Common.Test/WithTimeoutTests.cs
+++ b/test/Reown.Core.Common.Test/WithTimeoutTests.cs
@@ -76,6 +76,48 @@ namespace Reown.Core.Common.Test
 
         [Fact]
         [Trait("Category", "unit")]
+        public async Task A_timed_out_task_that_fails_later_does_not_resurface_on_the_finalizer()
+        {
+            // The task outlives the wait: the socket it belongs to can still fail seconds later, and
+            // with nobody left to observe it the exception comes back as an UnobservedTaskException.
+            var unobserved = 0;
+            void OnUnobserved(object sender, UnobservedTaskExceptionEventArgs e)
+            {
+                unobserved++;
+                e.SetObserved();
+            }
+
+            TaskScheduler.UnobservedTaskException += OnUnobserved;
+            try
+            {
+                await FaultAfterTimeout();
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                await Task.Delay(200);
+
+                Assert.Equal(0, unobserved);
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= OnUnobserved;
+            }
+
+            // Kept in its own frame so the task becomes unreachable before the collection above.
+            static async Task FaultAfterTimeout()
+            {
+                var source = new TaskCompletionSource<bool>();
+
+                await Assert.ThrowsAsync<TimeoutException>(
+                    () => source.Task.WithTimeout(TimeSpan.FromMilliseconds(50), "socket stalled"));
+
+                source.TrySetException(new IOException("Unavailable WS RPC url"));
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
         public async Task Successful_results_are_returned_unchanged()
         {
             Assert.Equal(42, await Task.FromResult(42).WithTimeout(TimeSpan.FromSeconds(5)));

--- a/test/Reown.Core.Network.Test/RelayerRecoveryTests.cs
+++ b/test/Reown.Core.Network.Test/RelayerRecoveryTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Reflection;
 using System.Threading;
@@ -132,6 +132,20 @@ namespace Reown.Core.Network.Test
             Assert.Same(restart, finished);
             var error = await Assert.ThrowsAsync<InvalidOperationException>(() => restart);
             Assert.Equal("storage unavailable", error.Message);
+
+            // The backoff loop is still retrying, and every attempt holds Connected true between
+            // the connect and the close that follows its failed resubscribe. Reading Connected
+            // without this lands in that window sooner or later — the same guard the sibling test
+            // uses, for the same reason.
+            relayer.FailOpensUntil = relayer.OpenAttempts + 100;
+
+            // An attempt that started before that flag was set can still be inside its window, so
+            // give it a moment to close rather than reading the state mid-attempt.
+            var settledBy = DateTime.UtcNow.AddSeconds(5);
+            while (relayer.Connected && DateTime.UtcNow < settledBy)
+            {
+                await Task.Delay(10);
+            }
 
             // The open failed, so the socket it left behind has to go with it: leaving it up lets
             // the next caller read Connected and conclude there is nothing to restart.
@@ -279,13 +293,19 @@ namespace Reown.Core.Network.Test
             var relayer = new TestRelayer();
             await relayer.Init();
 
+            // Measured against what the relayer keeps for itself rather than against zero: it holds
+            // one permanent listener on Resubscribed to know which connection the subscriber has
+            // replayed onto. The leak this test is about is growth per reconnect, not the baseline.
+            var resubscribedBaseline = HandlerCount(relayer.Subscriber, "Resubscribed");
+            var failedBaseline = HandlerCount(relayer.Subscriber, "ResubscribeFailed");
+
             for (var i = 0; i < 3; i++)
             {
                 await relayer.RestartTransport();
             }
 
-            Assert.Equal(0, HandlerCount(relayer.Subscriber, "Resubscribed"));
-            Assert.Equal(0, HandlerCount(relayer.Subscriber, "ResubscribeFailed"));
+            Assert.Equal(resubscribedBaseline, HandlerCount(relayer.Subscriber, "Resubscribed"));
+            Assert.Equal(failedBaseline, HandlerCount(relayer.Subscriber, "ResubscribeFailed"));
 
             relayer.Dispose();
         }
@@ -475,6 +495,75 @@ namespace Reown.Core.Network.Test
             Assert.Equal(0, relayer.OpenAttempts);
         }
 
+        /// <summary>
+        ///     A transport that came up through Init counts as carrying its subscriptions.
+        /// </summary>
+        /// <remarks>
+        ///     Init registers the listeners after Subscriber.Init has already run, so the replay
+        ///     that happens on the way up is never heard. Deriving the answer from what was heard
+        ///     leaves a freshly opened, fully subscribed transport looking unrecovered, and the
+        ///     first pass of the reconnect loop then tears down a healthy socket.
+        /// </remarks>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_transport_opened_by_init_counts_as_replayed()
+        {
+            var relayer = new TestRelayer();
+            await relayer.Init();
+
+            Assert.True(relayer.Connected, "the transport should be up after Init");
+            Assert.True(relayer.Replayed, "a transport opened by Init must not be treated as unrecovered");
+
+            relayer.Dispose();
+        }
+
+        /// <summary>
+        ///     A socket that came back on its own does not end the reconnect loop.
+        /// </summary>
+        /// <remarks>
+        ///     WebsocketConnection.SendRequest re-registers the transport in place when it finds
+        ///     none. That path raises Opened rather than the provider's Connected, so the subscriber
+        ///     never replays — and because the provider object is unchanged, anything comparing it
+        ///     against the one last replayed onto would call this recovered and let the loop exit
+        ///     over an empty topic map.
+        /// </remarks>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_socket_that_came_back_without_a_replay_is_not_treated_as_recovered()
+        {
+            var relayer = new TestRelayer();
+            await relayer.Init();
+
+            // A replay onto the provider that is current now, so a check comparing the two would
+            // hold — this is the state the loop is actually in when a socket drops mid-session.
+            await relayer.RestartTransport();
+            Assert.True(relayer.Replayed, "the restart should have replayed the subscriptions");
+
+            var atBuild = new TaskCompletionSource<bool>();
+            var release = new TaskCompletionSource<bool>();
+            relayer.WhileBuildingConnection = async () =>
+            {
+                // Held before CreateProvider assigns the new provider, so the identity the check
+                // would compare is still the one that was replayed onto.
+                relayer.Connection.IsConnected = true;
+                atBuild.TrySetResult(true);
+                await release.Task;
+            };
+
+            relayer.Connection.IsConnected = true;
+            relayer.Connection.RaiseClosed();
+
+            var reached = await Task.WhenAny(atBuild.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.Same(atBuild.Task, reached);
+
+            Assert.True(relayer.Connected, "the socket is up in this window");
+            Assert.False(relayer.Replayed,
+                "a live socket with no replay behind it was reported as carrying its subscriptions");
+
+            release.TrySetResult(true);
+            relayer.Dispose();
+        }
+
         private sealed class TestRelayer : Relayer
         {
             public readonly FakeConnection Connection = new FakeConnection();
@@ -493,6 +582,11 @@ namespace Reown.Core.Network.Test
             public ICoreClient Core
             {
                 get => CoreClient;
+            }
+
+            public bool Replayed
+            {
+                get => ConnectedAndReplayed;
             }
 
             public static readonly TimeSpan CloseTimeout = TimeSpan.FromMilliseconds(500);

--- a/test/Reown.Core.Network.Test/RelayerRecoveryTests.cs
+++ b/test/Reown.Core.Network.Test/RelayerRecoveryTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using NSubstitute;
@@ -28,21 +30,26 @@ namespace Reown.Core.Network.Test
             // TransportOpen, so two callers arriving together both passed it, both replaced the
             // provider, and one returned without clearing a flag it never took.
             var relayer = new TestRelayer();
-            await relayer.EstablishProvider();
+            await relayer.Init();
+
+            // Both callers have to arrive while the close is still running — that is the window the
+            // old guard leaves open, because _reconnecting is not raised until TransportOpen. Holding
+            // the close is the only way to stand in it: parking inside the open instead puts the
+            // second caller behind the old guard, and the test passes with the latch removed.
+            relayer.Connection.HoldClose = new TaskCompletionSource<bool>();
 
             var before = relayer.ConnectionsBuilt;
-            relayer.HoldOpen = new TaskCompletionSource<bool>();
-
             var first = relayer.RestartTransport();
-            await relayer.OpenStarted.Task;
+            await relayer.Connection.CloseStarted.Task;
 
             await relayer.RestartTransport();
-            Assert.False(first.IsCompleted);
 
-            relayer.HoldOpen.TrySetResult(true);
+            relayer.Connection.HoldClose.TrySetResult(true);
             await first;
 
             Assert.Equal(before + 1, relayer.ConnectionsBuilt);
+
+            relayer.Dispose();
         }
 
         [Fact]
@@ -72,17 +79,272 @@ namespace Reown.Core.Network.Test
         {
             // The compensating event must not double up: a second OnDisable would cache an already
             // empty map, leaving Reset with nothing to resubscribe.
+            // Through Init, not EstablishProvider: a provider built over a connection that is not up
+            // yet never registers its listeners, so Closed does not reach Disconnected and the close
+            // is not reported at all — the restart then takes the abandoned path and this test
+            // measures its neighbour instead of the path it names.
             var relayer = new TestRelayer();
-            await relayer.EstablishProvider();
-
-            relayer.Connection.IsConnected = true;
+            await relayer.Init();
 
             var disconnects = 0;
-            relayer.OnDisconnected += (_, _) => Interlocked.Increment(ref disconnects);
+            var reportedAt = DateTime.MaxValue;
+            relayer.OnDisconnected += (_, _) =>
+            {
+                Interlocked.Increment(ref disconnects);
+                reportedAt = DateTime.UtcNow;
+            };
 
+            var started = DateTime.UtcNow;
             await relayer.RestartTransport();
 
+            // Only the close phase, not the whole restart: the reopen that follows has no bearing on
+            // whether the close reported itself, and timing the two together turns a slow machine
+            // into a failure.
+            var elapsed = reportedAt - started;
+
             Assert.Equal(1, disconnects);
+
+            // What separates this test from its neighbour: a close that is reported returns as soon
+            // as Disconnected arrives, while an abandoned one always costs the full timeout. Without
+            // this the two tests measure the same path.
+            Assert.True(elapsed < TestRelayer.CloseTimeout, $"the close was not reported, it was waited out ({elapsed})");
+
+            relayer.Dispose();
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_resubscription_that_fails_fails_the_open()
+        {
+            // The socket comes up and carries nothing. Before this, the open waited for a
+            // Resubscribed that could no longer arrive — the whole ResubscribeBudget, three
+            // minutes, with _reconnecting raised the entire time, and every restart arriving in
+            // that window returning on its first line.
+            var relayer = new TestRelayer();
+            await relayer.Init();
+
+            relayer.Core.Storage.HasItem(Arg.Any<string>())
+                .Returns(_ => Task.FromException<bool>(new InvalidOperationException("storage unavailable")));
+
+            var restart = relayer.RestartTransport();
+            var finished = await Task.WhenAny(restart, Task.Delay(TimeSpan.FromSeconds(10)));
+
+            Assert.Same(restart, finished);
+            var error = await Assert.ThrowsAsync<InvalidOperationException>(() => restart);
+            Assert.Equal("storage unavailable", error.Message);
+
+            // The open failed, so the socket it left behind has to go with it: leaving it up lets
+            // the next caller read Connected and conclude there is nothing to restart.
+            Assert.False(relayer.Connected);
+
+            // That close is what the backoff loop watches, and storage keeps failing, so the loop
+            // would go on retrying for the lifetime of the test process.
+            relayer.Dispose();
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_close_that_was_abandoned_does_not_report_itself_later()
+        {
+            // The close is given up on, the reopen goes ahead, and only then does the old socket
+            // finally finish closing. That report used to land on the transport that replaced it:
+            // RejectTransportOpen is listening, and it tears down the healthy connection.
+            var relayer = new TestRelayer();
+            await relayer.Init();
+
+            relayer.Connection.HoldClose = new TaskCompletionSource<bool>();
+            relayer.HoldOpen = new TaskCompletionSource<bool>();
+
+            var restart = relayer.RestartTransport();
+
+            // The reopen is under way: the abandoned close is now racing a live connect.
+            var reopenBy = DateTime.UtcNow.AddSeconds(5);
+            while (relayer.OpenAttempts < 2 && DateTime.UtcNow < reopenBy)
+            {
+                await Task.Delay(10);
+            }
+
+            Assert.True(relayer.OpenAttempts >= 2, "the reopen never started");
+
+            relayer.Connection.HoldClose.TrySetResult(true);
+            await Task.Delay(50);
+            relayer.HoldOpen.TrySetResult(true);
+
+            var finished = await Task.WhenAny(restart, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.Same(restart, finished);
+            await restart;
+            Assert.True(relayer.Connected);
+
+            relayer.Dispose();
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_resubscription_that_never_reports_does_not_leave_the_socket_up()
+        {
+            // The connect succeeded and the replay said nothing either way. Timing out used to be
+            // swallowed as success with the socket still up — connected, carrying no subscriptions,
+            // and with every reconnect loop stopping on Connected, so nothing retried.
+            var relayer = new TestRelayer();
+            await relayer.Init();
+
+            var neverReports = new TaskCompletionSource<bool>();
+            relayer.Core.Storage.HasItem(Arg.Any<string>()).Returns(_ => neverReports.Task);
+
+            var attemptsBefore = relayer.OpenAttempts;
+
+            var restart = relayer.RestartTransport();
+
+            // The close this failure performs is a disconnect, so a reconnect loop starts behind the
+            // assertion and would put the socket back up within its initial delay. Letting later
+            // attempts fail at the connect keeps the state being asserted from moving under it.
+            var connectedBy = DateTime.UtcNow.AddSeconds(5);
+            while (relayer.OpenAttempts == attemptsBefore && DateTime.UtcNow < connectedBy)
+            {
+                await Task.Delay(10);
+            }
+
+            relayer.FailOpensUntil = relayer.OpenAttempts + 100;
+
+            var finished = await Task.WhenAny(restart, Task.Delay(TimeSpan.FromSeconds(10)));
+
+            Assert.Same(restart, finished);
+            await restart;
+
+            Assert.False(relayer.Connected);
+
+            relayer.Dispose();
+            neverReports.TrySetResult(false);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task Repeated_disconnects_run_one_reconnect_loop()
+        {
+            // Each failed open closes the socket it opened, and that close arrives back here as a
+            // disconnect. Without a latch every failure started its own loop: the earlier ones never
+            // exit, they only stop on Connected, and each newcomer restarts the delay at its initial
+            // value, so the backoff flattens into a steady stream of attempts.
+            var relayer = new TestRelayer();
+            await relayer.Init();
+
+            // Every attempt from here connects and then fails to replay, so each one closes the
+            // socket it just opened — which is the disconnect that arrives back here.
+            relayer.Core.Storage.HasItem(Arg.Any<string>())
+                .Returns(_ => Task.FromException<bool>(new InvalidOperationException("storage unavailable")));
+
+            var before = relayer.ReconnectLoopsStarted;
+            var attemptsBefore = relayer.OpenAttempts;
+
+            relayer.Connection.RaiseClosed();
+
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (relayer.OpenAttempts < attemptsBefore + 4 && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(10);
+            }
+
+            Assert.True(relayer.OpenAttempts >= attemptsBefore + 4, "the retries never got going");
+            Assert.Equal(before + 1, relayer.ReconnectLoopsStarted);
+
+            relayer.Dispose();
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task Closing_a_transport_that_is_already_down_still_stops_the_reconnects()
+        {
+            // The flag means "do not reconnect", and the state a caller most needs it in is the one
+            // where the transport is already down and the loop is working to bring it back. Gating it
+            // on Connected made this call a no-op in exactly that state.
+            var relayer = new TestRelayer();
+            await relayer.Init();
+
+            relayer.Connection.IsConnected = false;
+
+            await relayer.TransportClose();
+
+            Assert.True(relayer.TransportExplicitlyClosed);
+
+            relayer.Dispose();
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_finished_open_leaves_no_listeners_behind()
+        {
+            // Exactly one of the two outcomes fires, and ListenOnce only detaches the handler whose
+            // event did. The other stayed subscribed for good — one more on every reconnect, for the
+            // life of the process.
+            var relayer = new TestRelayer();
+            await relayer.Init();
+
+            for (var i = 0; i < 3; i++)
+            {
+                await relayer.RestartTransport();
+            }
+
+            Assert.Equal(0, HandlerCount(relayer.Subscriber, "Resubscribed"));
+            Assert.Equal(0, HandlerCount(relayer.Subscriber, "ResubscribeFailed"));
+
+            relayer.Dispose();
+        }
+
+        private static int HandlerCount(object target, string eventName)
+        {
+            var field = target.GetType().GetField(eventName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+
+            var handlers = (Delegate)field.GetValue(target);
+            return handlers?.GetInvocationList().Length ?? 0;
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_disconnect_arriving_as_the_loop_leaves_still_gets_a_loop()
+        {
+            // The latch turns a disconnect that arrives in the loop's last moments into nothing at
+            // all: it finds the latch taken, returns, and the loop it deferred to then exits. Losing
+            // that wakeup is worse than the duplicate loops the latch removes — the transport stays
+            // down with nothing watching it.
+            var relayer = new TestRelayer();
+            await relayer.Init();
+
+            // The reconnect will succeed, and the socket will go down again on the very read that
+            // tells the loop it may stop — which is the read the loop exits on.
+            relayer.Connection.DropOnNextConnectedRead = true;
+            relayer.Connection.RaiseClosed();
+
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (!relayer.Connection.IsConnected && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(10);
+            }
+
+            Assert.True(relayer.Connection.IsConnected, "nothing reconnected after the wakeup was lost");
+
+            relayer.Dispose();
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_close_that_fails_does_not_replace_the_failure_that_caused_it()
+        {
+            // The transport can go away between the Connected check and the call, and Close says so
+            // by throwing. Letting that out would hand the caller the incidental failure instead of
+            // the one they need — and on the stalled path, which swallows by design, it would throw
+            // where nothing throws today.
+            var relayer = new TestRelayer();
+            await relayer.Init();
+
+            relayer.Core.Storage.HasItem(Arg.Any<string>())
+                .Returns(_ => Task.FromException<bool>(new InvalidOperationException("storage unavailable")));
+            relayer.Connection.FailClose = true;
+
+            var error = await Assert.ThrowsAsync<InvalidOperationException>(() => relayer.RestartTransport());
+            Assert.Equal("storage unavailable", error.Message);
+
+            relayer.Dispose();
         }
 
         [Fact]
@@ -127,11 +389,20 @@ namespace Reown.Core.Network.Test
                 Connection.Owner = this;
             }
 
-            protected override TimeSpan TransportCloseTimeout => TimeSpan.FromMilliseconds(200);
+            public ICoreClient Core
+            {
+                get => CoreClient;
+            }
+
+            public static readonly TimeSpan CloseTimeout = TimeSpan.FromMilliseconds(500);
+
+            protected override TimeSpan TransportCloseTimeout => CloseTimeout;
 
             protected override TimeSpan ReconnectInitialDelay => TimeSpan.FromMilliseconds(10);
 
             protected override TimeSpan ReconnectMaxDelay => TimeSpan.FromMilliseconds(20);
+
+            protected override TimeSpan ResubscribeBudget => TimeSpan.FromMilliseconds(300);
 
             public Task EstablishProvider()
             {
@@ -166,6 +437,8 @@ namespace Reown.Core.Network.Test
             {
                 var core = Substitute.For<ICoreClient>();
                 core.Context.Returns("relayer-recovery-tests");
+                core.Crypto.GetClientId().Returns(Task.FromResult("client-id"));
+                core.Storage.HasItem(Arg.Any<string>()).Returns(Task.FromResult(false));
 
                 return new RelayerOptions
                 {
@@ -183,10 +456,36 @@ namespace Reown.Core.Network.Test
             public TestRelayer Owner;
             public bool IsConnected;
             public bool SwallowClose;
+            public TaskCompletionSource<bool> HoldClose;
+            public readonly TaskCompletionSource<bool> CloseStarted = new TaskCompletionSource<bool>();
+
+            /// <summary>
+            ///     Drops the socket on the next read that would have said it was up.
+            /// </summary>
+            /// <remarks>
+            ///     Reproduces the one interleaving that matters for the reconnect latch: the state
+            ///     changing between the loop's decision to exit and the release of the latch. The
+            ///     reader is told the transport is up, and by the time anyone asks again it is down.
+            /// </remarks>
+            public bool DropOnNextConnectedRead;
 
             public bool Connected
             {
-                get => IsConnected;
+                get
+                {
+                    if (!IsConnected)
+                    {
+                        return false;
+                    }
+
+                    if (DropOnNextConnectedRead)
+                    {
+                        DropOnNextConnectedRead = false;
+                        IsConnected = false;
+                    }
+
+                    return true;
+                }
             }
 
             public bool Connecting { get; private set; }
@@ -232,16 +531,27 @@ namespace Reown.Core.Network.Test
                 Closed?.Invoke(this, EventArgs.Empty);
             }
 
-            public Task Close()
+            public bool FailClose;
+
+            public async Task Close()
             {
                 IsConnected = false;
+
+                if (FailClose)
+                {
+                    throw new IOException("Connection already closed");
+                }
+
+                if (HoldClose != null)
+                {
+                    CloseStarted.TrySetResult(true);
+                    await HoldClose.Task;
+                }
 
                 if (!SwallowClose)
                 {
                     Closed?.Invoke(this, EventArgs.Empty);
                 }
-
-                return Task.CompletedTask;
             }
 
             public Task SendRequest<T>(IJsonRpcRequest<T> requestPayload, object context)

--- a/test/Reown.Core.Network.Test/RelayerRecoveryTests.cs
+++ b/test/Reown.Core.Network.Test/RelayerRecoveryTests.cs
@@ -374,6 +374,107 @@ namespace Reown.Core.Network.Test
             Assert.True(relayer.Connected);
         }
 
+        /// <summary>
+        ///     Ensures opening a transport that is already open leaves it alone.
+        /// </summary>
+        /// <remarks>
+        ///     The open waits for <c>Subscriber.Resubscribed</c>, which only comes out of a restart
+        ///     driven by the provider's Connected event — an already connected provider never raises
+        ///     it. The wait therefore runs to its budget and then, because a failed open closes what
+        ///     it finds, takes down a healthy connection along with its subscriptions.
+        /// </remarks>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task Opening_a_transport_that_is_already_open_leaves_it_alone()
+        {
+            var relayer = new TestRelayer();
+            await relayer.Init();
+
+            Assert.True(relayer.Connected, "the transport should be up after Init");
+            int attemptsBefore = relayer.OpenAttempts;
+
+            Task open = relayer.TransportOpen();
+
+            Task finished = await Task.WhenAny(open, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.Same(open, finished);
+            await open;
+
+            Assert.True(relayer.Connected, "the healthy connection was torn down");
+            Assert.Equal(attemptsBefore, relayer.OpenAttempts);
+
+            relayer.Dispose();
+        }
+
+        /// <summary>
+        ///     Ensures a close issued while a connect is in flight is not undone when it completes.
+        /// </summary>
+        /// <remarks>
+        ///     A connect runs for as long as its whole timeout, and a close arriving inside that
+        ///     window finds the socket still down — there is nothing to tear down, so it leaves
+        ///     behind nothing but the flag. Handing the finished connection over anyway answers a
+        ///     caller who asked for the transport to go away by bringing it back, and the reconnect
+        ///     loop then exits on Connected and leaves it up.
+        /// </remarks>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_close_during_a_connect_is_not_undone_when_it_completes()
+        {
+            var relayer = new TestRelayer();
+            await relayer.Init();
+
+            relayer.HoldOpen = new TaskCompletionSource<bool>();
+
+            Task restart = relayer.RestartTransport();
+
+            // The restart has closed the old socket and is now parked inside the reopen.
+            var reopenBy = DateTime.UtcNow.AddSeconds(5);
+            while (relayer.OpenAttempts < 2 && DateTime.UtcNow < reopenBy)
+            {
+                await Task.Delay(10);
+            }
+
+            Assert.True(relayer.OpenAttempts >= 2, "the reopen never started");
+            Assert.False(relayer.Connected, "the socket should be down while the reopen is parked");
+
+            // Nothing to disconnect at this point, so this leaves only the flag behind.
+            await relayer.TransportClose();
+
+            relayer.HoldOpen.TrySetResult(true);
+
+            Task finished = await Task.WhenAny(restart, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.Same(restart, finished);
+            await restart;
+
+            Assert.True(relayer.TransportExplicitlyClosed);
+            Assert.False(relayer.Connected);
+
+            relayer.Dispose();
+        }
+
+        /// <summary>
+        ///     Ensures a close issued during a restart is not undone by the reopen that restart runs.
+        /// </summary>
+        /// <remarks>
+        ///     The flag means "do not reconnect", and a restart already past its own guard still has
+        ///     a reopen ahead of it. Clearing the flag there would answer a caller who just closed the
+        ///     transport by bringing it back up — the wallet going to background mid-reconnect is
+        ///     exactly this sequence.
+        /// </remarks>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_close_during_a_restart_survives_the_reopen()
+        {
+            var relayer = new TestRelayer();
+            await relayer.EstablishProvider();
+
+            relayer.WhileBuildingConnection = () => relayer.TransportClose();
+
+            await relayer.RestartTransport();
+
+            Assert.True(relayer.TransportExplicitlyClosed);
+            Assert.Equal(0, relayer.OpenAttempts);
+        }
+
         private sealed class TestRelayer : Relayer
         {
             public readonly FakeConnection Connection = new FakeConnection();
@@ -409,10 +510,21 @@ namespace Reown.Core.Network.Test
                 return CreateProvider();
             }
 
-            protected override Task<IJsonRpcConnection> BuildConnection(string url)
+            /// <summary>
+            ///     Runs while the restart is between its own guard and the reopen that follows it.
+            /// </summary>
+            public Func<Task> WhileBuildingConnection;
+
+            protected override async Task<IJsonRpcConnection> BuildConnection(string url)
             {
                 ConnectionsBuilt++;
-                return Task.FromResult<IJsonRpcConnection>(Connection);
+
+                if (WhileBuildingConnection != null)
+                {
+                    await WhileBuildingConnection();
+                }
+
+                return Connection;
             }
 
             public async Task OnOpen()

--- a/test/Reown.Core.Network.Test/RelayerRecoveryTests.cs
+++ b/test/Reown.Core.Network.Test/RelayerRecoveryTests.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using Reown.Core.Controllers;
+using Reown.Core.Interfaces;
+using Reown.Core.Models.Relay;
+
+using Xunit;
+
+namespace Reown.Core.Network.Test
+{
+    /// <summary>
+    ///     Covers the transport recovery paths: the restart latch, the disconnect reported when a
+    ///     close is abandoned, and the reconnect loop.
+    /// </summary>
+    /// <remarks>
+    ///     None of these need a relay. The connection is faked through <c>BuildConnection</c>, and the
+    ///     timeouts come from the protected seams so the tests do not wait out real ones.
+    /// </remarks>
+    public class RelayerRecoveryTests
+    {
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task RestartTransport_runs_one_restart_at_a_time()
+        {
+            // The original guard is not mutual exclusion: _reconnecting is raised later, inside
+            // TransportOpen, so two callers arriving together both passed it, both replaced the
+            // provider, and one returned without clearing a flag it never took.
+            var relayer = new TestRelayer();
+            await relayer.EstablishProvider();
+
+            var before = relayer.ConnectionsBuilt;
+            relayer.HoldOpen = new TaskCompletionSource<bool>();
+
+            var first = relayer.RestartTransport();
+            await relayer.OpenStarted.Task;
+
+            await relayer.RestartTransport();
+            Assert.False(first.IsCompleted);
+
+            relayer.HoldOpen.TrySetResult(true);
+            await first;
+
+            Assert.Equal(before + 1, relayer.ConnectionsBuilt);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task An_abandoned_close_still_reports_the_disconnect()
+        {
+            // Subscriber learns that its subscriptions died with the socket only from OnDisconnected.
+            // Without this the reopened socket carries no relay-side subscriptions at all while the
+            // local map still claims every one of them.
+            var relayer = new TestRelayer();
+            await relayer.EstablishProvider();
+
+            relayer.Connection.IsConnected = true;
+            relayer.Connection.SwallowClose = true;
+
+            var disconnects = 0;
+            relayer.OnDisconnected += (_, _) => Interlocked.Increment(ref disconnects);
+
+            await relayer.RestartTransport();
+
+            Assert.Equal(1, disconnects);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_reported_close_raises_exactly_one_disconnect()
+        {
+            // The compensating event must not double up: a second OnDisable would cache an already
+            // empty map, leaving Reset with nothing to resubscribe.
+            var relayer = new TestRelayer();
+            await relayer.EstablishProvider();
+
+            relayer.Connection.IsConnected = true;
+
+            var disconnects = 0;
+            relayer.OnDisconnected += (_, _) => Interlocked.Increment(ref disconnects);
+
+            await relayer.RestartTransport();
+
+            Assert.Equal(1, disconnects);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_dropped_connection_is_retried_until_it_comes_back()
+        {
+            // The reconnect loop is what a dropped socket relies on: the SDK used to make a single
+            // attempt and then sit there with the transport down until something else poked it.
+            var relayer = new TestRelayer();
+            await relayer.EstablishProvider();
+
+            // Open it for real first: the provider wires itself to the connection when it connects,
+            // and a disconnect raised before that reaches nobody.
+            await relayer.TransportOpen();
+            Assert.True(relayer.Connected);
+
+            relayer.FailOpensUntil = relayer.OpenAttempts + 3;
+            relayer.Connection.RaiseClosed();
+
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+            while (relayer.OpenAttempts < relayer.FailOpensUntil && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(20);
+            }
+
+            Assert.True(relayer.OpenAttempts >= 3, "attempts: " + relayer.OpenAttempts);
+            Assert.True(relayer.Connected);
+        }
+
+        private sealed class TestRelayer : Relayer
+        {
+            public readonly FakeConnection Connection = new FakeConnection();
+
+            public int ConnectionsBuilt;
+            public int OpenAttempts;
+            public int FailOpensUntil;
+            public TaskCompletionSource<bool> HoldOpen;
+            public readonly TaskCompletionSource<bool> OpenStarted = new TaskCompletionSource<bool>();
+
+            public TestRelayer() : base(BuildOptions())
+            {
+                Connection.Owner = this;
+            }
+
+            protected override TimeSpan TransportCloseTimeout => TimeSpan.FromMilliseconds(200);
+
+            protected override TimeSpan ReconnectInitialDelay => TimeSpan.FromMilliseconds(10);
+
+            protected override TimeSpan ReconnectMaxDelay => TimeSpan.FromMilliseconds(20);
+
+            public Task EstablishProvider()
+            {
+                return CreateProvider();
+            }
+
+            protected override Task<IJsonRpcConnection> BuildConnection(string url)
+            {
+                ConnectionsBuilt++;
+                return Task.FromResult<IJsonRpcConnection>(Connection);
+            }
+
+            public async Task OnOpen()
+            {
+                OpenAttempts++;
+                OpenStarted.TrySetResult(true);
+
+                if (HoldOpen != null)
+                {
+                    await HoldOpen.Task;
+                }
+
+                if (OpenAttempts < FailOpensUntil)
+                {
+                    throw new InvalidOperationException("no network");
+                }
+
+                Connection.IsConnected = true;
+            }
+
+            private static RelayerOptions BuildOptions()
+            {
+                var core = Substitute.For<ICoreClient>();
+                core.Context.Returns("relayer-recovery-tests");
+
+                return new RelayerOptions
+                {
+                    CoreClient = core,
+                    ProjectId = "test",
+                    RelayUrl = "wss://relay.invalid",
+                    ConnectionTimeout = TimeSpan.FromSeconds(2),
+                    RelayUrlBuilder = new RelayUrlBuilder()
+                };
+            }
+        }
+
+        private sealed class FakeConnection : IJsonRpcConnection
+        {
+            public TestRelayer Owner;
+            public bool IsConnected;
+            public bool SwallowClose;
+
+            public bool Connected
+            {
+                get => IsConnected;
+            }
+
+            public bool Connecting { get; private set; }
+
+            public string Url
+            {
+                get => "wss://relay.invalid";
+            }
+
+            public bool IsPaused
+            {
+                get => false;
+            }
+
+            public event EventHandler<string> PayloadReceived;
+            public event EventHandler Closed;
+            public event EventHandler<Exception> ErrorReceived;
+            public event EventHandler<object> Opened;
+            public event EventHandler<Exception> RegisterErrored;
+
+            public async Task Open()
+            {
+                Connecting = true;
+                try
+                {
+                    await Owner.OnOpen();
+                    Opened?.Invoke(this, this);
+                }
+                finally
+                {
+                    Connecting = false;
+                }
+            }
+
+            public Task Open<T>(T options)
+            {
+                return Open();
+            }
+
+            public void RaiseClosed()
+            {
+                IsConnected = false;
+                Closed?.Invoke(this, EventArgs.Empty);
+            }
+
+            public Task Close()
+            {
+                IsConnected = false;
+
+                if (!SwallowClose)
+                {
+                    Closed?.Invoke(this, EventArgs.Empty);
+                }
+
+                return Task.CompletedTask;
+            }
+
+            public Task SendRequest<T>(IJsonRpcRequest<T> requestPayload, object context)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task SendResult<T>(IJsonRpcResult<T> responsePayload, object context)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task SendError(IJsonRpcError errorPayload, object context)
+            {
+                return Task.CompletedTask;
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/test/Reown.Core.Network.Test/SubscriberRestartTests.cs
+++ b/test/Reown.Core.Network.Test/SubscriberRestartTests.cs
@@ -8,6 +8,7 @@ using NSubstitute;
 using Reown.Core.Controllers;
 using Reown.Core.Interfaces;
 using Reown.Core.Models.Relay;
+using Reown.Core.Network;
 using Reown.Core.Models.Subscriber;
 using Xunit;
 
@@ -223,6 +224,43 @@ namespace Reown.Core.Network.Test
             Assert.True(true, "the process is still here");
         }
 
+        /// <summary>
+        ///     Ensures a map left over from a replaced connection is dropped rather than blocking
+        ///     every restart that follows.
+        /// </summary>
+        /// <remarks>
+        ///     Reproduces what a device showed: the transport errored out without a disconnect ever
+        ///     being raised, so nothing cleared the map. Restore then refused to run against it,
+        ///     no batch subscribe went out, and the wallet reported every topic subscribed while the
+        ///     relay had none of them — a state that only a restart of the application recovered
+        ///     from. Entries recorded on a provider that is no longer in use are not live state.
+        /// </remarks>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_map_left_by_a_replaced_provider_is_dropped_on_restart()
+        {
+            var relayer = BuildRelayer();
+            var first = Substitute.For<IJsonRpcProvider>();
+            var second = Substitute.For<IJsonRpcProvider>();
+
+            relayer.Provider.Returns(first);
+
+            var subscriber = new ProviderTrackingSubscriber(relayer);
+            await subscriber.Init();
+            await subscriber.Subscribe("topic-a");
+
+            Assert.Contains("topic-a", subscriber.Topics);
+
+            // The connection is replaced and nobody reports the old one as gone.
+            relayer.Provider.Returns(second);
+            subscriber.Swept.Clear();
+
+            await subscriber.OnConnectAsync();
+
+            Assert.DoesNotContain("topic-a", subscriber.Topics);
+            Assert.Contains("topic-persisted", subscriber.Swept);
+        }
+
         private static IRelayer BuildRelayer()
         {
             var relayer = Substitute.For<IRelayer>();
@@ -318,6 +356,71 @@ namespace Reown.Core.Network.Test
             /// <returns>A completed task.</returns>
             protected override Task Restore()
             {
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>
+        ///     Test subscriber that restores a known set and records what the restart re-subscribes.
+        /// </summary>
+        private sealed class ProviderTrackingSubscriber : Subscriber
+        {
+            /// <summary>
+            ///     Initializes the subscriber.
+            /// </summary>
+            /// <param name="relayer">The relayer instance to attach to.</param>
+            public ProviderTrackingSubscriber(IRelayer relayer) : base(relayer)
+            {
+            }
+
+            /// <summary>
+            ///     Gets the topics a restart handed to the batch subscribe.
+            /// </summary>
+            public List<string> Swept { get; } = new List<string>();
+
+            /// <summary>
+            ///     Skips the listener registration so nothing outside holds this subscriber alive.
+            /// </summary>
+            protected override void RegisterEventListeners()
+            {
+            }
+
+            /// <summary>
+            ///     Answers as the relay would, without reaching one.
+            /// </summary>
+            /// <param name="topic">The topic being subscribed to.</param>
+            /// <param name="relay">The relay protocol options.</param>
+            /// <returns>The subscription id.</returns>
+            protected override Task<string> RpcSubscribe(string topic, ProtocolOptions relay)
+            {
+                return Task.FromResult("id-" + topic);
+            }
+
+            /// <summary>
+            ///     Restores a fixed set, so Restore reaches its guard instead of returning early.
+            /// </summary>
+            /// <returns>One persisted subscription.</returns>
+            protected override Task<ActiveSubscription[]> GetRelayerSubscriptions()
+            {
+                return Task.FromResult(new[]
+                {
+                    new ActiveSubscription
+                    {
+                        Id = "id-persisted",
+                        Topic = "topic-persisted",
+                        Relay = new ProtocolOptions { Protocol = "irn" }
+                    }
+                });
+            }
+
+            /// <summary>
+            ///     Records what the restart tried to subscribe instead of reaching the relay.
+            /// </summary>
+            /// <param name="subscriptions">The subscriptions being re-subscribed.</param>
+            /// <returns>A completed task.</returns>
+            protected override Task BatchSubscribe(PendingSubscription[] subscriptions)
+            {
+                Swept.AddRange(subscriptions.Select(sub => sub.Topic));
                 return Task.CompletedTask;
             }
         }

--- a/test/Reown.Core.Network.Test/SubscriberRestartTests.cs
+++ b/test/Reown.Core.Network.Test/SubscriberRestartTests.cs
@@ -189,6 +189,13 @@ namespace Reown.Core.Network.Test
             await subscriber.CheckPendingAsync();
 
             Assert.Contains("topic-a", subscriber.SweptTopics);
+
+            // And the caller's own retry has to work too: the entry kept for the sweep must not
+            // make Subscribe throw on a duplicate key, which would fail the very call it was for.
+            string id = await subscriber.Subscribe("topic-a");
+
+            Assert.Equal("id-topic-a", id);
+            Assert.Contains("topic-a", subscriber.Topics);
         }
 
         /// <summary>

--- a/test/Reown.Core.Network.Test/SubscriberRestartTests.cs
+++ b/test/Reown.Core.Network.Test/SubscriberRestartTests.cs
@@ -54,10 +54,17 @@ namespace Reown.Core.Network.Test
         {
             // Nothing awaits the restart latch unless a Subscribe happens to race the restart, so
             // the exception put on it has no observer in the ordinary case.
+            // Matched on the message rather than counted: this event is process-wide, so a task
+            // leaked by any earlier test in the assembly would otherwise fail this one for
+            // something it never did.
             var unobserved = 0;
             void OnUnobserved(object sender, UnobservedTaskExceptionEventArgs e)
             {
-                unobserved++;
+                if (e.Exception?.InnerExceptions.Any(x => x.Message == "storage unavailable") == true)
+                {
+                    unobserved++;
+                }
+
                 e.SetObserved();
             }
 
@@ -180,7 +187,9 @@ namespace Reown.Core.Network.Test
             subscriber.SimulateDisconnect();
             subscriber.ReleaseRpc();
 
-            await Assert.ThrowsAnyAsync<Exception>(() => subscribing);
+            // Pinned to the type the discard actually throws: ThrowsAnyAsync would pass just as
+            // happily on a NullReferenceException from some later refactor.
+            await Assert.ThrowsAsync<IOException>(() => subscribing);
 
             Assert.Empty(subscriber.Subscriptions);
             Assert.DoesNotContain("topic-a", subscriber.Topics);

--- a/test/Reown.Core.Network.Test/SubscriberRestartTests.cs
+++ b/test/Reown.Core.Network.Test/SubscriberRestartTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using Reown.Core.Controllers;
+using Reown.Core.Interfaces;
+using Xunit;
+
+namespace Reown.Core.Network.Test
+{
+    /// <summary>
+    ///     Covers what a restart does when it cannot rebuild the subscriptions.
+    /// </summary>
+    /// <remarks>
+    ///     A restart that fails leaves a live socket carrying no relay-side subscriptions. Reporting
+    ///     that as completion is worse than reporting nothing: the caller stops waiting, the reconnect
+    ///     loop exits on <c>Connected</c>, and the client stays deaf until an unrelated disconnect.
+    /// </remarks>
+    public class SubscriberRestartTests
+    {
+        /// <summary>
+        ///     Ensures a failed restore is reported as a failure and never as a resubscription.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_failed_restore_is_reported_as_a_failure()
+        {
+            var failure = new InvalidOperationException("storage unavailable");
+            var subscriber = new FailingRestoreSubscriber(BuildRelayer(), failure);
+
+            Exception reported = null;
+            var resubscribed = 0;
+            subscriber.ResubscribeFailed += (_, e) => reported = e;
+            subscriber.Resubscribed += (_, _) => resubscribed++;
+
+            await subscriber.Init();
+
+            Assert.Same(failure, reported);
+            Assert.Equal(0, resubscribed);
+        }
+
+        /// <summary>
+        ///     Ensures the failure stored on the restart latch does not resurface on the finalizer.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_failed_restart_does_not_resurface_on_the_finalizer()
+        {
+            // Nothing awaits the restart latch unless a Subscribe happens to race the restart, so
+            // the exception put on it has no observer in the ordinary case.
+            var unobserved = 0;
+            void OnUnobserved(object sender, UnobservedTaskExceptionEventArgs e)
+            {
+                unobserved++;
+                e.SetObserved();
+            }
+
+            TaskScheduler.UnobservedTaskException += OnUnobserved;
+            try
+            {
+                await FailARestart();
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                await Task.Delay(200);
+
+                Assert.Equal(0, unobserved);
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= OnUnobserved;
+            }
+
+            // Kept in its own frame so the latch becomes unreachable before the collection above.
+            static async Task FailARestart()
+            {
+                var subscriber = new FailingRestoreSubscriber(
+                    BuildRelayer(), new InvalidOperationException("storage unavailable"));
+
+                await subscriber.Init();
+            }
+        }
+
+        private static IRelayer BuildRelayer()
+        {
+            var relayer = Substitute.For<IRelayer>();
+            relayer.CoreClient.Crypto.GetClientId().Returns(Task.FromResult("client-id"));
+            return relayer;
+        }
+
+        /// <summary>
+        ///     Test subscriber whose restore always fails.
+        /// </summary>
+        private sealed class FailingRestoreSubscriber : Subscriber
+        {
+            private readonly Exception _failure;
+
+            /// <summary>
+            ///     Initializes a subscriber that cannot restore.
+            /// </summary>
+            /// <param name="relayer">The relayer instance to attach to.</param>
+            /// <param name="failure">The failure restore raises.</param>
+            public FailingRestoreSubscriber(IRelayer relayer, Exception failure) : base(relayer)
+            {
+                _failure = failure;
+            }
+
+            /// <summary>
+            ///     Skips the listener registration so nothing outside holds this subscriber alive.
+            /// </summary>
+            protected override void RegisterEventListeners()
+            {
+            }
+
+            /// <summary>
+            ///     Fails instead of restoring the persisted subscriptions.
+            /// </summary>
+            /// <returns>A task that is always faulted.</returns>
+            protected override Task Restore()
+            {
+                return Task.FromException(_failure);
+            }
+        }
+    }
+}

--- a/test/Reown.Core.Network.Test/SubscriberRestartTests.cs
+++ b/test/Reown.Core.Network.Test/SubscriberRestartTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using NSubstitute;
 using Reown.Core.Controllers;
@@ -81,6 +82,73 @@ namespace Reown.Core.Network.Test
             }
         }
 
+        /// <summary>
+        ///     Ensures a restart that rebuilt nothing does not leave the subscriber enabled.
+        /// </summary>
+        /// <remarks>
+        ///     <c>OnEnabled</c> clears the cache the next restart rebuilds from, so running it after
+        ///     a failed restart throws away the topics that restart was supposed to bring back.
+        /// </remarks>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_failed_restart_leaves_the_subscriber_disabled()
+        {
+            var failure = new InvalidOperationException("storage unavailable");
+            var subscriber = new FailingRestoreSubscriber(BuildRelayer(), failure);
+
+            Exception reported = null;
+            subscriber.ResubscribeFailed += (_, e) => reported = e;
+
+            // The awaitable body of the handler, so the assertion below runs after the decision it
+            // is about rather than after a delay chosen to outlast it.
+            await subscriber.OnConnectAsync();
+
+            Assert.Same(failure, reported);
+            Assert.Equal(0, subscriber.EnabledCount);
+        }
+
+        /// <summary>
+        ///     Ensures a restart that did rebuild the subscriptions still enables the subscriber.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_successful_restart_enables_the_subscriber()
+        {
+            var subscriber = new RestoringSubscriber(BuildRelayer());
+
+            await subscriber.OnConnectAsync();
+
+            Assert.Equal(1, subscriber.EnabledCount);
+        }
+
+        /// <summary>
+        ///     Ensures two overlapping restarts do not complete each other's latch.
+        /// </summary>
+        /// <remarks>
+        ///     <c>Init</c> restarts without checking <c>RestartInProgress</c>, so it can overlap the
+        ///     restart a connect started. Completing through the field rather than the latch each
+        ///     restart created makes the second completion land on an already completed latch, which
+        ///     throws out of Restart and leaves both Resubscribed and ResubscribeFailed unraised —
+        ///     the open then waits out its whole resubscribe budget.
+        /// </remarks>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task Overlapping_restarts_do_not_complete_each_others_latch()
+        {
+            var subscriber = new GatedRestoreSubscriber(BuildRelayer());
+
+            Task fromConnect = subscriber.OnConnectAsync();
+            await subscriber.FirstRestoreEntered;
+
+            Task fromInit = subscriber.Init();
+            await subscriber.SecondRestoreEntered;
+
+            subscriber.ReleaseRestores();
+
+            // Both must simply finish: a crossed latch surfaces as InvalidOperationException here.
+            await Task.WhenAll(fromConnect, fromInit);
+        }
+
         private static IRelayer BuildRelayer()
         {
             var relayer = Substitute.For<IRelayer>();
@@ -106,10 +174,24 @@ namespace Reown.Core.Network.Test
             }
 
             /// <summary>
+            ///     Gets how many times the subscriber was enabled.
+            /// </summary>
+            public int EnabledCount { get; private set; }
+
+            /// <summary>
             ///     Skips the listener registration so nothing outside holds this subscriber alive.
             /// </summary>
             protected override void RegisterEventListeners()
             {
+            }
+
+            /// <summary>
+            ///     Records that the subscriber was enabled.
+            /// </summary>
+            protected override void OnEnabled()
+            {
+                EnabledCount++;
+                base.OnEnabled();
             }
 
             /// <summary>
@@ -119,6 +201,124 @@ namespace Reown.Core.Network.Test
             protected override Task Restore()
             {
                 return Task.FromException(_failure);
+            }
+        }
+
+        /// <summary>
+        ///     Test subscriber whose restore succeeds with nothing to rebuild.
+        /// </summary>
+        private sealed class RestoringSubscriber : Subscriber
+        {
+            /// <summary>
+            ///     Initializes a subscriber that restores cleanly.
+            /// </summary>
+            /// <param name="relayer">The relayer instance to attach to.</param>
+            public RestoringSubscriber(IRelayer relayer) : base(relayer)
+            {
+            }
+
+            /// <summary>
+            ///     Gets how many times the subscriber was enabled.
+            /// </summary>
+            public int EnabledCount { get; private set; }
+
+            /// <summary>
+            ///     Skips the listener registration so nothing outside holds this subscriber alive.
+            /// </summary>
+            protected override void RegisterEventListeners()
+            {
+            }
+
+            /// <summary>
+            ///     Records that the subscriber was enabled.
+            /// </summary>
+            protected override void OnEnabled()
+            {
+                EnabledCount++;
+                base.OnEnabled();
+            }
+
+            /// <summary>
+            ///     Restores without reaching storage.
+            /// </summary>
+            /// <returns>A completed task.</returns>
+            protected override Task Restore()
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>
+        ///     Test subscriber whose restores park until released, so two can overlap.
+        /// </summary>
+        private sealed class GatedRestoreSubscriber : Subscriber
+        {
+            private readonly TaskCompletionSource<bool> _gate =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private readonly TaskCompletionSource<bool> _first =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private readonly TaskCompletionSource<bool> _second =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private int _entries;
+
+            /// <summary>
+            ///     Initializes a subscriber whose restores can be held open.
+            /// </summary>
+            /// <param name="relayer">The relayer instance to attach to.</param>
+            public GatedRestoreSubscriber(IRelayer relayer) : base(relayer)
+            {
+            }
+
+            /// <summary>
+            ///     Completes once the first restore is parked.
+            /// </summary>
+            public Task FirstRestoreEntered
+            {
+                get => _first.Task;
+            }
+
+            /// <summary>
+            ///     Completes once the second restore is parked.
+            /// </summary>
+            public Task SecondRestoreEntered
+            {
+                get => _second.Task;
+            }
+
+            /// <summary>
+            ///     Lets every parked restore run to completion.
+            /// </summary>
+            public void ReleaseRestores()
+            {
+                _gate.TrySetResult(true);
+            }
+
+            /// <summary>
+            ///     Skips the listener registration so nothing outside holds this subscriber alive.
+            /// </summary>
+            protected override void RegisterEventListeners()
+            {
+            }
+
+            /// <summary>
+            ///     Parks until the gate opens, reporting which restore this is.
+            /// </summary>
+            /// <returns>A task that completes once released.</returns>
+            protected override async Task Restore()
+            {
+                if (Interlocked.Increment(ref _entries) == 1)
+                {
+                    _first.TrySetResult(true);
+                }
+                else
+                {
+                    _second.TrySetResult(true);
+                }
+
+                await _gate.Task;
             }
         }
     }

--- a/test/Reown.Core.Network.Test/SubscriberRestartTests.cs
+++ b/test/Reown.Core.Network.Test/SubscriberRestartTests.cs
@@ -1,9 +1,14 @@
 using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NSubstitute;
 using Reown.Core.Controllers;
 using Reown.Core.Interfaces;
+using Reown.Core.Models.Relay;
+using Reown.Core.Models.Subscriber;
 using Xunit;
 
 namespace Reown.Core.Network.Test
@@ -149,6 +154,68 @@ namespace Reown.Core.Network.Test
             await Task.WhenAll(fromConnect, fromInit);
         }
 
+        /// <summary>
+        ///     Ensures a subscription that completes after its socket went away is not kept.
+        /// </summary>
+        /// <remarks>
+        ///     Both Subscribe and BatchSubscribe record into the map only once the relay has
+        ///     answered, and RpcSubscribe even restarts the transport itself between attempts. A
+        ///     disconnect landing in that gap clears the map, and the answer that arrives afterwards
+        ///     puts back an entry belonging to a socket that no longer exists. The relay has no such
+        ///     subscription on the new connection, so nothing is delivered on that topic — while
+        ///     every local check, the wallet's "missing" list included, reports it as subscribed.
+        /// </remarks>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_subscription_answered_after_the_socket_died_is_discarded()
+        {
+            var subscriber = new GatedRpcSubscriber(BuildRelayer());
+            await subscriber.Init();
+
+            Task<string> subscribing = subscriber.Subscribe("topic-a");
+            await subscriber.RpcEntered;
+
+            // The socket goes away while the relay is still answering.
+            subscriber.SimulateDisconnect();
+            subscriber.ReleaseRpc();
+
+            await Assert.ThrowsAnyAsync<Exception>(() => subscribing);
+
+            Assert.Empty(subscriber.Subscriptions);
+            Assert.DoesNotContain("topic-a", subscriber.Topics);
+
+            // Still pending, so the heartbeat sweep subscribes it again on the connection that is
+            // up. Dropping it here instead would leave the topic in neither the map nor the sweep.
+            await subscriber.CheckPendingAsync();
+
+            Assert.Contains("topic-a", subscriber.SweptTopics);
+        }
+
+        /// <summary>
+        ///     Ensures a failing pending sweep does not take the process down.
+        /// </summary>
+        /// <remarks>
+        ///     The heartbeat calls CheckPending, and BatchSubscribe handles only TimeoutException —
+        ///     a transport that cannot connect at all throws IOException straight out of an
+        ///     async void. On the lab that killed the subscriber on the first heartbeat after the
+        ///     network went away. Without the fix this test does not fail, it takes the test host
+        ///     with it, which is the point being made.
+        /// </remarks>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_failing_pending_sweep_does_not_kill_the_process()
+        {
+            var subscriber = new ThrowingBatchSubscriber(BuildRelayer());
+            await subscriber.Init();
+
+            subscriber.SweepPending();
+
+            // Long enough for the continuation to run and rethrow, had nothing caught it.
+            await Task.Delay(200);
+
+            Assert.True(true, "the process is still here");
+        }
+
         private static IRelayer BuildRelayer()
         {
             var relayer = Substitute.For<IRelayer>();
@@ -245,6 +312,143 @@ namespace Reown.Core.Network.Test
             protected override Task Restore()
             {
                 return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>
+        ///     Test subscriber whose batch subscribe fails the way a dead transport does.
+        /// </summary>
+        private sealed class ThrowingBatchSubscriber : Subscriber
+        {
+            /// <summary>
+            ///     Initializes a subscriber whose batch subscribe always fails.
+            /// </summary>
+            /// <param name="relayer">The relayer instance to attach to.</param>
+            public ThrowingBatchSubscriber(IRelayer relayer) : base(relayer)
+            {
+            }
+
+            /// <summary>
+            ///     Runs the sweep the heartbeat would run.
+            /// </summary>
+            public void SweepPending()
+            {
+                CheckPending();
+            }
+
+            /// <summary>
+            ///     Skips the listener registration so nothing outside holds this subscriber alive.
+            /// </summary>
+            protected override void RegisterEventListeners()
+            {
+            }
+
+            /// <summary>
+            ///     Restores without reaching storage.
+            /// </summary>
+            /// <returns>A completed task.</returns>
+            protected override Task Restore()
+            {
+                return Task.CompletedTask;
+            }
+
+            /// <summary>
+            ///     Fails the way Relayer.Request does when the transport cannot be established.
+            /// </summary>
+            /// <param name="subscriptions">The pending subscriptions being swept.</param>
+            /// <returns>A task that is always faulted.</returns>
+            protected override Task BatchSubscribe(PendingSubscription[] subscriptions)
+            {
+                return Task.FromException(new IOException("Could not establish connection"));
+            }
+        }
+
+        /// <summary>
+        ///     Test subscriber whose relay call parks until released, so a disconnect can land in it.
+        /// </summary>
+        private sealed class GatedRpcSubscriber : Subscriber
+        {
+            private readonly TaskCompletionSource<bool> _gate =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private readonly TaskCompletionSource<bool> _entered =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            /// <summary>
+            ///     Initializes a subscriber whose relay call can be held open.
+            /// </summary>
+            /// <param name="relayer">The relayer instance to attach to.</param>
+            public GatedRpcSubscriber(IRelayer relayer) : base(relayer)
+            {
+            }
+
+            /// <summary>
+            ///     Completes once the relay call is parked.
+            /// </summary>
+            public Task RpcEntered
+            {
+                get => _entered.Task;
+            }
+
+            /// <summary>
+            ///     Lets the parked relay call answer.
+            /// </summary>
+            public void ReleaseRpc()
+            {
+                _gate.TrySetResult(true);
+            }
+
+            /// <summary>
+            ///     Runs the disconnect handler the relayer would raise.
+            /// </summary>
+            public void SimulateDisconnect()
+            {
+                OnDisconnect();
+            }
+
+            /// <summary>
+            ///     Skips the listener registration so nothing outside holds this subscriber alive.
+            /// </summary>
+            protected override void RegisterEventListeners()
+            {
+            }
+
+            /// <summary>
+            ///     Restores without reaching storage.
+            /// </summary>
+            /// <returns>A completed task.</returns>
+            protected override Task Restore()
+            {
+                return Task.CompletedTask;
+            }
+
+            /// <summary>
+            ///     Gets the topics the pending sweep tried to subscribe.
+            /// </summary>
+            public List<string> SweptTopics { get; } = new List<string>();
+
+            /// <summary>
+            ///     Records what the sweep picked up instead of reaching the relay.
+            /// </summary>
+            /// <param name="subscriptions">The pending subscriptions being swept.</param>
+            /// <returns>A completed task.</returns>
+            protected override Task BatchSubscribe(PendingSubscription[] subscriptions)
+            {
+                SweptTopics.AddRange(subscriptions.Select(sub => sub.Topic));
+                return Task.CompletedTask;
+            }
+
+            /// <summary>
+            ///     Parks until released, then answers as the relay would.
+            /// </summary>
+            /// <param name="topic">The topic being subscribed to.</param>
+            /// <param name="relay">The relay protocol options.</param>
+            /// <returns>The subscription id.</returns>
+            protected override async Task<string> RpcSubscribe(string topic, ProtocolOptions relay)
+            {
+                _entered.TrySetResult(true);
+                await _gate.Task;
+                return "id-" + topic;
             }
         }
 

--- a/test/Reown.Core.Network.Test/WebsocketConnectionFaultTests.cs
+++ b/test/Reown.Core.Network.Test/WebsocketConnectionFaultTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading.Tasks;
+using Reown.Core.Network.Websocket;
+using Xunit;
+
+namespace Reown.Core.Network.Test
+{
+    /// <summary>
+    ///     A failed registration must not leave a second copy of its exception behind.
+    /// </summary>
+    /// <remarks>
+    ///     <c>RegisterCore</c> stores the failure in the pending-register source for callers that
+    ///     joined an attempt already in flight, and throws it to the caller that started it. With no
+    ///     concurrent caller, the stored copy is never awaited and comes back on the finalizer thread
+    ///     as an UnobservedTaskException — one per failed connect, which is every attempt the
+    ///     reconnect loop makes while the network is down.
+    /// </remarks>
+    public class WebsocketConnectionFaultTests
+    {
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task A_failed_open_leaves_no_unobserved_exception()
+        {
+            var unobserved = 0;
+            void OnUnobserved(object sender, UnobservedTaskExceptionEventArgs e)
+            {
+                unobserved++;
+                e.SetObserved();
+            }
+
+            TaskScheduler.UnobservedTaskException += OnUnobserved;
+            try
+            {
+                await FailToOpen();
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                await Task.Delay(300);
+
+                Assert.Equal(0, unobserved);
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= OnUnobserved;
+            }
+
+            // Its own frame so the connection and its sources are unreachable by the collection above.
+            static async Task FailToOpen()
+            {
+                // .invalid never resolves, so this fails the same way a phone with no network does.
+                var connection = new WebsocketConnection("wss://relay.invalid", "unobserved-fault-tests")
+                {
+                    OpenTimeout = TimeSpan.FromSeconds(10)
+                };
+
+                await Assert.ThrowsAnyAsync<Exception>(() => connection.Open());
+
+                connection.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #313.

A client that loses the network while backgrounded comes back with a live socket and no relay-side subscriptions, and only a process restart recovers it. The issue has the full chain; this is the fix.

## Changes

**`Relayer.RestartTransport` no longer waits on the close forever.** `Task.WhenAll(task1.Task, TransportClose())` waits for every task even after one faults, so an `IOException` from `Close()` — thrown whenever a reconnect has already cleared `_transport` — was invisible and `task1` still gated the call. A close whose network is gone may never report at all. The wait is now bounded and the restart continues.

**When that close is abandoned, the relayer reports the disconnect itself.** This is the core of the issue: `Subscriber` learns about a dead socket only from `OnDisconnected`, and without it `OnDisable` never runs, `Restore` throws `Restoring will override existing data` into an unobserved `_restartTask`, `Reset` never runs, and no `irn_batchSubscribe` is ever sent.

**`TransportClose` split into public and internal forms.** The internal restart no longer raises `TransportExplicitlyClosed`. Previously a stalled close left that latch raised permanently, after which `RestartTransport` returned on its first line and `OnProviderDisconnected` gave up — the client refused every future reconnect while reporting itself connected.

**`RestartTransport` takes an explicit latch.** The existing `_reconnecting` check is not mutual exclusion: the flag is raised much later, inside `TransportOpen`, so two callers arriving together (typically an external restart and the one `OnProviderDisconnected` raises when that restart closes the socket) both pass the guard, both replace `Provider`, one takes the flag and the other returns without clearing it.

**`CreateProvider` detaches the replaced provider's handlers.** An abandoned socket that reports its close later otherwise reaches the live relayer, wipes its fresh subscription map into `Subscriber`'s cache and starts a reconnect over a healthy connection.

**`TransportOpen` is bounded and its `Task2` failure path is symmetric.** An exception there previously left `task1` pending forever.

**`OnProviderDisconnected` retries with backoff** instead of giving up after a single failed attempt.

**`WebsocketConnection.OpenTimeout` is settable** (default unchanged at 60s). `Relayer.ConnectionTimeout` does not cancel the underlying attempt — it only stops waiting — so the socket keeps trying until its own timeout, `Connecting` stays true for that whole stretch, and `RestartTransport` refuses to start a new attempt while it does. The retry period was therefore dictated by a hardcoded constant regardless of configuration. `WebsocketConnectionBuilder` forwards the value.

**`ClientWebSocketTransport` requires a PONG** via `ClientWebSocketOptions.KeepAliveTimeout` on .NET 9+. Without it the keep-alive PINGs never demand an answer, which is how a socket stays `WebSocketState.Open` over a network that is gone.

**`Subscriber.Restart` logs a failed restart.** Nothing observes `_restartTask` unless a `Subscribe` races it, and a failed `Restore` means the socket carries no relay-side subscriptions at all — worth a log line.

## Verification

Two `CoreClient`s over a shared topic against the live relay, subscriber's network blackholed with `iptables -j DROP` for 120s, a forced `RestartTransport` during the outage, and a decorator swallowing exactly one `Closed` event to reproduce the unreported close (the transport bounds its own close to ~4.5s in a container, so the path is otherwise unreachable there).

| this commit | result |
|---|---|
| without the disconnect report | `Restart failed: Restoring will override existing data`, no `irn_batchSubscribe`, delivery never resumes |
| with it | `Close was abandoned, reporting the disconnect`, `irn_batchSubscribe` sent, delivery resumes |

Also running in a production .NET MAUI wallet on iOS and Android: reconnect and subscription recovery after long device sleep now work without restarting the app.

## Notes

Defaults are unchanged — `OpenTimeout` stays 60s and the new timeouts only bound paths that previously had no bound at all. Happy to split this into smaller PRs if you prefer; the pieces are separable, though the first two together are what actually fixes the reported behaviour.
