### PR TITLE
fix(cacao): reject expired and not-before timestamps

### DIFF
--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -952,7 +952,7 @@ namespace Reown.Sign
                 Version = "1",
                 Nonce = authParams.Nonce,
                 Iat = DateTimeOffset.UtcNow.ToRfc3339(),
-                Exp = authParams.Expiration?.ToString(),
+                Exp = CacaoUtils.NormalizeExpiration(authParams.Expiration),
                 Nbf = authParams.NotBefore?.ToString(),
                 Resources = authParams.Resources,
                 PairingTopic = pairingData.Topic

--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -953,7 +953,7 @@ namespace Reown.Sign
                 Nonce = authParams.Nonce,
                 Iat = DateTimeOffset.UtcNow.ToRfc3339(),
                 Exp = CacaoUtils.NormalizeExpiration(authParams.Expiration),
-                Nbf = authParams.NotBefore?.ToString(),
+                Nbf = CacaoUtils.NormalizeExpiration(authParams.NotBefore),
                 Resources = authParams.Resources,
                 PairingTopic = pairingData.Topic
             };

--- a/src/Reown.Sign/Runtime/Models/Cacao/CacaoObject.cs
+++ b/src/Reown.Sign/Runtime/Models/Cacao/CacaoObject.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Reown.Core.Common.Logging;
 using Reown.Sign.Utils;
 
 namespace Reown.Sign.Models.Cacao
