### PR TITLE
ci: move .NET build, test, and analysis to Linux runners

### DIFF
--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -26,8 +26,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest]
-        os: [windows-latest]
+        os: [ubuntu-latest]
         dotnet-version: [8.0.x, 9.0.x, 10.0.x]
         test-type: [unit-tests, integration-tests]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -14,7 +14,6 @@ on:
       - '**.md'
       - '.editorconfig'
       - '.github/ISSUE_TEMPLATE/**'
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -82,5 +82,8 @@ jobs:
         run: |
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"reown-com_reown-dotnet" /o:"reown-com" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.token="$SONAR_TOKEN"
           dotnet build Reown.NoUnity.slnf --no-incremental
-          dotnet-coverage collect "dotnet test Reown.NoUnity.slnf" -f xml -o "coverage.xml"
+          # Tests run here only to produce coverage. dotnet-build-test.yml is what
+          # gates test results, so a failing test must not stop the analysis from
+          # being submitted.
+          dotnet-coverage collect "dotnet test Reown.NoUnity.slnf" -f xml -o "coverage.xml" || true
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -28,6 +28,7 @@ jobs:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository)
     name: Build and analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v5

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -14,6 +14,7 @@ on:
       - '**.md'
       - '.editorconfig'
       - '.github/ISSUE_TEMPLATE/**'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -27,7 +28,7 @@ jobs:
   build:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository)
     name: Build and analyze
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -53,31 +54,34 @@ jobs:
       - name: Cache SonarQube Cloud packages
         uses: actions/cache@v6
         with:
-          path: ~\sonar\cache
+          path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarQube Cloud scanner
         id: cache-sonar-scanner
         uses: actions/cache@v6
         with:
-          path: .\.sonar\scanner
+          path: ./.sonar/scanner
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
       - name: Install SonarQube Cloud scanner
         if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
-        shell: powershell
+        shell: bash
         run: |
-          New-Item -Path .\.sonar\scanner -ItemType Directory
-          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+          mkdir -p ./.sonar/scanner
+          dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner
       - name: Install dotnet-coverage
-        run: dotnet tool install --global dotnet-coverage
+        shell: bash
+        run: |
+          dotnet tool install --global dotnet-coverage
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        shell: powershell
+        shell: bash
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"reown-com_reown-dotnet" /o:"reown-com" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.token="$env:SONAR_TOKEN"
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"reown-com_reown-dotnet" /o:"reown-com" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.token="$SONAR_TOKEN"
           dotnet build Reown.NoUnity.slnf --no-incremental
           dotnet-coverage collect "dotnet test Reown.NoUnity.slnf" -f xml -o "coverage.xml"
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="$env:SONAR_TOKEN"
+          ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,11 +308,11 @@ com.reown.appkit.unity
 ### CI/CD Pipeline
 
 **Pull Request Validation:**
-- .NET unit and integration tests on Windows (`dotnet-build-test.yml`) — requires .NET 8.0.x, 9.0.x, and 10.0.x SDKs; runs across all three target frameworks
+- .NET unit and integration tests on Linux (`dotnet-build-test.yml`) — requires .NET 8.0.x, 9.0.x, and 10.0.x SDKs; runs across all three target frameworks
 - Unity builds for Windows, Android, WebGL using `game-ci/unity-builder` v4.5 (`unity-build-test.yml`)
 - Unity playmode and editmode tests using `game-ci/unity-test-runner` v4.3.1
 - WebGL deployment to Vercel with PR comment (runs after Unity build job)
-- SonarCloud code quality analysis with coverage collection (`sonarcloud.yml`)
+- SonarCloud code quality analysis with coverage collection on Linux (`sonarcloud.yml`)
 - Claude AI code review on PRs targeting `develop`, or triggered by `@claude review` comment (`claude-review.yml`)
 - Version sync: when `src/Directory.Build.props` changes, `sync-unity-package-version.yml` auto-commits version updates
 


### PR DESCRIPTION
Switches the two Windows-pinned workflows to `ubuntu-latest`.

- `dotnet-build-test.yml`: matrix `os` goes from `windows-latest` to `ubuntu-latest`. The dotnet-version (8/9/10) and test-type (unit/integration) dimensions are unchanged, and the shared `test-dotnet` composite action needed no change — it already runs its steps under `shell: bash`. The `os` axis is kept as a single-value list so a second OS can be added back without restructuring the matrix.
- `sonarcloud.yml`: runner, cache paths, and the scanner/analysis steps move from PowerShell to bash. `~\sonar\cache` becomes `~/.sonar/cache`, which is the directory the scanner actually uses (the old path never matched anything), and `$HOME/.dotnet/tools` is added to `GITHUB_PATH` so the `dotnet-coverage` global tool resolves. The job also gets `timeout-minutes: 30`, matching `dotnet-build-test.yml` — it had none, so it inherited the 6-hour default and one run sat for 6h0m10s on 2026-08-21 before being cancelled.
- The NuGet cache needed no change: `~/.nuget/packages` is the correct global packages folder on Linux, and the key already includes `runner.os`, so Windows and Linux entries never collide.

Why: CI now matches the environment the SDK is developed and consumed on — the maintainers' Unix machines and rs-relay's Linux self-hosted runner, whose `validate_sharp` job has been failing in ways Windows CI never reproduced. Nothing in `src/` or `test/` is Windows-specific, so Windows-only coverage was not protecting anything.

Unity workflows and `release.yml` are untouched.

### One deliberate behaviour change

GitHub runs bash with `-e`, so a failing test inside `dotnet-coverage collect` would abort the analysis step. PowerShell did not stop on native exit codes, so under the old workflow a failing test was silently swallowed and the check went green. Rather than adopt either extreme, the test command is explicitly allowed to fail: this job runs tests only to produce coverage, and `dotnet-build-test.yml` is what gates test results. A failing **build** still fails the step, because analysing a tree that does not compile is meaningless.

### Testing

Six full matrix runs on Linux, 36 jobs total:

| | unit (8/9/10) | integration (8/9/10) |
|---|---|---|
| 6 runs | 18/18 pass | 15/18 pass |

All three failures were an integration job stalling silently and being killed at the 30-minute timeout — the known `Engine.RequestAsync` race fixed in #332, not a Linux problem. Confirmed platform-independent: a SonarCloud run replayed today on the **old Windows workflow** hung the same way for 45 minutes. It does appear to hit far more often on Linux than Windows CI ever showed, which is the point of the move.

SonarCloud on Linux: passes in 6m8s against a ~7m Windows baseline, coverage imported (131 main files), check correctly scoped to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
