### PR TITLE
ci: stop fork PRs from failing on secret-dependent jobs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -14,11 +14,16 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
       cancel-in-progress: true
     if: |
-      (github.event_name == 'pull_request' && (github.event.action == 'ready_for_review' || github.event.pull_request.draft == false))
+      (
+        github.event_name == 'pull_request'
+        && (github.event.action == 'ready_for_review' || github.event.pull_request.draft == false)
+        && github.event.pull_request.head.repo.full_name == github.repository
+      )
       || (
         github.event_name == 'issue_comment'
         && github.event.issue.pull_request
         && contains(github.event.comment.body, '@claude review')
+        && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER')
       )
     permissions:
       contents: read
@@ -30,6 +35,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/merge', github.event.issue.number) || '' }}
 
       - name: Claude Review
         uses: WalletConnect/actions/claude/auto-review@dcfaa4e5f22b1c6f371a3d670f162cba4d221738

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - develop
     paths-ignore:
       - '**.md'
       - '.editorconfig'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository)
     name: Build and analyze
     runs-on: windows-latest
     steps:

--- a/.github/workflows/unity-build-test.yml
+++ b/.github/workflows/unity-build-test.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   buildForAllSupportedPlatforms:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository)
     name: Build for ${{ matrix.targetPlatform }}
     runs-on: ubuntu-latest
     strategy:
@@ -75,7 +75,7 @@ jobs:
           name: Build-${{ matrix.targetPlatform }}
           path: Builds/${{ matrix.targetPlatform }}
   testAllModes:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository)
     name: Test in ${{ matrix.testMode }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
On `pull_request` events from a fork, GitHub provides no repository secrets and will not grant `id-token: write`, regardless of the workflow `permissions:` block. Every job needing a secret therefore fails. On PR #322 that meant SonarCloud failing on an empty `SONAR_TOKEN` after six minutes of building and testing, five Unity jobs failing on a missing license, and the Claude review failing on OIDC.

- Gate SonarCloud and both Unity jobs on `github.event.pull_request.head.repo.full_name == github.repository`, so they skip instead of failing on fork PRs. The existing `github.event_name != 'pull_request'` short-circuit is preserved, so `push` and `workflow_dispatch` runs still evaluate true.
- Gate the `pull_request` branch of the Claude review job the same way. The `issue_comment` branch stays reachable, so a maintainer can still run the review on a fork PR — that path executes in base-repo context and does receive secrets.
- Restrict the `@claude review` comment trigger to `OWNER` and `MEMBER` commenters. Previously any commenter, including a fork PR author, could trigger a run that spends `ANTHROPIC_API_KEY`.
- Check out `refs/pull/<n>/merge` on `issue_comment` events. Without a `ref`, `actions/checkout` takes the default branch, so Claude was reviewing `develop` instead of the pull request.
- Run SonarCloud on pushes to `develop`. Analysis previously ran only on pushes to `main`, so a merged fork contribution got no analysis at all until the next release. This restores a post-merge signal for the PRs that can no longer be analyzed at PR time.

`deployToVercel` is left alone: it declares `needs: buildForAllSupportedPlatforms` and so skips when that job skips. `develop` has no required status checks, so skipped jobs do not block merges.

`pull_request_target` was deliberately not used — it runs fork-authored code with secrets in scope, and this repo's own review action flags it as CRITICAL. For the same reason there is no automated fork-PR path for Sonar: the .NET scanner needs `SONAR_TOKEN` before the build and the Roslyn output after it, so any arrangement that gets the token to the analysis also puts it next to `dotnet build` running fork code.

## Testing

`actionlint` reports 0 errors across all changed files. Each `if:` expression was re-read to confirm the `push` and `workflow_dispatch` paths still evaluate true, since `github.event.pull_request` is null on those events and a bare comparison would silently disable them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