@@ -27,8 +28,9 @@ namespace Reown.Sign.Models.Cacao
 
         public async Task<bool> VerifySignature(string projectId, string rpcUrl = null)
         {
-            if (!Payload.IsWithinValidityWindow())
+            if (!Payload.IsWithinValidityWindow(null, out var reason))
             {
+                ReownLogger.Log($"CACAO rejected: {reason}");
                 return false;
             }
 

--- a/src/Reown.Sign/Runtime/Models/Cacao/CacaoObject.cs
+++ b/src/Reown.Sign/Runtime/Models/Cacao/CacaoObject.cs
@@ -27,6 +27,11 @@ namespace Reown.Sign.Models.Cacao
 
         public async Task<bool> VerifySignature(string projectId, string rpcUrl = null)
         {
+            if (!Payload.IsWithinValidityWindow())
+            {
+                return false;
+            }
+
             var reconstructed = FormatMessage();
             var walletAddress = CacaoUtils.ExtractDidAddress(Payload.Iss);
             var chainId = CacaoUtils.ExtractDidChainId(Payload.Iss);

--- a/src/Reown.Sign/Runtime/Models/Cacao/CacaoPayload.cs
+++ b/src/Reown.Sign/Runtime/Models/Cacao/CacaoPayload.cs
@@ -70,25 +70,53 @@ namespace Reown.Sign.Models.Cacao
         }
 
         /// <summary>
-        ///     Returns true when optional CACAO <c>exp</c> and <c>nbf</c> are absent or <paramref name="now"/>
-        ///     is inside the validity window. Unparseable timestamps fail closed.
+        ///     Returns true when optional CACAO <c>exp</c> and <c>nbf</c> are absent or
+        ///     <paramref name="now"/> is inside the validity window. Unparseable
+        ///     timestamps fail closed. Blank values are treated as absent.
         /// </summary>
+        /// <param name="now">Clock used for the comparison. Defaults to UTC now.</param>
         public bool IsWithinValidityWindow(DateTimeOffset? now = null)
         {
-            var clock = now ?? DateTimeOffset.UtcNow;
+            return IsWithinValidityWindow(now, out _);
+        }
 
-            if (Expiration != null)
+        /// <summary>
+        ///     Same as <see cref="IsWithinValidityWindow(DateTimeOffset?)"/> and writes
+        ///     a short reason when the window check fails.
+        /// </summary>
+        /// <param name="now">Clock used for the comparison. Defaults to UTC now.</param>
+        /// <param name="reason">expired, not yet valid, or unparseable exp/nbf.</param>
+        public bool IsWithinValidityWindow(DateTimeOffset? now, out string reason)
+        {
+            var clock = now ?? DateTimeOffset.UtcNow;
+            reason = string.Empty;
+
+            if (!string.IsNullOrWhiteSpace(Expiration))
             {
-                if (!TryParseCacaoTimestamp(Expiration, out var exp) || clock >= exp)
+                if (!TryParseCacaoTimestamp(Expiration, out var exp))
                 {
+                    reason = "unparseable exp";
+                    return false;
+                }
+
+                if (clock >= exp)
+                {
+                    reason = "expired";
                     return false;
                 }
             }
 
-            if (NotBefore != null)
+            if (!string.IsNullOrWhiteSpace(NotBefore))
             {
-                if (!TryParseCacaoTimestamp(NotBefore, out var nbf) || clock < nbf)
+                if (!TryParseCacaoTimestamp(NotBefore, out var nbf))
                 {
+                    reason = "unparseable nbf";
+                    return false;
+                }
+
+                if (clock < nbf)
+                {
+                    reason = "not yet valid";
                     return false;
                 }
             }
@@ -96,6 +124,11 @@ namespace Reown.Sign.Models.Cacao
             return true;
         }
 
+        /// <summary>
+        ///     Parses a CACAO timestamp. Unparseable values fail closed.
+        /// </summary>
+        /// <param name="value">RFC 3339 / ISO-8601 timestamp.</param>
+        /// <param name="timestamp">Parsed instant in UTC when the parse succeeds.</param>
         private static bool TryParseCacaoTimestamp(string value, out DateTimeOffset timestamp)
         {
             return DateTimeOffset.TryParse(

--- a/src/Reown.Sign/Runtime/Models/Cacao/CacaoPayload.cs
+++ b/src/Reown.Sign/Runtime/Models/Cacao/CacaoPayload.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json;
 using Reown.Sign.Utils;
@@ -66,6 +67,42 @@ namespace Reown.Sign.Models.Cacao
             Statement = statement;
             RequestId = requestId;
             Resources = resources;
+        }
+
+        /// <summary>
+        ///     Returns true when optional CACAO <c>exp</c> and <c>nbf</c> are absent or <paramref name="now"/>
+        ///     is inside the validity window. Unparseable timestamps fail closed.
+        /// </summary>
+        public bool IsWithinValidityWindow(DateTimeOffset? now = null)
+        {
+            var clock = now ?? DateTimeOffset.UtcNow;
+
+            if (Expiration != null)
+            {
+                if (!TryParseCacaoTimestamp(Expiration, out var exp) || clock >= exp)
+                {
+                    return false;
+                }
+            }
+
+            if (NotBefore != null)
+            {
+                if (!TryParseCacaoTimestamp(NotBefore, out var nbf) || clock < nbf)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool TryParseCacaoTimestamp(string value, out DateTimeOffset timestamp)
+        {
+            return DateTimeOffset.TryParse(
+                value,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out timestamp);
         }
 
         public static CacaoPayload FromAuthPayloadParams(AuthPayloadParams authPayloadParams, string iss)

--- a/src/Reown.Sign/Runtime/Models/Engine/AuthParams.cs
+++ b/src/Reown.Sign/Runtime/Models/Engine/AuthParams.cs
@@ -20,9 +20,19 @@ namespace Reown.Sign.Models.Engine
         [JsonProperty("uri")]
         public string Uri;
 
+        /// <summary>
+        ///     CACAO not-before. RFC 3339 timestamp, or a positive duration in
+        ///     seconds below one year (expanded to UTC now plus that many seconds,
+        ///     same as <see cref="Expiration"/>). Omit or leave blank for no nbf.
+        /// </summary>
         [JsonProperty("nbf", NullValueHandling = NullValueHandling.Include)]
         public string NotBefore;
 
+        /// <summary>
+        ///     CACAO expiration. RFC 3339 timestamp, or a positive duration in
+        ///     seconds below one year (expanded to UTC now plus that many seconds).
+        ///     Epoch-sized integers are left unchanged and fail closed as unparseable.
+        /// </summary>
         [JsonProperty("exp", NullValueHandling = NullValueHandling.Include)]
         public string Expiration;
 

--- a/src/Reown.Sign/Runtime/Utils/CacaoUtils.cs
+++ b/src/Reown.Sign/Runtime/Utils/CacaoUtils.cs
@@ -47,5 +47,28 @@ namespace Reown.Sign.Utils
         {
             return dateTimeOffset.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture);
         }
+
+        /// <summary>
+        ///     <c>AuthParams.Expiration</c> is used both as an RFC 3339 timestamp and
+        ///     as a duration in seconds. When the value is an integer, emit
+        ///     <paramref name="now"/> plus that many seconds so CACAO <c>exp</c> stays
+        ///     a timestamp.
+        /// </summary>
+        /// <param name="expiration">Raw exp from AuthParams, timestamp or seconds.</param>
+        /// <param name="now">Clock used when expanding a duration. Defaults to UTC now.</param>
+        public static string NormalizeExpiration(string expiration, DateTimeOffset? now = null)
+        {
+            if (string.IsNullOrWhiteSpace(expiration))
+            {
+                return expiration;
+            }
+
+            if (long.TryParse(expiration, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
+            {
+                return (now ?? DateTimeOffset.UtcNow).AddSeconds(seconds).ToRfc3339();
+            }
+
+            return expiration;
+        }
     }
 }

--- a/src/Reown.Sign/Runtime/Utils/CacaoUtils.cs
+++ b/src/Reown.Sign/Runtime/Utils/CacaoUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using Reown.Core.Common.Utils;
 
 namespace Reown.Sign.Utils
 {
@@ -49,12 +50,15 @@ namespace Reown.Sign.Utils
         }
 
         /// <summary>
-        ///     <c>AuthParams.Expiration</c> is used both as an RFC 3339 timestamp and
-        ///     as a duration in seconds. When the value is an integer, emit
-        ///     <paramref name="now"/> plus that many seconds so CACAO <c>exp</c> stays
-        ///     a timestamp.
+        ///     <c>AuthParams.Expiration</c> and <c>NotBefore</c> are used both as
+        ///     RFC 3339 timestamps and as durations in seconds. When the value is a
+        ///     positive integer below one year, emit UTC <paramref name="now"/> plus
+        ///     that many seconds so CACAO <c>exp</c>/<c>nbf</c> stay timestamps.
+        ///     Epoch-sized or negative integers are left unchanged so they fail
+        ///     closed as unparseable instead of overflowing or expanding into a
+        ///     decades-long window.
         /// </summary>
-        /// <param name="expiration">Raw exp from AuthParams, timestamp or seconds.</param>
+        /// <param name="expiration">Raw exp or nbf from AuthParams, timestamp or seconds.</param>
         /// <param name="now">Clock used when expanding a duration. Defaults to UTC now.</param>
         public static string NormalizeExpiration(string expiration, DateTimeOffset? now = null)
         {
@@ -63,9 +67,11 @@ namespace Reown.Sign.Utils
                 return expiration;
             }
 
-            if (long.TryParse(expiration, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
+            if (long.TryParse(expiration, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds)
+                && seconds > 0
+                && seconds <= Clock.ONE_YEAR)
             {
-                return (now ?? DateTimeOffset.UtcNow).AddSeconds(seconds).ToRfc3339();
+                return (now ?? DateTimeOffset.UtcNow).ToUniversalTime().AddSeconds(seconds).ToRfc3339();
             }
 
             return expiration;

--- a/test/Reown.Sign.Test/CacaoTests.cs
+++ b/test/Reown.Sign.Test/CacaoTests.cs
@@ -6,11 +6,27 @@ namespace Reown.Sign.Test;
 
 public class CacaoTests
 {
+    private static readonly DateTimeOffset Now = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
+
     private readonly ITestOutputHelper _testOutputHelper;
 
     public CacaoTests(ITestOutputHelper testOutputHelper)
     {
         _testOutputHelper = testOutputHelper;
+    }
+
+    private static CacaoPayload Payload(string? exp = null, string? nbf = null)
+    {
+        return new CacaoPayload(
+            "example.com",
+            "did:pkh:eip155:1:0x3613699A6c5D8BC97a08805876c8005543125F09",
+            "https://example.com",
+            "1",
+            "nonce",
+            "2023-09-07T11:04:23+02:00",
+            nbf,
+            exp
+        );
     }
 
     [Fact] [Trait("Category", "unit")]
@@ -47,5 +63,89 @@ public class CacaoTests
         var formattedMessage = cacaoObject.FormatMessage();
 
         Assert.Equal(normalizedMessage, formattedMessage);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void IsWithinValidityWindow_AbsentExpAndNbf_IsValid()
+    {
+        Assert.True(Payload().IsWithinValidityWindow(Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void IsWithinValidityWindow_FutureExp_IsValid()
+    {
+        Assert.True(Payload(exp: "2024-01-01T00:00:00Z").IsWithinValidityWindow(Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void IsWithinValidityWindow_PastExp_IsExpired()
+    {
+        Assert.False(Payload(exp: "2023-01-01T00:00:00Z").IsWithinValidityWindow(Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void IsWithinValidityWindow_ExpEqualToNow_IsExpired()
+    {
+        Assert.False(Payload(exp: "2023-11-14T22:13:20Z").IsWithinValidityWindow(Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void IsWithinValidityWindow_PastNbf_IsValid()
+    {
+        Assert.True(Payload(nbf: "2023-01-01T00:00:00Z").IsWithinValidityWindow(Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void IsWithinValidityWindow_FutureNbf_IsNotYetValid()
+    {
+        Assert.False(Payload(nbf: "2024-01-01T00:00:00Z").IsWithinValidityWindow(Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void IsWithinValidityWindow_UnparseableExp_FailsClosed()
+    {
+        Assert.False(Payload(exp: "not-a-timestamp").IsWithinValidityWindow(Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void IsWithinValidityWindow_UnparseableNbf_FailsClosed()
+    {
+        Assert.False(Payload(nbf: "not-a-timestamp").IsWithinValidityWindow(Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public async Task VerifySignature_ExpiredCacao_ReturnsFalseWithoutThrowing()
+    {
+        var cacao = new CacaoObject(
+            CacaoHeader.Eip4361,
+            Payload(exp: "2020-01-01T00:00:00Z"),
+            new CacaoSignature(CacaoSignatureType.Eip191, "")
+        );
+
+        Assert.False(await cacao.VerifySignature("project"));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public async Task VerifySignature_NotYetValidCacao_ReturnsFalseWithoutThrowing()
+    {
+        var cacao = new CacaoObject(
+            CacaoHeader.Eip4361,
+            Payload(nbf: "2099-01-01T00:00:00Z"),
+            new CacaoSignature(CacaoSignatureType.Eip191, "")
+        );
+
+        Assert.False(await cacao.VerifySignature("project"));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public async Task VerifySignature_UnparseableExp_ReturnsFalseWithoutThrowing()
+    {
+        var cacao = new CacaoObject(
+            CacaoHeader.Eip4361,
+            Payload(exp: "not-a-timestamp"),
+            new CacaoSignature(CacaoSignatureType.Eip191, "")
+        );
+
+        Assert.False(await cacao.VerifySignature("project"));
     }
 }

--- a/test/Reown.Sign.Test/CacaoTests.cs
+++ b/test/Reown.Sign.Test/CacaoTests.cs
@@ -1,4 +1,5 @@
 using Reown.Sign.Models.Cacao;
+using Reown.Sign.Utils;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -99,6 +100,47 @@ public class CacaoTests
     public void IsWithinValidityWindow_FutureNbf_IsNotYetValid()
     {
         Assert.False(Payload(nbf: "2024-01-01T00:00:00Z").IsWithinValidityWindow(Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void IsWithinValidityWindow_NbfEqualToNow_IsValid()
+    {
+        Assert.True(Payload(nbf: "2023-11-14T22:13:20Z").IsWithinValidityWindow(Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void IsWithinValidityWindow_ExpWithNonUtcOffset_HonorsOffset()
+    {
+        Assert.False(Payload(exp: "2023-11-14T23:13:20+02:00").IsWithinValidityWindow(Now));
+        Assert.True(Payload(exp: "2023-11-15T01:13:20+02:00").IsWithinValidityWindow(Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void IsWithinValidityWindow_BlankExpAndNbf_TreatedAsAbsent()
+    {
+        Assert.True(Payload(exp: "", nbf: "   ").IsWithinValidityWindow(Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void IsWithinValidityWindow_Expired_ReportsReason()
+    {
+        Assert.False(Payload(exp: "2023-01-01T00:00:00Z").IsWithinValidityWindow(Now, out var reason));
+        Assert.Equal("expired", reason);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void NormalizeExpiration_IntegerSeconds_BecomesRfc3339()
+    {
+        var now = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
+        var normalized = CacaoUtils.NormalizeExpiration("3600", now);
+        Assert.Equal(now.AddSeconds(3600).ToRfc3339(), normalized);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void NormalizeExpiration_Timestamp_Unchanged()
+    {
+        const string timestamp = "2024-01-01T00:00:00.0000000Z";
+        Assert.Equal(timestamp, CacaoUtils.NormalizeExpiration(timestamp, Now));
     }
 
     [Fact] [Trait("Category", "unit")]

--- a/test/Reown.Sign.Test/CacaoTests.cs
+++ b/test/Reown.Sign.Test/CacaoTests.cs
@@ -133,7 +133,35 @@ public class CacaoTests
     {
         var now = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
         var normalized = CacaoUtils.NormalizeExpiration("3600", now);
-        Assert.Equal(now.AddSeconds(3600).ToRfc3339(), normalized);
+        Assert.Equal("2023-11-14T23:13:20.0000000Z", normalized);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void NormalizeExpiration_NonUtcNow_EmitsUtcZ()
+    {
+        var now = new DateTimeOffset(2023, 11, 14, 23, 13, 20, TimeSpan.FromHours(2));
+        var normalized = CacaoUtils.NormalizeExpiration("3600", now);
+        Assert.Equal("2023-11-14T22:13:20.0000000Z", normalized);
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void NormalizeExpiration_EpochLikeInteger_Unchanged()
+    {
+        const string epochSeconds = "1735689600";
+        Assert.Equal(epochSeconds, CacaoUtils.NormalizeExpiration(epochSeconds, Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void NormalizeExpiration_NegativeInteger_Unchanged()
+    {
+        Assert.Equal("-1", CacaoUtils.NormalizeExpiration("-1", Now));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public void NormalizeExpiration_EpochMilliseconds_Unchanged()
+    {
+        const string epochMs = "1735689600000";
+        Assert.Equal(epochMs, CacaoUtils.NormalizeExpiration(epochMs, Now));
     }
 
     [Fact] [Trait("Category", "unit")]


### PR DESCRIPTION
## Summary

`CacaoObject.VerifySignature` checked the signature only. It formatted `exp` and `nbf` into the CAIP-122 message, then returned true for any valid signature, including after `exp`, before `nbf`, or when those fields were unparseable.

Session authenticate (`Engine`, `EngineHandler`) and SIWE (`SiweController.VerifyMessageAsync`) treat that boolean as the gate. Request-level `ExpiryTimestamp` is a different field.

Fail closed when `exp` is present and past or unparseable, and when `nbf` is present and future or unparseable. Absent timestamps stay optional, matching CAIP-122 / EIP-4361.

Language-split of WalletConnect/walletconnect-monorepo#7312, reown-com/reown-kotlin#427, and reown-com/reown-rust#109. Distinct from reown-swift#345 (CR/LF in SIWE fields).

**Threat-model:** the attacker already holds a previously valid signed CACAO. They do not control the verifier clock or the key. After `exp` (or before `nbf`) the signature is still valid, and `VerifySignature` still returned true. That is replay after expiry, not host or agent authority.

## Test plan

- [x] `dotnet test test/Reown.Sign.Test/Reown.Sign.Test.csproj --filter FullyQualifiedName~CacaoTests` (12/12, net8.0)
- [x] `dotnet test test/Reown.Sign.Test/Reown.Sign.Test.csproj --filter Category=unit` (206/206, net8.0)
- [x] Revert-tested: removing the `IsWithinValidityWindow` check in `CacaoObject.VerifySignature` makes `VerifySignature_ExpiredCacao_ReturnsFalseWithoutThrowing` fail (empty signature reaches `SignatureUtils` and throws)