### PR TITLE
fix(sign): register response listeners before publishing

### DIFF
--- a/src/Reown.Core.Common/Runtime/Events/EventHandlerMap.cs
+++ b/src/Reown.Core.Common/Runtime/Events/EventHandlerMap.cs
@@ -81,26 +81,33 @@ namespace Reown.Core.Common.Events
             EventHandler<TEventArgs> internalHandler = null;
             internalHandler = (src, args) =>
             {
-                this[eventId] -= internalHandler;
+                Remove(eventId, internalHandler);
                 eventHandler(src, args);
             };
-            this[eventId] += internalHandler;
 
-            var removed = false;
-            return () =>
+            Combine(eventId, internalHandler);
+
+            return () => Remove(eventId, internalHandler);
+        }
+
+        private void Combine(string eventId, EventHandler<TEventArgs> handler)
+        {
+            lock (_mappingLock)
             {
-                lock (_mappingLock)
+                _mapping.TryAdd(eventId, _beforeEventExecuted);
+                _mapping[eventId] += handler;
+            }
+        }
+
+        private void Remove(string eventId, EventHandler<TEventArgs> handler)
+        {
+            lock (_mappingLock)
+            {
+                if (_mapping.TryGetValue(eventId, out var current))
                 {
-                    if (removed)
-                    {
-                        return;
-                    }
-
-                    removed = true;
+                    _mapping[eventId] = current - handler;
                 }
-
-                this[eventId] -= internalHandler;
-            };
+            }
         }
 
         public bool TryGetValue(string eventName, out EventHandler<TEventArgs> handler)

--- a/src/Reown.Core.Common/Runtime/Events/EventHandlerMap.cs
+++ b/src/Reown.Core.Common/Runtime/Events/EventHandlerMap.cs
@@ -67,7 +67,16 @@ namespace Reown.Core.Common.Events
             // This is necessary to avoid null reference exceptions when no event handler is provided.
         }
 
-        public void ListenOnce(string eventId, EventHandler<TEventArgs> eventHandler)
+        /// <summary>
+        ///     Register an EventHandler that is removed again as soon as it fires once.
+        /// </summary>
+        /// <param name="eventId">The eventId to listen on</param>
+        /// <param name="eventHandler">The handler to invoke on the first event</param>
+        /// <returns>
+        ///     An action that removes the registration. Use it to cancel a listener that is no longer wanted
+        ///     without disturbing other listeners on the same eventId. It is safe to call more than once.
+        /// </returns>
+        public Action ListenOnce(string eventId, EventHandler<TEventArgs> eventHandler)
         {
             EventHandler<TEventArgs> internalHandler = null;
             internalHandler = (src, args) =>
@@ -76,6 +85,22 @@ namespace Reown.Core.Common.Events
                 eventHandler(src, args);
             };
             this[eventId] += internalHandler;
+
+            var removed = false;
+            return () =>
+            {
+                lock (_mappingLock)
+                {
+                    if (removed)
+                    {
+                        return;
+                    }
+
+                    removed = true;
+                }
+
+                this[eventId] -= internalHandler;
+            };
         }
 
         public bool TryGetValue(string eventName, out EventHandler<TEventArgs> handler)

--- a/src/Reown.Core.Common/Runtime/Model/Errors/SdkErrors.cs
+++ b/src/Reown.Core.Common/Runtime/Model/Errors/SdkErrors.cs
@@ -91,6 +91,9 @@
                 case ErrorType.SESSION_SETTLEMENT_FAILED:
                     errorMessage = "Session settlement failed.";
                     break;
+                case ErrorType.SESSION_REQUEST_EXPIRED:
+                    errorMessage = "Request expired. Please try again.";
+                    break;
                 case ErrorType.UNKNOWN:
                     errorMessage = "Unknown error {params}";
                     break;

--- a/src/Reown.Core/Runtime/Controllers/Pairing.cs
+++ b/src/Reown.Core/Runtime/Controllers/Pairing.cs
@@ -323,16 +323,30 @@ namespace Reown.Core.Controllers
             await IsValidPairingTopic(topic);
             if (Store.Keys.Contains(topic))
             {
-                var id = await CoreClient.MessageHandler.SendRequest<PairingPing, bool>(topic, new PairingPing());
+                var pairingPing = new PairingPing();
+                var id = CoreClient.MessageHandler.GenerateRequestId(pairingPing);
+                var pingEventId = $"pairing_ping{id}";
+
                 var done = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                _pairingPingResponseEvents.ListenOnce($"pairing_ping{id}", (sender, args) =>
+                // Registered before publishing: the pong can arrive before the relay acknowledges our publish.
+                _pairingPingResponseEvents.ListenOnce(pingEventId, (sender, args) =>
                 {
                     if (args.IsError)
-                        done.SetException(args.Error.ToException());
+                        done.TrySetException(args.Error.ToException());
                     else
-                        done.SetResult(args.Result);
+                        done.TrySetResult(args.Result);
                 });
+
+                try
+                {
+                    await CoreClient.MessageHandler.SendRequestWithId<PairingPing, bool>(topic, pairingPing, id);
+                }
+                catch
+                {
+                    _pairingPingResponseEvents.Clear(pingEventId);
+                    throw;
+                }
 
                 await done.Task;
             }
@@ -491,13 +505,9 @@ namespace Reown.Core.Controllers
             }
         }
 
-        private async Task OnPairingPingResponse(string topic, JsonRpcResponse<bool> payload)
+        private Task OnPairingPingResponse(string topic, JsonRpcResponse<bool> payload)
         {
             var id = payload.Id;
-
-            // put at the end of the stack to avoid a race condition
-            // where session_ping listener is not yet initialized
-            await Task.Delay(500);
 
             PairingPinged?.Invoke(this, new PairingEvent
             {
@@ -506,6 +516,8 @@ namespace Reown.Core.Controllers
             });
 
             _pairingPingResponseEvents[$"pairing_ping{id}"](this, payload);
+
+            return Task.CompletedTask;
         }
 
         private async Task OnPairingDeleteRequest(string topic, JsonRpcRequest<PairingDelete> payload)

--- a/src/Reown.Core/Runtime/Controllers/Pairing.cs
+++ b/src/Reown.Core/Runtime/Controllers/Pairing.cs
@@ -340,7 +340,11 @@ namespace Reown.Core.Controllers
 
                 try
                 {
-                    await CoreClient.MessageHandler.SendRequestWithId<PairingPing, bool>(topic, pairingPing, id);
+                    await CoreClient.MessageHandler.SendRequest<PairingPing, bool>(topic, pairingPing,
+                        new SendRequestOptions
+                        {
+                            RequestId = id
+                        });
                 }
                 catch
                 {

--- a/src/Reown.Core/Runtime/Controllers/Pairing.cs
+++ b/src/Reown.Core/Runtime/Controllers/Pairing.cs
@@ -325,7 +325,7 @@ namespace Reown.Core.Controllers
             {
                 var pairingPing = new PairingPing();
                 var id = CoreClient.MessageHandler.GenerateRequestId(pairingPing);
-                var pingEventId = $"pairing_ping{id}";
+                var pingEventId = $"pairing_ping_{id}";
 
                 var done = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -519,7 +519,7 @@ namespace Reown.Core.Controllers
                 Topic = topic
             });
 
-            _pairingPingResponseEvents[$"pairing_ping{id}"](this, payload);
+            _pairingPingResponseEvents[$"pairing_ping_{id}"](this, payload);
 
             return Task.CompletedTask;
         }

--- a/src/Reown.Core/Runtime/Controllers/Pairing.cs
+++ b/src/Reown.Core/Runtime/Controllers/Pairing.cs
@@ -330,7 +330,7 @@ namespace Reown.Core.Controllers
                 var done = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 // Registered before publishing: the pong can arrive before the relay acknowledges our publish.
-                _pairingPingResponseEvents.ListenOnce(pingEventId, (sender, args) =>
+                var removePingListener = _pairingPingResponseEvents.ListenOnce(pingEventId, (sender, args) =>
                 {
                     if (args.IsError)
                         done.TrySetException(args.Error.ToException());
@@ -344,7 +344,7 @@ namespace Reown.Core.Controllers
                 }
                 catch
                 {
-                    _pairingPingResponseEvents.Clear(pingEventId);
+                    removePingListener();
                     throw;
                 }
 

--- a/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
+++ b/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
@@ -376,13 +376,15 @@ namespace Reown.Core.Controllers
         }
 
         /// <summary>
-        ///     Send a typed request message with the given request / response type pair T, TR to the given topic
+        ///     Send a typed request message with the given request / response type pair T, TR to the given topic.
+        ///     Set <see cref="SendRequestOptions.RequestId" /> when a response listener has to be registered
+        ///     before the request is published, which requires knowing the request id up front.
         /// </summary>
         /// <param name="topic">The topic to send the request in</param>
         /// <param name="parameters">The typed request message to send</param>
-        /// <param name="expiry">
-        ///     An override to specify how long this request will live for. If null is given, then expiry will be taken from either T or TR
-        ///     attributed options
+        /// <param name="requestOptions">
+        ///     The id, lifetime and encoding to send the request with. All of its values are optional, and null
+        ///     is equivalent to a new instance with nothing set
         /// </param>
         /// <param name="ct">
         ///     Cancels the request only before the send begins; the token is not propagated into encoding,
@@ -390,49 +392,25 @@ namespace Reown.Core.Controllers
         /// </param>
         /// <typeparam name="T">The request type</typeparam>
         /// <typeparam name="TR">The response type</typeparam>
-        /// <returns>The id of the request sent</returns>
-        public Task<long> SendRequest<T, TR>(string topic, T parameters, long? expiry = null,
-            EncodeOptions options = null, CancellationToken ct = default)
-        {
-            return SendRequestWithId<T, TR>(topic, parameters, GenerateRequestId(parameters), expiry, options, ct);
-        }
-
-        /// <summary>
-        ///     Send a typed request message with the given request / response type pair T, TR to the given topic,
-        ///     using an id obtained beforehand from <see cref="GenerateRequestId{T}" />.
-        /// </summary>
-        /// <param name="topic">The topic to send the request in</param>
-        /// <param name="parameters">
-        ///     The typed request message to send. This must be the same, unmodified instance that
-        ///     <see cref="GenerateRequestId{T}" /> was called with
-        /// </param>
-        /// <param name="requestId">The id to send the request with</param>
-        /// <param name="expiry">
-        ///     An override to specify how long this request will live for. If null is given, then expiry will be taken from either T or TR
-        ///     attributed options
-        /// </param>
-        /// <param name="options">(optional) Crypto Encoding options</param>
-        /// <param name="ct">
-        ///     Cancels the request only before the send begins; the token is not propagated into encoding,
-        ///     history recording, or publishing
-        /// </param>
-        /// <typeparam name="T">The request type</typeparam>
-        /// <typeparam name="TR">The response type</typeparam>
-        /// <returns>The id of the request sent, which is always the given <paramref name="requestId" /></returns>
-        public async Task<long> SendRequestWithId<T, TR>(string topic, T parameters, long requestId, long? expiry = null,
-            EncodeOptions options = null, CancellationToken ct = default)
+        /// <returns>
+        ///     The id of the request sent, which is <see cref="SendRequestOptions.RequestId" /> when one was given
+        /// </returns>
+        public async Task<long> SendRequest<T, TR>(string topic, T parameters, SendRequestOptions requestOptions,
+            CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             EnsureTypeIsSerializerSafe(parameters);
 
             var method = RpcMethodAttribute.MethodForType<T>();
 
+            var requestId = requestOptions?.RequestId ?? GenerateRequestId(parameters);
             var payload = new JsonRpcRequest<T>(method, parameters, requestId);
 
-            var message = await CoreClient.Crypto.Encode(topic, payload, options);
+            var message = await CoreClient.Crypto.Encode(topic, payload, requestOptions?.EncodeOptions);
 
             var opts = RpcRequestOptionsFromType<T, TR>();
 
+            var expiry = requestOptions?.Expiry;
             if (expiry != null)
             {
                 opts.TTL = (long)expiry;
@@ -446,8 +424,35 @@ namespace Reown.Core.Controllers
         }
 
         /// <summary>
-        ///     Derive the id that <see cref="SendRequest{T,TR}(string,T,long?,EncodeOptions,CancellationToken)" />
-        ///     would use for the given request parameters.
+        ///     Send a typed request message with the given request / response type pair T, TR to the given topic
+        /// </summary>
+        /// <param name="topic">The topic to send the request in</param>
+        /// <param name="parameters">The typed request message to send</param>
+        /// <param name="expiry">
+        ///     An override to specify how long this request will live for. If null is given, then expiry will be taken from either T or TR
+        ///     attributed options
+        /// </param>
+        /// <param name="options">(optional) Crypto Encoding options</param>
+        /// <param name="ct">
+        ///     Cancels the request only before the send begins; the token is not propagated into encoding,
+        ///     history recording, or publishing
+        /// </param>
+        /// <typeparam name="T">The request type</typeparam>
+        /// <typeparam name="TR">The response type</typeparam>
+        /// <returns>The id of the request sent</returns>
+        public Task<long> SendRequest<T, TR>(string topic, T parameters, long? expiry = null,
+            EncodeOptions options = null, CancellationToken ct = default)
+        {
+            return SendRequest<T, TR>(topic, parameters, new SendRequestOptions
+            {
+                Expiry = expiry,
+                EncodeOptions = options
+            }, ct);
+        }
+
+        /// <summary>
+        ///     Derive the id that <see cref="SendRequest{T,TR}(string,T,SendRequestOptions,CancellationToken)" />
+        ///     would use for the given request parameters when no <see cref="SendRequestOptions.RequestId" /> is set.
         /// </summary>
         /// <param name="parameters">The typed request message that will be sent</param>
         /// <typeparam name="T">The request type</typeparam>

--- a/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
+++ b/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
@@ -391,7 +391,35 @@ namespace Reown.Core.Controllers
         /// <typeparam name="T">The request type</typeparam>
         /// <typeparam name="TR">The response type</typeparam>
         /// <returns>The id of the request sent</returns>
-        public async Task<long> SendRequest<T, TR>(string topic, T parameters, long? expiry = null,
+        public Task<long> SendRequest<T, TR>(string topic, T parameters, long? expiry = null,
+            EncodeOptions options = null, CancellationToken ct = default)
+        {
+            return SendRequestWithId<T, TR>(topic, parameters, GenerateRequestId(parameters), expiry, options, ct);
+        }
+
+        /// <summary>
+        ///     Send a typed request message with the given request / response type pair T, TR to the given topic,
+        ///     using an id obtained beforehand from <see cref="GenerateRequestId{T}" />.
+        /// </summary>
+        /// <param name="topic">The topic to send the request in</param>
+        /// <param name="parameters">
+        ///     The typed request message to send. This must be the same, unmodified instance that
+        ///     <see cref="GenerateRequestId{T}" /> was called with
+        /// </param>
+        /// <param name="requestId">The id to send the request with</param>
+        /// <param name="expiry">
+        ///     An override to specify how long this request will live for. If null is given, then expiry will be taken from either T or TR
+        ///     attributed options
+        /// </param>
+        /// <param name="options">(optional) Crypto Encoding options</param>
+        /// <param name="ct">
+        ///     Cancels the request only before the send begins; the token is not propagated into encoding,
+        ///     history recording, or publishing
+        /// </param>
+        /// <typeparam name="T">The request type</typeparam>
+        /// <typeparam name="TR">The response type</typeparam>
+        /// <returns>The id of the request sent, which is always the given <paramref name="requestId" /></returns>
+        public async Task<long> SendRequestWithId<T, TR>(string topic, T parameters, long requestId, long? expiry = null,
             EncodeOptions options = null, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
@@ -399,9 +427,7 @@ namespace Reown.Core.Controllers
 
             var method = RpcMethodAttribute.MethodForType<T>();
 
-            var messageId = RpcPayloadId.GenerateFromDataHash(parameters);
-
-            var payload = new JsonRpcRequest<T>(method, parameters, messageId);
+            var payload = new JsonRpcRequest<T>(method, parameters, requestId);
 
             var message = await CoreClient.Crypto.Encode(topic, payload, options);
 
@@ -417,6 +443,18 @@ namespace Reown.Core.Controllers
             await CoreClient.Relayer.Publish(topic, message, opts);
 
             return payload.Id;
+        }
+
+        /// <summary>
+        ///     Derive the id that <see cref="SendRequest{T,TR}(string,T,long?,EncodeOptions,CancellationToken)" />
+        ///     would use for the given request parameters.
+        /// </summary>
+        /// <param name="parameters">The typed request message that will be sent</param>
+        /// <typeparam name="T">The request type</typeparam>
+        /// <returns>The id the request will be sent with</returns>
+        public long GenerateRequestId<T>(T parameters)
+        {
+            return RpcPayloadId.GenerateFromDataHash(parameters);
         }
 
         /// <summary>

--- a/src/Reown.Core/Runtime/Interfaces/ITypedMessageHandler.cs
+++ b/src/Reown.Core/Runtime/Interfaces/ITypedMessageHandler.cs
@@ -110,32 +110,32 @@ namespace Reown.Core.Interfaces
         DecodeOptions DecodeOptionForTopic(string topic);
 
         /// <summary>
+        ///     Send a typed request message with the given request / response type pair T, TR to the given topic.
+        ///     Set <see cref="SendRequestOptions.RequestId" /> when a response listener has to be registered
+        ///     before the request is published, which requires knowing the request id up front.
+        /// </summary>
+        /// <param name="topic">The topic to send the request in</param>
+        /// <param name="parameters">The typed request message to send</param>
+        /// <param name="requestOptions">
+        ///     The id, lifetime and encoding to send the request with. All of its values are optional, and null
+        ///     is equivalent to a new instance with nothing set
+        /// </param>
+        /// <param name="ct">
+        ///     Cancels the request only before the send begins; the token is not propagated into encoding,
+        ///     history recording, or publishing
+        /// </param>
+        /// <typeparam name="T">The request type</typeparam>
+        /// <typeparam name="TR">The response type</typeparam>
+        /// <returns>
+        ///     The id of the request sent, which is <see cref="SendRequestOptions.RequestId" /> when one was given
+        /// </returns>
+        Task<long> SendRequest<T, TR>(string topic, T parameters, SendRequestOptions requestOptions, CancellationToken ct = default);
+
+        /// <summary>
         ///     Send a typed request message with the given request / response type pair T, TR to the given topic
         /// </summary>
         /// <param name="topic">The topic to send the request in</param>
         /// <param name="parameters">The typed request message to send</param>
-        /// <param name="expiry">
-        ///     An override to specify how long this request will live for. If null is given, then expiry will be taken from either T or TR
-        ///     attributed options
-        /// </param>
-        /// <param name="options">(optional) Crypto Encoding options</param>
-        /// <typeparam name="T">The request type</typeparam>
-        /// <typeparam name="TR">The response type</typeparam>
-        /// <returns>The id of the request sent</returns>
-        Task<long> SendRequest<T, TR>(string topic, T parameters, long? expiry = null, EncodeOptions options = null, CancellationToken ct = default);
-
-        /// <summary>
-        ///     Send a typed request message with the given request / response type pair T, TR to the given topic,
-        ///     using an id obtained beforehand from <see cref="GenerateRequestId{T}" />. Use this overload when a
-        ///     response listener has to be registered before the request is published, which requires knowing the
-        ///     request id up front.
-        /// </summary>
-        /// <param name="topic">The topic to send the request in</param>
-        /// <param name="parameters">
-        ///     The typed request message to send. This must be the same, unmodified instance that
-        ///     <see cref="GenerateRequestId{T}" /> was called with, since the id is derived from its contents
-        /// </param>
-        /// <param name="requestId">The id to send the request with, obtained from <see cref="GenerateRequestId{T}" /></param>
         /// <param name="expiry">
         ///     An override to specify how long this request will live for. If null is given, then expiry will be taken from either T or TR
         ///     attributed options
@@ -147,13 +147,14 @@ namespace Reown.Core.Interfaces
         /// </param>
         /// <typeparam name="T">The request type</typeparam>
         /// <typeparam name="TR">The response type</typeparam>
-        /// <returns>The id of the request sent, which is always the given <paramref name="requestId" /></returns>
-        Task<long> SendRequestWithId<T, TR>(string topic, T parameters, long requestId, long? expiry = null, EncodeOptions options = null, CancellationToken ct = default);
+        /// <returns>The id of the request sent</returns>
+        Task<long> SendRequest<T, TR>(string topic, T parameters, long? expiry = null, EncodeOptions options = null, CancellationToken ct = default);
 
         /// <summary>
-        ///     Derive the id that <see cref="SendRequest{T,TR}(string,T,long?,EncodeOptions,CancellationToken)" />
-        ///     would use for the given request parameters. Ids are derived from the contents of the parameters, so
-        ///     the same instance must be passed on to the send in order for the ids to match.
+        ///     Derive the id that <see cref="SendRequest{T,TR}(string,T,SendRequestOptions,CancellationToken)" />
+        ///     would use for the given request parameters when no <see cref="SendRequestOptions.RequestId" /> is
+        ///     set. Ids are derived from the contents of the parameters, so the same instance must be passed on to
+        ///     the send in order for the ids to match.
         /// </summary>
         /// <param name="parameters">The typed request message that will be sent</param>
         /// <typeparam name="T">The request type</typeparam>

--- a/src/Reown.Core/Runtime/Interfaces/ITypedMessageHandler.cs
+++ b/src/Reown.Core/Runtime/Interfaces/ITypedMessageHandler.cs
@@ -125,6 +125,42 @@ namespace Reown.Core.Interfaces
         Task<long> SendRequest<T, TR>(string topic, T parameters, long? expiry = null, EncodeOptions options = null, CancellationToken ct = default);
 
         /// <summary>
+        ///     Send a typed request message with the given request / response type pair T, TR to the given topic,
+        ///     using an id obtained beforehand from <see cref="GenerateRequestId{T}" />. Use this overload when a
+        ///     response listener has to be registered before the request is published, which requires knowing the
+        ///     request id up front.
+        /// </summary>
+        /// <param name="topic">The topic to send the request in</param>
+        /// <param name="parameters">
+        ///     The typed request message to send. This must be the same, unmodified instance that
+        ///     <see cref="GenerateRequestId{T}" /> was called with, since the id is derived from its contents
+        /// </param>
+        /// <param name="requestId">The id to send the request with, obtained from <see cref="GenerateRequestId{T}" /></param>
+        /// <param name="expiry">
+        ///     An override to specify how long this request will live for. If null is given, then expiry will be taken from either T or TR
+        ///     attributed options
+        /// </param>
+        /// <param name="options">(optional) Crypto Encoding options</param>
+        /// <param name="ct">
+        ///     Cancels the request only before the send begins; the token is not propagated into encoding,
+        ///     history recording, or publishing
+        /// </param>
+        /// <typeparam name="T">The request type</typeparam>
+        /// <typeparam name="TR">The response type</typeparam>
+        /// <returns>The id of the request sent, which is always the given <paramref name="requestId" /></returns>
+        Task<long> SendRequestWithId<T, TR>(string topic, T parameters, long requestId, long? expiry = null, EncodeOptions options = null, CancellationToken ct = default);
+
+        /// <summary>
+        ///     Derive the id that <see cref="SendRequest{T,TR}(string,T,long?,EncodeOptions,CancellationToken)" />
+        ///     would use for the given request parameters. Ids are derived from the contents of the parameters, so
+        ///     the same instance must be passed on to the send in order for the ids to match.
+        /// </summary>
+        /// <param name="parameters">The typed request message that will be sent</param>
+        /// <typeparam name="T">The request type</typeparam>
+        /// <returns>The id the request will be sent with</returns>
+        long GenerateRequestId<T>(T parameters);
+
+        /// <summary>
         ///     Send a typed response message with the given request / response type pair T, TR to the given topic
         /// </summary>
         /// <param name="id">The id of the request to respond to</param>

--- a/src/Reown.Core/Runtime/Models/MessageHandler/TypedEventHandler.cs
+++ b/src/Reown.Core/Runtime/Models/MessageHandler/TypedEventHandler.cs
@@ -39,9 +39,12 @@ namespace Reown.Core.Models.MessageHandler
 
         protected static readonly Dictionary<string, TypedEventHandler<T, TR>> Instances = new();
         private readonly object _eventLock = new();
+        private readonly object _disposeActionsLock = new();
         protected readonly List<Action> DisposeActions = new();
         protected readonly ICoreClient Ref;
         private int _activeCount;
+        private Action _detachFromParent;
+        private Task _setupTask;
 
         protected DisposeHandlerToken MessageHandler;
         protected Func<RequestEventArgs<T, TR>, bool> RequestPredicate;
@@ -68,7 +71,9 @@ namespace Reown.Core.Models.MessageHandler
         ///     Get a singleton instance of this class for the given <see cref="IEngine" /> context. The context
         ///     string of the given <see cref="IEngine" /> will be used to determine the singleton instance to
         ///     return (or if a new one needs to be created). Beware that multiple <see cref="IEngine" /> instances
-        ///     with the same context string will share the same event handlers.
+        ///     with the same context string will share the same event handlers. A cached instance whose client has
+        ///     already been disposed is discarded rather than returned, since context strings are derived from the
+        ///     client name and are therefore reused by a client that is re-created after being disposed.
         /// </summary>
         /// <param name="engine">
         ///     The engine this singleton instance is for, and where the context string will
@@ -79,7 +84,7 @@ namespace Reown.Core.Models.MessageHandler
         {
             var context = engine.Context;
 
-            if (Instances.TryGetValue(context, out var instance))
+            if (TryGetLiveInstance(engine, out var instance))
                 return instance;
 
             var newInstance = new TypedEventHandler<T, TR>(engine);
@@ -87,6 +92,50 @@ namespace Reown.Core.Models.MessageHandler
             Instances.Add(context, newInstance);
 
             return newInstance;
+        }
+
+        /// <summary>
+        ///     Returns the registered instance for the given client's context, discarding and unregistering a
+        ///     cached instance that is itself disposed or whose client has been disposed. An instance belonging to
+        ///     another client that is still alive is returned, which is the documented sharing behaviour.
+        /// </summary>
+        /// <param name="engine">The client asking for the instance</param>
+        /// <param name="instance">The registered instance, when a usable one exists</param>
+        /// <returns>true when a usable instance was found, false otherwise</returns>
+        protected static bool TryGetLiveInstance(ICoreClient engine, out TypedEventHandler<T, TR> instance)
+        {
+            var context = engine.Context;
+
+            if (!Instances.TryGetValue(context, out instance))
+                return false;
+
+            if (!instance.Disposed && !instance.Ref.Disposed)
+                return true;
+
+            Instances.Remove(context);
+
+            var stale = instance;
+            instance = null;
+
+            if (!stale.Disposed)
+            {
+                stale.Dispose();
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Disposes the instance registered for the given client's context, if there is one. Used to tear
+        ///     down a handler that another handler wraps.
+        /// </summary>
+        /// <param name="engine">The client whose registered instance should be disposed</param>
+        public static void DisposeInstance(ICoreClient engine)
+        {
+            if (Instances.TryGetValue(engine.Context, out var instance))
+            {
+                instance.Dispose();
+            }
         }
 
         /// <summary>
@@ -105,7 +154,7 @@ namespace Reown.Core.Models.MessageHandler
 
                     if (_activeCount == 0)
                     {
-                        Setup();
+                        BeginSetup();
                     }
 
                     _activeCount++;
@@ -143,7 +192,7 @@ namespace Reown.Core.Models.MessageHandler
 
                     if (_activeCount == 0)
                     {
-                        Setup();
+                        BeginSetup();
                     }
 
                     _activeCount++;
@@ -213,18 +262,77 @@ namespace Reown.Core.Models.MessageHandler
                 ResponsePredicate = responsePredicate
             };
 
-            DisposeActions.Add(wrappedRef.Dispose);
+            TrackDerivedInstance(wrappedRef);
 
             return wrappedRef;
         }
 
-        protected virtual async void Setup()
+        /// <summary>
+        ///     Registers an instance produced by <see cref="FilterRequests" /> or <see cref="FilterResponses" /> so
+        ///     that disposing this instance also disposes the derived one. The derived instance removes itself from
+        ///     this list when it is disposed first, so a long-lived handler that hands out many filtered instances
+        ///     does not accumulate dead entries.
+        /// </summary>
+        /// <param name="derived">The instance produced from this one by a filter call</param>
+        protected void TrackDerivedInstance(TypedEventHandler<T, TR> derived)
+        {
+            Action disposeDerived = derived.Dispose;
+
+            lock (_disposeActionsLock)
+            {
+                DisposeActions.Add(disposeDerived);
+            }
+
+            derived._detachFromParent = () =>
+            {
+                lock (_disposeActionsLock)
+                {
+                    DisposeActions.Remove(disposeDerived);
+                }
+            };
+        }
+
+        /// <summary>
+        ///     Returns a task that completes once the message handler registration triggered by the first
+        ///     <see cref="OnRequest" /> or <see cref="OnResponse" /> subscription has finished. Await this before
+        ///     publishing a request whose response this handler is meant to receive: registration is asynchronous,
+        ///     so a response that arrives before it completes would find no handler and be dropped.
+        /// </summary>
+        /// <returns>
+        ///     A task that completes when the handler is registered, or an already completed task when no
+        ///     subscription is currently active.
+        /// </returns>
+        public Task WhenRegisteredAsync()
+        {
+            lock (_eventLock)
+            {
+                return _setupTask ?? Task.CompletedTask;
+            }
+        }
+
+        private void BeginSetup()
+        {
+            var setupTask = SetupAsync();
+            _setupTask = setupTask;
+
+            setupTask.ContinueWith(t => ReownLogger.LogError(t.Exception),
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        /// <summary>
+        ///     Registers this handler with the underlying <see cref="ITypedMessageHandler" /> so that requests and
+        ///     responses of the type pair T, TR are routed to it. Called when the first event subscription is added.
+        /// </summary>
+        /// <returns>A task that completes once the handler is live and able to receive messages</returns>
+        protected virtual async Task SetupAsync()
         {
             MessageHandler = await Ref.MessageHandler.HandleMessageType<T, TR>(RequestCallback, ResponseCallback);
         }
 
         protected virtual void Teardown()
         {
+            _setupTask = null;
+
             if (MessageHandler != null)
             {
                 MessageHandler.Dispose();
@@ -361,13 +469,29 @@ namespace Reown.Core.Models.MessageHandler
             if (disposing)
             {
                 var context = Ref.Context;
-                foreach (var action in DisposeActions)
+
+                _detachFromParent?.Invoke();
+                _detachFromParent = null;
+
+                Action[] disposeActions;
+                lock (_disposeActionsLock)
+                {
+                    disposeActions = DisposeActions.ToArray();
+                    DisposeActions.Clear();
+                }
+
+                foreach (var action in disposeActions)
                 {
                     action();
                 }
 
-                DisposeActions.Clear();
-                Instances.Remove(context);
+                // Only the singleton registered for this context may evict itself; instances produced by
+                // FilterRequests/FilterResponses share the context but are not the registered singleton.
+                if (Instances.TryGetValue(context, out var registered) && ReferenceEquals(registered, this))
+                {
+                    Instances.Remove(context);
+                }
+
                 Teardown();
             }
 

--- a/src/Reown.Core/Runtime/Models/MessageHandler/TypedEventHandler.cs
+++ b/src/Reown.Core/Runtime/Models/MessageHandler/TypedEventHandler.cs
@@ -41,7 +41,8 @@ namespace Reown.Core.Models.MessageHandler
 
         /// <summary>
         ///     Guards every read and write of <see cref="Instances" />. Dictionary operations only: never call
-        ///     into an instance while holding it.
+        ///     into an instance while holding it. Like the dictionary it guards, this is one lock per closed
+        ///     generic type, which is what keeps the base and derived handlers of the same closed type in sync.
         /// </summary>
         protected static readonly object InstancesLock = new();
         private readonly object _eventLock = new();

--- a/src/Reown.Core/Runtime/Models/MessageHandler/TypedEventHandler.cs
+++ b/src/Reown.Core/Runtime/Models/MessageHandler/TypedEventHandler.cs
@@ -38,6 +38,12 @@ namespace Reown.Core.Models.MessageHandler
         public delegate Task ResponseMethod<TResponseArgs>(ResponseEventArgs<TResponseArgs> e);
 
         protected static readonly Dictionary<string, TypedEventHandler<T, TR>> Instances = new();
+
+        /// <summary>
+        ///     Guards every read and write of <see cref="Instances" />. Dictionary operations only: never call
+        ///     into an instance while holding it.
+        /// </summary>
+        protected static readonly object InstancesLock = new();
         private readonly object _eventLock = new();
         private readonly object _disposeActionsLock = new();
         protected readonly List<Action> DisposeActions = new();
@@ -87,11 +93,18 @@ namespace Reown.Core.Models.MessageHandler
             if (TryGetLiveInstance(engine, out var instance))
                 return instance;
 
-            var newInstance = new TypedEventHandler<T, TR>(engine);
+            lock (InstancesLock)
+            {
+                if (Instances.TryGetValue(context, out var raced))
+                {
+                    return raced;
+                }
 
-            Instances.Add(context, newInstance);
+                var newInstance = new TypedEventHandler<T, TR>(engine);
+                Instances.Add(context, newInstance);
 
-            return newInstance;
+                return newInstance;
+            }
         }
 
         /// <summary>
@@ -105,17 +118,21 @@ namespace Reown.Core.Models.MessageHandler
         protected static bool TryGetLiveInstance(ICoreClient engine, out TypedEventHandler<T, TR> instance)
         {
             var context = engine.Context;
+            TypedEventHandler<T, TR> stale;
 
-            if (!Instances.TryGetValue(context, out instance))
-                return false;
+            lock (InstancesLock)
+            {
+                if (!Instances.TryGetValue(context, out instance))
+                    return false;
 
-            if (!instance.Disposed && !instance.Ref.Disposed)
-                return true;
+                if (!instance.Disposed && !instance.Ref.Disposed)
+                    return true;
 
-            Instances.Remove(context);
+                Instances.Remove(context);
 
-            var stale = instance;
-            instance = null;
+                stale = instance;
+                instance = null;
+            }
 
             if (!stale.Disposed)
             {
@@ -132,10 +149,19 @@ namespace Reown.Core.Models.MessageHandler
         /// <param name="engine">The client whose registered instance should be disposed</param>
         public static void DisposeInstance(ICoreClient engine)
         {
-            if (Instances.TryGetValue(engine.Context, out var instance))
+            TypedEventHandler<T, TR> instance;
+
+            lock (InstancesLock)
             {
-                instance.Dispose();
+                // The reference check matters: contexts are reused, so a replacement client may already have
+                // registered its own instance under the same context.
+                if (!Instances.TryGetValue(engine.Context, out instance) || !ReferenceEquals(instance.Ref, engine))
+                {
+                    return;
+                }
             }
+
+            instance.Dispose();
         }
 
         /// <summary>
@@ -505,12 +531,18 @@ namespace Reown.Core.Models.MessageHandler
 
                 // Only the singleton registered for this context may evict itself; instances produced by
                 // FilterRequests/FilterResponses share the context but are not the registered singleton.
-                if (Instances.TryGetValue(context, out var registered) && ReferenceEquals(registered, this))
+                lock (InstancesLock)
                 {
-                    Instances.Remove(context);
+                    if (Instances.TryGetValue(context, out var registered) && ReferenceEquals(registered, this))
+                    {
+                        Instances.Remove(context);
+                    }
                 }
 
-                Teardown();
+                lock (_eventLock)
+                {
+                    Teardown();
+                }
             }
 
             Disposed = true;

--- a/src/Reown.Core/Runtime/Models/MessageHandler/TypedEventHandler.cs
+++ b/src/Reown.Core/Runtime/Models/MessageHandler/TypedEventHandler.cs
@@ -278,10 +278,7 @@ namespace Reown.Core.Models.MessageHandler
         {
             Action disposeDerived = derived.Dispose;
 
-            lock (_disposeActionsLock)
-            {
-                DisposeActions.Add(disposeDerived);
-            }
+            AddDisposeAction(disposeDerived);
 
             derived._detachFromParent = () =>
             {
@@ -290,6 +287,26 @@ namespace Reown.Core.Models.MessageHandler
                     DisposeActions.Remove(disposeDerived);
                 }
             };
+        }
+
+        /// <summary>
+        ///     Registers work to run when this instance is disposed. If it has already been disposed the action
+        ///     runs immediately, so cleanup registered by an asynchronous setup that finished after disposal is
+        ///     not silently dropped.
+        /// </summary>
+        /// <param name="action">The cleanup to run on disposal</param>
+        protected void AddDisposeAction(Action action)
+        {
+            lock (_disposeActionsLock)
+            {
+                if (!Disposed)
+                {
+                    DisposeActions.Add(action);
+                    return;
+                }
+            }
+
+            action();
         }
 
         /// <summary>
@@ -476,6 +493,7 @@ namespace Reown.Core.Models.MessageHandler
                 Action[] disposeActions;
                 lock (_disposeActionsLock)
                 {
+                    Disposed = true;
                     disposeActions = DisposeActions.ToArray();
                     DisposeActions.Clear();
                 }

--- a/src/Reown.Core/Runtime/Models/MessageHandler/TypedEventHandler.cs
+++ b/src/Reown.Core/Runtime/Models/MessageHandler/TypedEventHandler.cs
@@ -51,6 +51,7 @@ namespace Reown.Core.Models.MessageHandler
         private int _activeCount;
         private Action _detachFromParent;
         private Task _setupTask;
+        private int _setupGeneration;
 
         protected DisposeHandlerToken MessageHandler;
         protected Func<RequestEventArgs<T, TR>, bool> RequestPredicate;
@@ -128,15 +129,23 @@ namespace Reown.Core.Models.MessageHandler
                 if (!instance.Disposed && !instance.Ref.Disposed)
                     return true;
 
-                Instances.Remove(context);
-
                 stale = instance;
                 instance = null;
             }
 
+            // Disposed before the entry is removed, so an override that has to tear down a handler it wraps can
+            // still recognise itself as the registered instance.
             if (!stale.Disposed)
             {
                 stale.Dispose();
+            }
+
+            lock (InstancesLock)
+            {
+                if (Instances.TryGetValue(context, out var remaining) && ReferenceEquals(remaining, stale))
+                {
+                    Instances.Remove(context);
+                }
             }
 
             return false;
@@ -369,11 +378,27 @@ namespace Reown.Core.Models.MessageHandler
         /// <returns>A task that completes once the handler is live and able to receive messages</returns>
         protected virtual async Task SetupAsync()
         {
-            MessageHandler = await Ref.MessageHandler.HandleMessageType<T, TR>(RequestCallback, ResponseCallback);
+            var generation = _setupGeneration;
+
+            var handler = await Ref.MessageHandler.HandleMessageType<T, TR>(RequestCallback, ResponseCallback);
+
+            lock (_eventLock)
+            {
+                // A teardown while the registration was in flight makes this token obsolete. Assigning it would
+                // overwrite a newer one and leak this registration into the message handler's callback maps.
+                if (generation == _setupGeneration && !Disposed)
+                {
+                    MessageHandler = handler;
+                    return;
+                }
+            }
+
+            handler.Dispose();
         }
 
         protected virtual void Teardown()
         {
+            _setupGeneration++;
             _setupTask = null;
 
             if (MessageHandler != null)

--- a/src/Reown.Core/Runtime/Models/SendRequestOptions.cs
+++ b/src/Reown.Core/Runtime/Models/SendRequestOptions.cs
@@ -1,0 +1,33 @@
+﻿using Reown.Core.Crypto.Models;
+
+namespace Reown.Core.Models
+{
+    /// <summary>
+    ///     Options for sending a typed request message. Every value is optional, and defaults to the
+    ///     behaviour a request gets when no options are given at all.
+    /// </summary>
+    public class SendRequestOptions
+    {
+        /// <summary>
+        ///     The id to send the request with. When null, the id is derived from the contents of the request
+        ///     parameters. Set this when a response listener has to be registered before the request is
+        ///     published, which requires knowing the id up front; obtain the value from
+        ///     <see cref="Reown.Core.Interfaces.ITypedMessageHandler.GenerateRequestId{T}(T)" /> so that it
+        ///     matches the id the request would otherwise have been sent with.
+        /// </summary>
+        public long? RequestId { get; set; }
+
+        /// <summary>
+        ///     How long the request lives for, in seconds. When null, the lifetime is taken from the
+        ///     <see cref="Reown.Core.Network.Models.RpcRequestOptionsAttribute" /> on either the request or
+        ///     the response type.
+        /// </summary>
+        public long? Expiry { get; set; }
+
+        /// <summary>
+        ///     Crypto encoding options for the published message. When null, the default encoding for the
+        ///     topic is used.
+        /// </summary>
+        public EncodeOptions EncodeOptions { get; set; }
+    }
+}

--- a/src/Reown.Core/Runtime/Models/SendRequestOptions.cs
+++ b/src/Reown.Core/Runtime/Models/SendRequestOptions.cs
@@ -19,8 +19,7 @@ namespace Reown.Core.Models
 
         /// <summary>
         ///     How long the request lives for, in seconds. When null, the lifetime is taken from the
-        ///     <see cref="Reown.Core.Network.Models.RpcRequestOptionsAttribute" /> on either the request or
-        ///     the response type.
+        ///     <see cref="Reown.Core.Network.Models.RpcRequestOptionsAttribute" /> on the request type.
         /// </summary>
         public long? Expiry { get; set; }
 

--- a/src/Reown.Core/Runtime/Models/SendRequestOptions.cs.meta
+++ b/src/Reown.Core/Runtime/Models/SendRequestOptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dffd258684b24133810391cf64d0fe7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Reown.Sign.Nethereum/Runtime/Extensions.cs
+++ b/src/Reown.Sign.Nethereum/Runtime/Extensions.cs
@@ -35,6 +35,11 @@ namespace Reown.Sign.Nethereum
                 }
                 catch (ReownNetworkException e)
                 {
+                    if (e.CodeType == ErrorType.SESSION_REQUEST_EXPIRED)
+                    {
+                        throw;
+                    }
+
                     try
                     {
                         var metaMaskError = JsonConvert.DeserializeObject<MetaMaskError>(e.Message);

--- a/src/Reown.Sign.Unity/Runtime/Linker.cs
+++ b/src/Reown.Sign.Unity/Runtime/Linker.cs
@@ -195,7 +195,7 @@ namespace Reown.Sign.Unity
             if (disposed) return;
 
             if (disposing)
-                _signClient.SessionRequestSent -= SessionRequestSentHandler;
+                _signClient.SessionRequestSentUnity -= SessionRequestSentHandler;
 
             disposed = true;
         }

--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -805,11 +805,6 @@ namespace Reown.Sign
 
             responseHandlerInstance.OnResponse += onResponseHandler;
 
-            // Registering the handler is asynchronous, and the relay's acknowledgement of our publish carries no
-            // ordering guarantee against the peer's response. Wait for the handler to be live before publishing,
-            // otherwise a response that overtakes the acknowledgement is dropped and this call never completes.
-            await responseHandlerInstance.WhenRegisteredAsync();
-
             using (var timeoutTokenSource = new CancellationTokenSource(timeout))
             using (ct.Register(() => taskSource.TrySetCanceled()))
             using (timeoutTokenSource.Token.Register(() => taskSource.TrySetException(
@@ -818,6 +813,12 @@ namespace Reown.Sign
             {
                 try
                 {
+                    // Registering the handler is asynchronous, and the relay's acknowledgement of our publish
+                    // carries no ordering guarantee against the peer's response. Wait for the handler to be live
+                    // before publishing, otherwise a response that overtakes the acknowledgement is dropped and
+                    // this call never completes.
+                    await responseHandlerInstance.WhenRegisteredAsync();
+
                     var sendTask = MessageHandler.SendRequestWithId<SessionRequest<T>, TR>(topic, sessionRequest, id, publishExpiry, ct: ct);
 
                     // Racing the publish against the wait means the timeout also bounds a publish

--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -46,6 +46,7 @@ namespace Reown.Sign
 
         private readonly EventHandlerMap<SessionEvent<JToken>> _customSessionEventsHandlerMap = new();
         private readonly Dictionary<string, Action> _disposeActions = new();
+        private readonly object _disposeActionsLock = new();
         private readonly EventHandlerMap<JsonRpcResponse<bool>> _sessionEventsHandlerMap = new();
 
         private bool _initialized;
@@ -259,7 +260,10 @@ namespace Reown.Sign
             var instance = SessionRequestEventHandler<T, TR>.GetInstance(Client.CoreClient, PrivateThis);
 
             // Assigned rather than added: a replacement instance has to be the one this engine disposes.
-            _disposeActions[uniqueKey] = () => instance.Dispose();
+            lock (_disposeActionsLock)
+            {
+                _disposeActions[uniqueKey] = () => instance.Dispose();
+            }
 
             return instance;
         }
@@ -816,8 +820,17 @@ namespace Reown.Sign
                     // Registering the handler is asynchronous, and the relay's acknowledgement of our publish
                     // carries no ordering guarantee against the peer's response. Wait for the handler to be live
                     // before publishing, otherwise a response that overtakes the acknowledgement is dropped and
-                    // this call never completes.
-                    await responseHandlerInstance.WhenRegisteredAsync();
+                    // this call never completes. The wait is raced against the task source so the timeout and the
+                    // cancellation token bound this leg as well.
+                    var registration = responseHandlerInstance.WhenRegisteredAsync();
+
+                    if (!ReferenceEquals(await Task.WhenAny(registration, taskSource.Task), registration))
+                    {
+                        LogFailure(registration);
+                        return await taskSource.Task;
+                    }
+
+                    await registration;
 
                     var sendTask = MessageHandler.SendRequestWithId<SessionRequest<T>, TR>(topic, sessionRequest, id, publishExpiry, ct: ct);
 
@@ -903,6 +916,17 @@ namespace Reown.Sign
             {
                 ReownLogger.LogError(e);
             }
+        }
+
+        /// <summary>
+        ///     Observes a task whose outcome is no longer awaited, logging its exception instead of leaving it
+        ///     unobserved.
+        /// </summary>
+        /// <param name="task">The task to observe</param>
+        private static void LogFailure(Task task)
+        {
+            _ = task.ContinueWith(t => ReownLogger.LogError(t.Exception),
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
         /// <summary>
@@ -1556,7 +1580,15 @@ namespace Reown.Sign
 
                 Client.CoreClient.Expirer.Expired -= ExpiredCallback;
 
-                foreach (var action in _disposeActions.Values)
+                Action[] disposeActions;
+                lock (_disposeActionsLock)
+                {
+                    disposeActions = new Action[_disposeActions.Count];
+                    _disposeActions.Values.CopyTo(disposeActions, 0);
+                    _disposeActions.Clear();
+                }
+
+                foreach (var action in disposeActions)
                 {
                     action();
                 }
@@ -1566,7 +1598,6 @@ namespace Reown.Sign
                     disposeHandlerToken.Dispose();
                 }
 
-                _disposeActions.Clear();
                 _messageDisposeHandlers = Array.Empty<DisposeHandlerToken>();
             }
 

--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -934,6 +934,23 @@ namespace Reown.Sign
         }
 
         /// <summary>
+        ///     Undoes the state a failed <see cref="AuthenticateAsync" /> created before publishing its requests.
+        ///     Each step is guarded and failures are logged rather than masking the original error.
+        /// </summary>
+        /// <param name="fallbackProposalId">The id of the fallback session proposal</param>
+        /// <param name="authId">The id of the authentication request</param>
+        private async Task CleanUpFailedAuthenticate(long fallbackProposalId, long authId)
+        {
+            await Suppress(() => PrivateThis.DeleteProposal(fallbackProposalId));
+
+            await Suppress(() => Client.Auth.PendingRequests.Delete(authId, Error.FromErrorType(ErrorType.USER_DISCONNECTED)));
+
+            await Suppress(() => Client.CoreClient.Expirer.Has(authId)
+                ? Client.CoreClient.Expirer.Delete(authId)
+                : Task.CompletedTask);
+        }
+
+        /// <summary>
         ///     Runs one compensating cleanup step, logging a failure instead of letting it mask the error that
         ///     started the rollback or stop the remaining steps.
         /// </summary>
@@ -1109,7 +1126,7 @@ namespace Reown.Sign
                         new SendRequestOptions
                         {
                             RequestId = id
-                        });
+                        }, ct);
                 }
                 catch
                 {
@@ -1335,21 +1352,18 @@ namespace Reown.Sign
                         new SendRequestOptions
                         {
                             RequestId = authId
-                        }),
+                        }, ct),
                     MessageHandler.SendRequest<SessionPropose, SessionProposeResponse>(pairingData.Topic, proposal,
                         new SendRequestOptions
                         {
                             RequestId = fallbackId
-                        })
+                        }, ct)
                 );
             }
             catch (Exception)
             {
                 UnsubscribeAll();
-
-                await Suppress(() => PrivateThis.DeleteProposal(fallbackId));
-                await Suppress(() => Client.Auth.PendingRequests.Delete(authId, Error.FromErrorType(ErrorType.USER_DISCONNECTED)));
-                await Suppress(() => Client.CoreClient.Expirer.Has(authId) ? Client.CoreClient.Expirer.Delete(authId) : Task.CompletedTask);
+                await CleanUpFailedAuthenticate(fallbackId, authId);
 
                 throw;
             }

--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -42,6 +42,7 @@ namespace Reown.Sign
         ///     Matches the default the reference TypeScript client uses for wc_sessionRequest.
         /// </summary>
         private const long DefaultRequestExpiry = Clock.FIVE_MINUTES * 3;
+
         private const int KeyLength = 32;
 
         private readonly EventHandlerMap<SessionEvent<JToken>> _customSessionEventsHandlerMap = new();
@@ -462,7 +463,11 @@ namespace Reown.Sign
                     SessionProperties = proposal.SessionProperties
                 });
 
-                await MessageHandler.SendRequestWithId<SessionPropose, SessionProposeResponse>(topic, proposal, proposalId, ct: ct);
+                await MessageHandler.SendRequest<SessionPropose, SessionProposeResponse>(topic, proposal,
+                    new SendRequestOptions
+                    {
+                        RequestId = proposalId
+                    }, ct);
             }
             catch
             {
@@ -612,7 +617,11 @@ namespace Reown.Sign
             {
                 await Client.Session.Set(sessionTopic, session);
 
-                await MessageHandler.SendRequestWithId<SessionSettle, bool>(sessionTopic, sessionSettle, requestId, ct: ct);
+                await MessageHandler.SendRequest<SessionSettle, bool>(sessionTopic, sessionSettle,
+                    new SendRequestOptions
+                    {
+                        RequestId = requestId
+                    }, ct);
             }
             catch
             {
@@ -697,7 +706,11 @@ namespace Reown.Sign
 
             try
             {
-                await MessageHandler.SendRequestWithId<SessionUpdate, bool>(topic, sessionUpdate, id, ct: ct);
+                await MessageHandler.SendRequest<SessionUpdate, bool>(topic, sessionUpdate,
+                    new SendRequestOptions
+                    {
+                        RequestId = id
+                    }, ct);
             }
             catch
             {
@@ -739,7 +752,11 @@ namespace Reown.Sign
 
             try
             {
-                await MessageHandler.SendRequestWithId<SessionExtend, bool>(topic, sessionExtend, id, ct: ct);
+                await MessageHandler.SendRequest<SessionExtend, bool>(topic, sessionExtend,
+                    new SendRequestOptions
+                    {
+                        RequestId = id
+                    }, ct);
             }
             catch
             {
@@ -832,7 +849,12 @@ namespace Reown.Sign
 
                     await registration;
 
-                    var sendTask = MessageHandler.SendRequestWithId<SessionRequest<T>, TR>(topic, sessionRequest, id, publishExpiry, ct: ct);
+                    var sendTask = MessageHandler.SendRequest<SessionRequest<T>, TR>(topic, sessionRequest,
+                        new SendRequestOptions
+                        {
+                            RequestId = id,
+                            Expiry = publishExpiry
+                        }, ct);
 
                     // Racing the publish against the wait means the timeout also bounds a publish
                     // acknowledgement that never arrives, instead of only the peer's response.
@@ -1051,7 +1073,11 @@ namespace Reown.Sign
 
                 try
                 {
-                    await MessageHandler.SendRequestWithId<SessionPing, bool>(topic, sessionPing, id);
+                    await MessageHandler.SendRequest<SessionPing, bool>(topic, sessionPing,
+                        new SendRequestOptions
+                        {
+                            RequestId = id
+                        });
                 }
                 catch
                 {
@@ -1273,8 +1299,16 @@ namespace Reown.Sign
                 Client.CoreClient.Expirer.Set(authId, request.ExpiryTimestamp);
 
                 await Task.WhenAll(
-                    MessageHandler.SendRequestWithId<SessionAuthenticate, AuthenticateResponse>(pairingData.Topic, request, authId),
-                    MessageHandler.SendRequestWithId<SessionPropose, SessionProposeResponse>(pairingData.Topic, proposal, fallbackId)
+                    MessageHandler.SendRequest<SessionAuthenticate, AuthenticateResponse>(pairingData.Topic, request,
+                        new SendRequestOptions
+                        {
+                            RequestId = authId
+                        }),
+                    MessageHandler.SendRequest<SessionPropose, SessionProposeResponse>(pairingData.Topic, proposal,
+                        new SendRequestOptions
+                        {
+                            RequestId = fallbackId
+                        })
                 );
             }
             catch (Exception)

--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -37,7 +37,8 @@ namespace Reown.Sign
         private const long SessionExpiry = Clock.SEVEN_DAYS;
 
         /// <summary>
-        ///     How long <see cref="RequestAsync{T,TR}" /> waits for a response when the caller gives no expiry.
+        ///     How long <see cref="RequestAsync{T,TR}(string,string,T,string,long?,CancellationToken)" /> waits
+        ///     for a response when the caller gives no expiry.
         ///     Matches the default the reference TypeScript client uses for wc_sessionRequest.
         /// </summary>
         private const long DefaultRequestExpiry = Clock.FIVE_MINUTES * 3;
@@ -256,8 +257,10 @@ namespace Reown.Sign
         {
             var uniqueKey = typeof(T).FullName + "--" + typeof(TR).FullName;
             var instance = SessionRequestEventHandler<T, TR>.GetInstance(Client.CoreClient, PrivateThis);
-            if (!_disposeActions.ContainsKey(uniqueKey))
-                _disposeActions.Add(uniqueKey, () => instance.Dispose());
+
+            // Assigned rather than added: a replacement instance has to be the one this engine disposes.
+            _disposeActions[uniqueKey] = () => instance.Dispose();
+
             return instance;
         }
 
@@ -461,14 +464,7 @@ namespace Reown.Sign
             {
                 RemoveConnectionListeners();
 
-                try
-                {
-                    await PrivateThis.DeleteProposal(proposalId);
-                }
-                catch (Exception e)
-                {
-                    ReownLogger.LogError(e);
-                }
+                await Suppress(() => PrivateThis.DeleteProposal(proposalId));
 
                 throw;
             }
@@ -797,18 +793,7 @@ namespace Reown.Sign
             var responseHandlerInstance = SessionRequestEvents<T, TR>()
                 .FilterResponses(e => e.Topic == topic && e.Response.Id == id);
 
-            TypedEventHandler<T, TR>.ResponseMethod<TR> onResponseHandler = null;
-            var unsubscribed = 0;
-
-            void Unsubscribe()
-            {
-                if (Interlocked.Exchange(ref unsubscribed, 1) != 0)
-                    return;
-
-                responseHandlerInstance.OnResponse -= onResponseHandler;
-            }
-
-            onResponseHandler = args =>
+            TypedEventHandler<T, TR>.ResponseMethod<TR> onResponseHandler = args =>
             {
                 if (args.Response.IsError)
                     taskSource.TrySetException(args.Response.Error.ToException());
@@ -860,7 +845,7 @@ namespace Reown.Sign
                 }
                 finally
                 {
-                    Unsubscribe();
+                    responseHandlerInstance.OnResponse -= onResponseHandler;
                     responseHandlerInstance.Dispose();
                 }
             }
@@ -875,29 +860,43 @@ namespace Reown.Sign
         /// <param name="selfPublicKey">The key pair generated for this session</param>
         private async Task CleanUpFailedSettle(string sessionTopic, string selfPublicKey)
         {
-            try
+            await Suppress(() => Client.Session.Keys.Contains(sessionTopic)
+                ? Client.Session.Delete(sessionTopic, Error.FromErrorType(ErrorType.SESSION_SETTLEMENT_FAILED))
+                : Task.CompletedTask);
+
+            await Suppress(() => Client.CoreClient.Expirer.Has(sessionTopic)
+                ? Client.CoreClient.Expirer.Delete(sessionTopic)
+                : Task.CompletedTask);
+
+            await Suppress(() => Client.CoreClient.Relayer.Unsubscribe(sessionTopic));
+
+            await Suppress(async () =>
             {
-                if (Client.Session.Keys.Contains(sessionTopic))
-                {
-                    await Client.Session.Delete(sessionTopic, Error.FromErrorType(ErrorType.SESSION_SETTLEMENT_FAILED));
-                }
-
-                if (Client.CoreClient.Expirer.Has(sessionTopic))
-                {
-                    await Client.CoreClient.Expirer.Delete(sessionTopic);
-                }
-
-                await Client.CoreClient.Relayer.Unsubscribe(sessionTopic);
-
                 if (await Client.CoreClient.Crypto.HasKeys(selfPublicKey))
                 {
                     await Client.CoreClient.Crypto.DeleteKeyPair(selfPublicKey);
                 }
+            });
 
+            await Suppress(async () =>
+            {
                 if (await Client.CoreClient.Crypto.HasKeys(sessionTopic))
                 {
                     await Client.CoreClient.Crypto.DeleteSymKey(sessionTopic);
                 }
+            });
+        }
+
+        /// <summary>
+        ///     Runs one compensating cleanup step, logging a failure instead of letting it mask the error that
+        ///     started the rollback or stop the remaining steps.
+        /// </summary>
+        /// <param name="step">The cleanup step to run</param>
+        private static async Task Suppress(Func<Task> step)
+        {
+            try
+            {
+                await step();
             }
             catch (Exception e)
             {
@@ -1256,16 +1255,9 @@ namespace Reown.Sign
             {
                 UnsubscribeAll();
 
-                try
-                {
-                    await PrivateThis.DeleteProposal(fallbackId);
-                    await Client.Auth.PendingRequests.Delete(authId, Error.FromErrorType(ErrorType.USER_DISCONNECTED));
-                    await Client.CoreClient.Expirer.Delete(authId);
-                }
-                catch (Exception e)
-                {
-                    ReownLogger.LogError(e);
-                }
+                await Suppress(() => PrivateThis.DeleteProposal(fallbackId));
+                await Suppress(() => Client.Auth.PendingRequests.Delete(authId, Error.FromErrorType(ErrorType.USER_DISCONNECTED)));
+                await Suppress(() => Client.CoreClient.Expirer.Has(authId) ? Client.CoreClient.Expirer.Delete(authId) : Task.CompletedTask);
 
                 throw;
             }

--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -837,7 +837,7 @@ namespace Reown.Sign
             responseHandlerInstance.OnResponse += onResponseHandler;
 
             using (var timeoutTokenSource = new CancellationTokenSource(timeout))
-            using (ct.Register(() => taskSource.TrySetCanceled()))
+            using (ct.Register(() => taskSource.TrySetCanceled(ct)))
             using (timeoutTokenSource.Token.Register(() => taskSource.TrySetException(
                        ReownNetworkException.FromType(ErrorType.SESSION_REQUEST_EXPIRED,
                            context: $"No response to {method} (id {id}) on topic {topic} within {timeout.TotalSeconds} seconds."))))

--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -585,7 +585,7 @@ namespace Reown.Sign
             await Client.CoreClient.Relayer.Subscribe(sessionTopic);
 
             var requestId = MessageHandler.GenerateRequestId(sessionSettle);
-            var acknowledgeEventId = $"session_approve{requestId}";
+            var acknowledgeEventId = $"session_approve_{requestId}";
 
             var acknowledgedTask = new TaskCompletionSource<Session>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -688,7 +688,7 @@ namespace Reown.Sign
             };
 
             var id = MessageHandler.GenerateRequestId(sessionUpdate);
-            var updateEventId = $"session_update{id}";
+            var updateEventId = $"session_update_{id}";
 
             var acknowledgedTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -696,7 +696,10 @@ namespace Reown.Sign
             var removeUpdateListener = _sessionEventsHandlerMap.ListenOnce(updateEventId, (sender, args) =>
             {
                 if (ct.IsCancellationRequested)
+                {
                     acknowledgedTask.TrySetCanceled();
+                    return;
+                }
 
                 if (args.IsError)
                     acknowledgedTask.TrySetException(args.Error.ToException());
@@ -734,7 +737,7 @@ namespace Reown.Sign
 
             var sessionExtend = new SessionExtend();
             var id = MessageHandler.GenerateRequestId(sessionExtend);
-            var extendEventId = $"session_extend{id}";
+            var extendEventId = $"session_extend_{id}";
 
             var acknowledgedTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -742,7 +745,10 @@ namespace Reown.Sign
             var removeExtendListener = _sessionEventsHandlerMap.ListenOnce(extendEventId, (sender, args) =>
             {
                 if (ct.IsCancellationRequested)
+                {
                     acknowledgedTask.TrySetCanceled();
+                    return;
+                }
 
                 if (args.IsError)
                     acknowledgedTask.TrySetException(args.Error.ToException());
@@ -811,6 +817,10 @@ namespace Reown.Sign
 
             var taskSource = new TaskCompletionSource<TR>(TaskCreationOptions.RunContinuationsAsynchronously);
 
+            // When the response wins the race, SessionRequestSent is raised from the publish continuation, which
+            // runs on a relay thread. Remember where the caller is so the event is raised there instead.
+            var callerContext = SynchronizationContext.Current;
+
             var responseHandlerInstance = SessionRequestEvents<T, TR>()
                 .FilterResponses(e => e.Topic == topic && e.Response.Id == id);
 
@@ -856,8 +866,8 @@ namespace Reown.Sign
                             Expiry = publishExpiry
                         }, ct);
 
-                    // Racing the publish against the wait means the timeout also bounds a publish
-                    // acknowledgement that never arrives, instead of only the peer's response.
+                    // Race the publish too, so the timeout also covers an acknowledgement that never
+                    // arrives, not just a response that never arrives.
                     if (ReferenceEquals(await Task.WhenAny(sendTask, taskSource.Task), sendTask))
                     {
                         await sendTask;
@@ -874,7 +884,7 @@ namespace Reown.Sign
                         // The response, the timeout or cancellation won. The publish is left to finish on its
                         // own; its outcome no longer decides the result of this call, but a request that was
                         // answered still has to report that it was sent.
-                        ReportWhenSent(sendTask, taskSource.Task, topic, id, requestChainId);
+                        ReportWhenSent(sendTask, taskSource.Task, topic, id, requestChainId, callerContext);
                     }
 
                     return await taskSource.Task;
@@ -962,36 +972,58 @@ namespace Reown.Sign
         /// <param name="topic">The topic the request was published on</param>
         /// <param name="id">The id of the request</param>
         /// <param name="chainId">The chain the request was made for</param>
-        private void ReportWhenSent(Task sendTask, Task requestTask, string topic, long id, string chainId)
+        /// <param name="callerContext">
+        ///     The synchronization context the request was made on, so the event reaches subscribers there
+        ///     rather than on the thread that finished the publish. Null raises it on that thread
+        /// </param>
+        private void ReportWhenSent(Task sendTask, Task requestTask, string topic, long id, string chainId,
+            SynchronizationContext callerContext)
         {
             _ = sendTask.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
                 {
-                    if (t.IsFaulted)
-                    {
-                        ReownLogger.LogError(t.Exception);
-                        return;
-                    }
+                    ReownLogger.LogError(t.Exception);
+                    return;
+                }
 
-                    if (t.IsCanceled || requestTask.Status != TaskStatus.RanToCompletion)
-                    {
-                        return;
-                    }
+                if (t.IsCanceled || requestTask.Status != TaskStatus.RanToCompletion)
+                {
+                    return;
+                }
 
-                    try
-                    {
-                        SessionRequestSent?.Invoke(this, new SessionRequestEvent
-                        {
-                            Topic = topic,
-                            Id = id,
-                            ChainId = chainId
-                        });
-                    }
-                    catch (Exception e)
-                    {
-                        ReownLogger.LogError(e);
-                    }
-                },
-                TaskContinuationOptions.ExecuteSynchronously);
+                var sent = new SessionRequestEvent
+                {
+                    Topic = topic,
+                    Id = id,
+                    ChainId = chainId
+                };
+
+                if (callerContext == null)
+                {
+                    RaiseSessionRequestSent(sent);
+                    return;
+                }
+
+                callerContext.Post(_ => RaiseSessionRequestSent(sent), null);
+            });
+        }
+
+        /// <summary>
+        ///     Raises <see cref="SessionRequestSent" /> without letting a subscriber's exception escape onto a
+        ///     thread that has nowhere to report it.
+        /// </summary>
+        /// <param name="sent">The event to raise</param>
+        private void RaiseSessionRequestSent(SessionRequestEvent sent)
+        {
+            try
+            {
+                SessionRequestSent?.Invoke(this, sent);
+            }
+            catch (Exception e)
+            {
+                ReownLogger.LogError(e);
+            }
         }
 
         /// <summary>
@@ -1058,7 +1090,7 @@ namespace Reown.Sign
             {
                 var sessionPing = new SessionPing();
                 var id = MessageHandler.GenerateRequestId(sessionPing);
-                var pingEventId = $"session_ping{id}";
+                var pingEventId = $"session_ping_{id}";
 
                 var done = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -973,17 +973,18 @@ namespace Reown.Sign
         }
 
         /// <summary>
-        ///     Clamps a request expiry in seconds to a range that can also be expressed as a
-        ///     <see cref="CancellationTokenSource" /> delay, which is rejected above
-        ///     <see cref="int.MaxValue" /> milliseconds.
+        ///     Clamps a request expiry in seconds to a range the relay accepts as a publish time to live and
+        ///     that can also be expressed as a <see cref="CancellationTokenSource" /> delay, which is rejected
+        ///     above <see cref="int.MaxValue" /> milliseconds. The relay refuses a time to live below thirty
+        ///     seconds, so that is the floor.
         /// </summary>
         /// <param name="expirySeconds">The requested expiry, in seconds</param>
         /// <returns>The clamped expiry, in seconds</returns>
         private static long ClampExpiry(long expirySeconds)
         {
-            if (expirySeconds < Clock.ONE_SECOND)
+            if (expirySeconds < Clock.THIRTY_SECONDS)
             {
-                return Clock.ONE_SECOND;
+                return Clock.THIRTY_SECONDS;
             }
 
             return expirySeconds > Clock.SEVEN_DAYS ? Clock.SEVEN_DAYS : expirySeconds;

--- a/src/Reown.Sign/Runtime/Engine.cs
+++ b/src/Reown.Sign/Runtime/Engine.cs
@@ -35,6 +35,12 @@ namespace Reown.Sign
     {
         private const long ProposalExpiry = Clock.THIRTY_DAYS;
         private const long SessionExpiry = Clock.SEVEN_DAYS;
+
+        /// <summary>
+        ///     How long <see cref="RequestAsync{T,TR}" /> waits for a response when the caller gives no expiry.
+        ///     Matches the default the reference TypeScript client uses for wc_sessionRequest.
+        /// </summary>
+        private const long DefaultRequestExpiry = Clock.FIVE_MINUTES * 3;
         private const int KeyLength = 32;
 
         private readonly EventHandlerMap<SessionEvent<JToken>> _customSessionEventsHandlerMap = new();
@@ -431,16 +437,16 @@ namespace Reown.Sign
                 approvalTask.TrySetCanceled(ct);
             });
 
+            var proposalId = MessageHandler.GenerateRequestId(proposal);
+
             try
             {
-                var id = await MessageHandler.SendRequest<SessionPropose, SessionProposeResponse>(topic, proposal, ct: ct);
-
-                var expiry = Clock.CalculateExpiry(options.Expiry);
-
-                await PrivateThis.SetProposal(id, new ProposalStruct
+                // The proposal has to be stored before the request is published: the response handler reads it
+                // back by id, and a response can reach us before the relay acknowledges our own publish.
+                await PrivateThis.SetProposal(proposalId, new ProposalStruct
                 {
-                    Expiry = expiry,
-                    Id = id,
+                    Expiry = Clock.CalculateExpiry(options.Expiry),
+                    Id = proposalId,
                     Proposer = proposal.Proposer,
                     PairingTopic = topic,
                     Relays = proposal.Relays,
@@ -448,10 +454,22 @@ namespace Reown.Sign
                     OptionalNamespaces = proposal.OptionalNamespaces,
                     SessionProperties = proposal.SessionProperties
                 });
+
+                await MessageHandler.SendRequestWithId<SessionPropose, SessionProposeResponse>(topic, proposal, proposalId, ct: ct);
             }
             catch
             {
                 RemoveConnectionListeners();
+
+                try
+                {
+                    await PrivateThis.DeleteProposal(proposalId);
+                }
+                catch (Exception e)
+                {
+                    ReownLogger.LogError(e);
+                }
+
                 throw;
             }
 
@@ -561,36 +579,10 @@ namespace Reown.Sign
 
             await Client.CoreClient.Relayer.Subscribe(sessionTopic);
 
-            long requestId;
-            try
-            {
-                requestId = await MessageHandler.SendRequest<SessionSettle, bool>(sessionTopic, sessionSettle, ct: ct);
-            }
-            catch
-            {
-                try
-                {
-                    await Client.CoreClient.Relayer.Unsubscribe(sessionTopic);
-                    await Client.CoreClient.Crypto.DeleteKeyPair(selfPublicKey);
-                    await Client.CoreClient.Crypto.DeleteSymKey(sessionTopic);
-                }
-                catch (Exception e)
-                {
-                    ReownLogger.LogError(e);
-                }
-
-                throw;
-            }
+            var requestId = MessageHandler.GenerateRequestId(sessionSettle);
+            var acknowledgeEventId = $"session_approve{requestId}";
 
             var acknowledgedTask = new TaskCompletionSource<Session>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            _sessionEventsHandlerMap.ListenOnce($"session_approve{requestId}", (sender, args) =>
-            {
-                if (args.IsError)
-                    acknowledgedTask.SetException(args.Error.ToException());
-                else
-                    acknowledgedTask.SetResult(Client.Session.Get(sessionTopic));
-            });
 
             var session = new Session
             {
@@ -606,7 +598,31 @@ namespace Reown.Sign
                 RequiredNamespaces = requiredNamespaces
             };
 
-            await Client.Session.Set(sessionTopic, session);
+            // Both the acknowledgement listener and the session itself have to exist before the settle request is
+            // published, because the peer's response can reach us before the relay acknowledges our own publish.
+            var removeAcknowledgeListener = _sessionEventsHandlerMap.ListenOnce(acknowledgeEventId, (sender, args) =>
+            {
+                if (args.IsError)
+                    acknowledgedTask.TrySetException(args.Error.ToException());
+                else
+                    acknowledgedTask.TrySetResult(Client.Session.Get(sessionTopic));
+            });
+
+            try
+            {
+                await Client.Session.Set(sessionTopic, session);
+
+                await MessageHandler.SendRequestWithId<SessionSettle, bool>(sessionTopic, sessionSettle, requestId, ct: ct);
+            }
+            catch
+            {
+                removeAcknowledgeListener();
+
+                await CleanUpFailedSettle(sessionTopic, selfPublicKey);
+
+                throw;
+            }
+
             await PrivateThis.SetExpiry(sessionTopic, Clock.CalculateExpiry(SessionExpiry));
             if (!string.IsNullOrWhiteSpace(pairingTopic))
                 await Client.CoreClient.Pairing.UpdateMetadata(pairingTopic, session.Peer.Metadata);
@@ -656,23 +672,38 @@ namespace Reown.Sign
             ct.ThrowIfCancellationRequested();
             IsInitialized();
             await PrivateThis.IsValidUpdate(topic, namespaces);
-            var id = await MessageHandler.SendRequest<SessionUpdate, bool>(topic,
-                new SessionUpdate
-                {
-                    Namespaces = namespaces
-                }, ct: ct);
+
+            var sessionUpdate = new SessionUpdate
+            {
+                Namespaces = namespaces
+            };
+
+            var id = MessageHandler.GenerateRequestId(sessionUpdate);
+            var updateEventId = $"session_update{id}";
 
             var acknowledgedTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _sessionEventsHandlerMap.ListenOnce($"session_update{id}", (sender, args) =>
+
+            // Registered before publishing: the acknowledgement can arrive before the relay acknowledges our publish.
+            var removeUpdateListener = _sessionEventsHandlerMap.ListenOnce(updateEventId, (sender, args) =>
             {
                 if (ct.IsCancellationRequested)
                     acknowledgedTask.TrySetCanceled();
 
                 if (args.IsError)
-                    acknowledgedTask.SetException(args.Error.ToException());
+                    acknowledgedTask.TrySetException(args.Error.ToException());
                 else
-                    acknowledgedTask.SetResult(args.Result);
+                    acknowledgedTask.TrySetResult(args.Result);
             });
+
+            try
+            {
+                await MessageHandler.SendRequestWithId<SessionUpdate, bool>(topic, sessionUpdate, id, ct: ct);
+            }
+            catch
+            {
+                removeUpdateListener();
+                throw;
+            }
 
             await Client.Session.Update(topic, new Session
             {
@@ -687,20 +718,34 @@ namespace Reown.Sign
             ct.ThrowIfCancellationRequested();
             IsInitialized();
             await PrivateThis.IsValidExtend(topic);
-            var id = await MessageHandler.SendRequest<SessionExtend, bool>(topic, new SessionExtend(), ct: ct);
+
+            var sessionExtend = new SessionExtend();
+            var id = MessageHandler.GenerateRequestId(sessionExtend);
+            var extendEventId = $"session_extend{id}";
 
             var acknowledgedTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            _sessionEventsHandlerMap.ListenOnce($"session_extend{id}", (sender, args) =>
+            // Registered before publishing: the acknowledgement can arrive before the relay acknowledges our publish.
+            var removeExtendListener = _sessionEventsHandlerMap.ListenOnce(extendEventId, (sender, args) =>
             {
                 if (ct.IsCancellationRequested)
                     acknowledgedTask.TrySetCanceled();
 
                 if (args.IsError)
-                    acknowledgedTask.SetException(args.Error.ToException());
+                    acknowledgedTask.TrySetException(args.Error.ToException());
                 else
-                    acknowledgedTask.SetResult(args.Result);
+                    acknowledgedTask.TrySetResult(args.Result);
             });
+
+            try
+            {
+                await MessageHandler.SendRequestWithId<SessionExtend, bool>(topic, sessionExtend, id, ct: ct);
+            }
+            catch
+            {
+                removeExtendListener();
+                throw;
+            }
 
             await PrivateThis.SetExpiry(topic, Clock.CalculateExpiry(SessionExpiry));
 
@@ -730,26 +775,41 @@ namespace Reown.Sign
             var request = new JsonRpcRequest<T>(method, data);
 
             await PrivateThis.IsValidRequest(topic, request, requestChainId);
-            var taskSource = new TaskCompletionSource<TR>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            var id = await MessageHandler.SendRequest<SessionRequest<T>, TR>(topic,
-                new SessionRequest<T>
-                {
-                    ChainId = requestChainId,
-                    Request = request
-                }, ct: ct);
+            var sessionRequest = new SessionRequest<T>
+            {
+                ChainId = requestChainId,
+                Request = request
+            };
+
+            var id = MessageHandler.GenerateRequestId(sessionRequest);
+
+            // A caller-supplied expiry bounds both the wait and the relay's time to live, as it does in the
+            // reference clients. Without one, the wait falls back to the protocol default while the relay keeps
+            // the time to live declared on SessionRequest<T>.
+            var publishExpiry = expiry.HasValue ? ClampExpiry(expiry.Value) : (long?)null;
+            var timeout = TimeSpan.FromSeconds(publishExpiry ?? ClampExpiry(Math.Min(
+                MessageHandler.RpcRequestOptionsFromType<SessionRequest<T>, TR>().TTL,
+                DefaultRequestExpiry)));
+
+            var taskSource = new TaskCompletionSource<TR>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var responseHandlerInstance = SessionRequestEvents<T, TR>()
                 .FilterResponses(e => e.Topic == topic && e.Response.Id == id);
 
             TypedEventHandler<T, TR>.ResponseMethod<TR> onResponseHandler = null;
-            CancellationTokenRegistration ctr = default;
+            var unsubscribed = 0;
+
+            void Unsubscribe()
+            {
+                if (Interlocked.Exchange(ref unsubscribed, 1) != 0)
+                    return;
+
+                responseHandlerInstance.OnResponse -= onResponseHandler;
+            }
 
             onResponseHandler = args =>
             {
-                responseHandlerInstance.OnResponse -= onResponseHandler;
-                ctr.Dispose();
-
                 if (args.Response.IsError)
                     taskSource.TrySetException(args.Response.Error.ToException());
                 else
@@ -760,20 +820,149 @@ namespace Reown.Sign
 
             responseHandlerInstance.OnResponse += onResponseHandler;
 
-            ctr = ct.Register(() =>
-            {
-                responseHandlerInstance.OnResponse -= onResponseHandler;
-                taskSource.TrySetCanceled();
-            });
+            // Registering the handler is asynchronous, and the relay's acknowledgement of our publish carries no
+            // ordering guarantee against the peer's response. Wait for the handler to be live before publishing,
+            // otherwise a response that overtakes the acknowledgement is dropped and this call never completes.
+            await responseHandlerInstance.WhenRegisteredAsync();
 
-            SessionRequestSent?.Invoke(this, new SessionRequestEvent
+            using (var timeoutTokenSource = new CancellationTokenSource(timeout))
+            using (ct.Register(() => taskSource.TrySetCanceled()))
+            using (timeoutTokenSource.Token.Register(() => taskSource.TrySetException(
+                       ReownNetworkException.FromType(ErrorType.SESSION_REQUEST_EXPIRED,
+                           context: $"No response to {method} (id {id}) on topic {topic} within {timeout.TotalSeconds} seconds."))))
             {
-                Topic = topic,
-                Id = id,
-                ChainId = requestChainId
-            });
+                try
+                {
+                    var sendTask = MessageHandler.SendRequestWithId<SessionRequest<T>, TR>(topic, sessionRequest, id, publishExpiry, ct: ct);
 
-            return await taskSource.Task;
+                    // Racing the publish against the wait means the timeout also bounds a publish
+                    // acknowledgement that never arrives, instead of only the peer's response.
+                    if (ReferenceEquals(await Task.WhenAny(sendTask, taskSource.Task), sendTask))
+                    {
+                        await sendTask;
+
+                        SessionRequestSent?.Invoke(this, new SessionRequestEvent
+                        {
+                            Topic = topic,
+                            Id = id,
+                            ChainId = requestChainId
+                        });
+                    }
+                    else
+                    {
+                        // The response, the timeout or cancellation won. The publish is left to finish on its
+                        // own; its outcome no longer decides the result of this call, but a request that was
+                        // answered still has to report that it was sent.
+                        ReportWhenSent(sendTask, taskSource.Task, topic, id, requestChainId);
+                    }
+
+                    return await taskSource.Task;
+                }
+                finally
+                {
+                    Unsubscribe();
+                    responseHandlerInstance.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Undoes the state a failed <see cref="ApproveAsync(ApproveParams,CancellationToken)" /> created for
+        ///     the session topic. The session may already have been removed by an inbound error response, so each
+        ///     step is guarded and failures are logged rather than masking the original error.
+        /// </summary>
+        /// <param name="sessionTopic">The topic the settle request was going to be published on</param>
+        /// <param name="selfPublicKey">The key pair generated for this session</param>
+        private async Task CleanUpFailedSettle(string sessionTopic, string selfPublicKey)
+        {
+            try
+            {
+                if (Client.Session.Keys.Contains(sessionTopic))
+                {
+                    await Client.Session.Delete(sessionTopic, Error.FromErrorType(ErrorType.SESSION_SETTLEMENT_FAILED));
+                }
+
+                if (Client.CoreClient.Expirer.Has(sessionTopic))
+                {
+                    await Client.CoreClient.Expirer.Delete(sessionTopic);
+                }
+
+                await Client.CoreClient.Relayer.Unsubscribe(sessionTopic);
+
+                if (await Client.CoreClient.Crypto.HasKeys(selfPublicKey))
+                {
+                    await Client.CoreClient.Crypto.DeleteKeyPair(selfPublicKey);
+                }
+
+                if (await Client.CoreClient.Crypto.HasKeys(sessionTopic))
+                {
+                    await Client.CoreClient.Crypto.DeleteSymKey(sessionTopic);
+                }
+            }
+            catch (Exception e)
+            {
+                ReownLogger.LogError(e);
+            }
+        }
+
+        /// <summary>
+        ///     Raises <see cref="SessionRequestSent" /> once a publish that lost the race against the response
+        ///     completes, so a request that was answered before its own acknowledgement arrived still reports
+        ///     that it was sent. Nothing is raised when the request already failed or was cancelled, and a failed
+        ///     publish is logged rather than left unobserved.
+        /// </summary>
+        /// <param name="sendTask">The publish that is still in flight</param>
+        /// <param name="requestTask">The task the caller is waiting on</param>
+        /// <param name="topic">The topic the request was published on</param>
+        /// <param name="id">The id of the request</param>
+        /// <param name="chainId">The chain the request was made for</param>
+        private void ReportWhenSent(Task sendTask, Task requestTask, string topic, long id, string chainId)
+        {
+            _ = sendTask.ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                    {
+                        ReownLogger.LogError(t.Exception);
+                        return;
+                    }
+
+                    if (t.IsCanceled || requestTask.Status != TaskStatus.RanToCompletion)
+                    {
+                        return;
+                    }
+
+                    try
+                    {
+                        SessionRequestSent?.Invoke(this, new SessionRequestEvent
+                        {
+                            Topic = topic,
+                            Id = id,
+                            ChainId = chainId
+                        });
+                    }
+                    catch (Exception e)
+                    {
+                        ReownLogger.LogError(e);
+                    }
+                },
+                TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        /// <summary>
+        ///     Clamps a request expiry in seconds to a range that can also be expressed as a
+        ///     <see cref="CancellationTokenSource" /> delay, which is rejected above
+        ///     <see cref="int.MaxValue" /> milliseconds.
+        /// </summary>
+        /// <param name="expirySeconds">The requested expiry, in seconds</param>
+        /// <returns>The clamped expiry, in seconds</returns>
+        private static long ClampExpiry(long expirySeconds)
+        {
+            if (expirySeconds < Clock.ONE_SECOND)
+            {
+                return Clock.ONE_SECOND;
+            }
+
+            return expirySeconds > Clock.SEVEN_DAYS ? Clock.SEVEN_DAYS : expirySeconds;
         }
 
         public async Task RespondAsync<T, TR>(string topic, JsonRpcResponse<TR> response, CancellationToken ct = default)
@@ -820,15 +1009,31 @@ namespace Reown.Sign
 
             if (Client.Session.Keys.Contains(topic))
             {
-                var id = await MessageHandler.SendRequest<SessionPing, bool>(topic, new SessionPing());
+                var sessionPing = new SessionPing();
+                var id = MessageHandler.GenerateRequestId(sessionPing);
+                var pingEventId = $"session_ping{id}";
+
                 var done = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                _sessionEventsHandlerMap.ListenOnce($"session_ping{id}", (sender, args) =>
+
+                // Registered before publishing: the pong can arrive before the relay acknowledges our publish.
+                var removePingListener = _sessionEventsHandlerMap.ListenOnce(pingEventId, (sender, args) =>
                 {
                     if (args.IsError)
-                        done.SetException(args.Error.ToException());
+                        done.TrySetException(args.Error.ToException());
                     else
-                        done.SetResult(args.Result);
+                        done.TrySetResult(args.Result);
                 });
+
+                try
+                {
+                    await MessageHandler.SendRequestWithId<SessionPing, bool>(topic, sessionPing, id);
+                }
+                catch
+                {
+                    removePingListener();
+                    throw;
+                }
+
                 await done.Task;
             }
             else if (Client.CoreClient.Pairing.Store.Keys.Contains(topic))
@@ -1004,53 +1209,66 @@ namespace Reown.Sign
                 RequiredNamespaces = new RequiredNamespaces()
             };
 
-            long authId = default;
-            long fallbackId = default;
+            var authId = MessageHandler.GenerateRequestId(request);
+            var fallbackId = MessageHandler.GenerateRequestId(proposal);
+
             EventHandler<SessionAuthenticatedEventArgs> sessionAuthHandler = null;
             EventHandler<Session> sessionConnectedHandler = null;
             var approvalTask = new TaskCompletionSource<Session>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // Listeners and the state their handlers read back by id are established before either request is
+            // published: a response can reach us before the relay acknowledges our own publish.
+            sessionAuthHandler = (sender, session) => OnSessionAuthenticated(sender, session, fallbackId);
+            sessionConnectedHandler = (sender, session) => OnSessionConnected(sender, session, fallbackId);
+
+            SessionConnected += sessionConnectedHandler;
+            SessionConnectionErrored += OnSessionConnectionErrored;
+            SessionAuthenticated += sessionAuthHandler;
+
             try
             {
-                var ids = await Task.WhenAll(
-                    MessageHandler.SendRequest<SessionAuthenticate, AuthenticateResponse>(pairingData.Topic, request),
-                    MessageHandler.SendRequest<SessionPropose, SessionProposeResponse>(pairingData.Topic, proposal)
+                await PrivateThis.SetProposal(fallbackId, new ProposalStruct
+                {
+                    Expiry = Clock.CalculateExpiry(long.TryParse(authParams.Expiration, out var fallbackExp) ? fallbackExp : Clock.ONE_HOUR),
+                    Id = fallbackId,
+                    Proposer = participant,
+                    PairingTopic = pairingData.Topic,
+                    Relays = proposal.Relays,
+                    OptionalNamespaces = proposal.OptionalNamespaces
+                });
+
+                await Client.Auth.PendingRequests.Set(authId, new AuthPendingRequest
+                {
+                    Id = authId,
+                    Requester = participant,
+                    PairingTopic = pairingData.Topic,
+                    PayloadParams = request.Payload,
+                    Expiry = request.ExpiryTimestamp
+                });
+                Client.CoreClient.Expirer.Set(authId, request.ExpiryTimestamp);
+
+                await Task.WhenAll(
+                    MessageHandler.SendRequestWithId<SessionAuthenticate, AuthenticateResponse>(pairingData.Topic, request, authId),
+                    MessageHandler.SendRequestWithId<SessionPropose, SessionProposeResponse>(pairingData.Topic, proposal, fallbackId)
                 );
-
-                authId = ids[0];
-                fallbackId = ids[1];
-
-                sessionAuthHandler = (sender, session) => OnSessionAuthenticated(sender, session, fallbackId);
-                sessionConnectedHandler = (sender, session) => OnSessionConnected(sender, session, fallbackId);
-
-                SessionConnected += sessionConnectedHandler;
-                SessionConnectionErrored += OnSessionConnectionErrored;
-                SessionAuthenticated += sessionAuthHandler;
             }
             catch (Exception)
             {
                 UnsubscribeAll();
+
+                try
+                {
+                    await PrivateThis.DeleteProposal(fallbackId);
+                    await Client.Auth.PendingRequests.Delete(authId, Error.FromErrorType(ErrorType.USER_DISCONNECTED));
+                    await Client.CoreClient.Expirer.Delete(authId);
+                }
+                catch (Exception e)
+                {
+                    ReownLogger.LogError(e);
+                }
+
                 throw;
             }
-
-            await PrivateThis.SetProposal(fallbackId, new ProposalStruct
-            {
-                Expiry = Clock.CalculateExpiry(long.TryParse(authParams.Expiration, out var fallbackExp) ? fallbackExp : Clock.ONE_HOUR),
-                Id = fallbackId,
-                Proposer = participant,
-                PairingTopic = pairingData.Topic,
-                Relays = proposal.Relays,
-                OptionalNamespaces = proposal.OptionalNamespaces
-            });
-
-            await Client.Auth.PendingRequests.Set(authId, new AuthPendingRequest
-            {
-                Id = authId,
-                Requester = participant,
-                PairingTopic = pairingData.Topic,
-                PayloadParams = request.Payload,
-                Expiry = request.ExpiryTimestamp
-            });
-            Client.CoreClient.Expirer.Set(authId, request.ExpiryTimestamp);
 
             return new AuthenticateData(pairingData.Uri, approvalTask.Task);
 

--- a/src/Reown.Sign/Runtime/Interfaces/IEngineApi.cs
+++ b/src/Reown.Sign/Runtime/Interfaces/IEngineApi.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using Reown.Core.Common.Model.Errors;
 using Reown.Core.Models;
 using Reown.Core.Models.MessageHandler;
 using Reown.Core.Models.Pairing;
@@ -287,7 +288,8 @@ namespace Reown.Sign.Interfaces
         /// <summary>
         ///     Send a request to the session in the given topic with the request data T. You may (optionally) specify
         ///     a chainId the request should be performed in. This function will await a response of type TR from the session.
-        ///     If no response is ever received, then a Timeout exception may be thrown.
+        ///     If no response arrives before the request expires, a <see cref="ReownNetworkException" /> with
+        ///     <see cref="ErrorType.SESSION_REQUEST_EXPIRED" /> is thrown.
         ///     The type T MUST define the RpcMethodAttribute to tell the SDK what JSON RPC method to use for the given
         ///     type T.
         ///     Either type T or TR MUST define a RpcRequestOptions and RpcResponseOptions attribute to tell the SDK
@@ -298,8 +300,10 @@ namespace Reown.Sign.Interfaces
         /// <param name="data">The data of the request</param>
         /// <param name="chainId">An (optional) chainId the request should be performed in</param>
         /// <param name="expiry">
-        ///     An override to specify how long this request will live for. If null is given, then expiry will be taken from either T or TR
-        ///     attributed options
+        ///     How long, in seconds, to wait for a response and to keep the request alive on the relay. Values
+        ///     outside one second to seven days are clamped into that range. If null is given, the wait falls back
+        ///     to the protocol default of fifteen minutes and the relay keeps the request for the time to live
+        ///     declared on the attributed options of T or TR
         /// </param>
         /// <param name="ct">Cancellation token</param>
         /// <typeparam name="T">The type of the request data. MUST define the RpcMethodAttribute</typeparam>
@@ -310,7 +314,8 @@ namespace Reown.Sign.Interfaces
         /// <summary>
         ///     Send a request to the default session with the request data T. You may (optionally) specify
         ///     a chainId the request should be performed in. This function will await a response of type TR from the session.
-        ///     If no response is ever received, then a Timeout exception may be thrown.
+        ///     If no response arrives before the request expires, a <see cref="ReownNetworkException" /> with
+        ///     <see cref="ErrorType.SESSION_REQUEST_EXPIRED" /> is thrown.
         ///     The type T MUST define the RpcMethodAttribute to tell the SDK what JSON RPC method to use for the given
         ///     type T.
         ///     Either type T or TR MUST define a RpcRequestOptions and RpcResponseOptions attribute to tell the SDK
@@ -320,8 +325,10 @@ namespace Reown.Sign.Interfaces
         /// <param name="data">The data of the request</param>
         /// <param name="chainId">An (optional) chainId the request should be performed in</param>
         /// <param name="expiry">
-        ///     An override to specify how long this request will live for. If null is given, then expiry will be taken from either T or TR
-        ///     attributed options
+        ///     How long, in seconds, to wait for a response and to keep the request alive on the relay. Values
+        ///     outside one second to seven days are clamped into that range. If null is given, the wait falls back
+        ///     to the protocol default of fifteen minutes and the relay keeps the request for the time to live
+        ///     declared on the attributed options of T or TR
         /// </param>
         /// <typeparam name="T">The type of the request data. MUST define the RpcMethodAttribute</typeparam>
         /// <typeparam name="TR">The type of the response data.</typeparam>

--- a/src/Reown.Sign/Runtime/Interfaces/IEngineApi.cs
+++ b/src/Reown.Sign/Runtime/Interfaces/IEngineApi.cs
@@ -301,7 +301,8 @@ namespace Reown.Sign.Interfaces
         /// <param name="chainId">An (optional) chainId the request should be performed in</param>
         /// <param name="expiry">
         ///     How long, in seconds, to wait for a response and to keep the request alive on the relay. Values
-        ///     outside one second to seven days are clamped into that range. If null is given, the wait falls back
+        ///     outside thirty seconds to seven days are clamped into that range, which is what the relay accepts
+        ///     as a publish time to live. If null is given, the wait falls back
         ///     to the protocol default of fifteen minutes and the relay keeps the request for the time to live
         ///     declared on the attributed options of T or TR
         /// </param>
@@ -326,7 +327,8 @@ namespace Reown.Sign.Interfaces
         /// <param name="chainId">An (optional) chainId the request should be performed in</param>
         /// <param name="expiry">
         ///     How long, in seconds, to wait for a response and to keep the request alive on the relay. Values
-        ///     outside one second to seven days are clamped into that range. If null is given, the wait falls back
+        ///     outside thirty seconds to seven days are clamped into that range, which is what the relay accepts
+        ///     as a publish time to live. If null is given, the wait falls back
         ///     to the protocol default of fifteen minutes and the relay keeps the request for the time to live
         ///     declared on the attributed options of T or TR
         /// </param>

--- a/src/Reown.Sign/Runtime/Internals/EngineHandler.cs
+++ b/src/Reown.Sign/Runtime/Internals/EngineHandler.cs
@@ -270,13 +270,9 @@ namespace Reown.Sign
             }
         }
 
-        async Task IEnginePrivate.OnSessionPingResponse(string topic, JsonRpcResponse<bool> payload)
+        Task IEnginePrivate.OnSessionPingResponse(string topic, JsonRpcResponse<bool> payload)
         {
             var id = payload.Id;
-
-            // put at the end of the stack to avoid a race condition
-            // where session_ping listener is not yet initialized
-            await Task.Delay(500);
 
             SessionPinged?.Invoke(this, new SessionEvent
             {
@@ -286,6 +282,8 @@ namespace Reown.Sign
 
             // Still used, do not remove
             _sessionEventsHandlerMap[$"session_ping{id}"](this, payload);
+
+            return Task.CompletedTask;
         }
 
         async Task IEnginePrivate.OnSessionDeleteRequest(string topic, JsonRpcRequest<SessionDelete> payload)

--- a/src/Reown.Sign/Runtime/Internals/EngineHandler.cs
+++ b/src/Reown.Sign/Runtime/Internals/EngineHandler.cs
@@ -167,7 +167,7 @@ namespace Reown.Sign
                 SessionRejected?.Invoke(this, session);
 
                 // Still used do not remove
-                _sessionEventsHandlerMap[$"session_approve{id}"](this, payload);
+                _sessionEventsHandlerMap[$"session_approve_{id}"](this, payload);
             }
             else
             {
@@ -176,7 +176,7 @@ namespace Reown.Sign
                     Acknowledged = true
                 });
                 SessionApproved?.Invoke(this, session);
-                _sessionEventsHandlerMap[$"session_approve{id}"](this, payload);
+                _sessionEventsHandlerMap[$"session_approve_{id}"](this, payload);
             }
         }
 
@@ -216,7 +216,7 @@ namespace Reown.Sign
                 Topic = topic
             });
             // Still used, do not remove
-            _sessionEventsHandlerMap[$"session_update{id}"](this, payload);
+            _sessionEventsHandlerMap[$"session_update_{id}"](this, payload);
         }
 
         async Task IEnginePrivate.OnSessionExtendRequest(string topic, JsonRpcRequest<SessionExtend> payload)
@@ -248,7 +248,7 @@ namespace Reown.Sign
                 Id = id
             });
             // Still used, do not remove
-            _sessionEventsHandlerMap[$"session_extend{id}"](this, payload);
+            _sessionEventsHandlerMap[$"session_extend_{id}"](this, payload);
         }
 
         async Task IEnginePrivate.OnSessionPingRequest(string topic, JsonRpcRequest<SessionPing> payload)
@@ -281,7 +281,7 @@ namespace Reown.Sign
             });
 
             // Still used, do not remove
-            _sessionEventsHandlerMap[$"session_ping{id}"](this, payload);
+            _sessionEventsHandlerMap[$"session_ping_{id}"](this, payload);
 
             return Task.CompletedTask;
         }

--- a/src/Reown.Sign/Runtime/Models/SessionRequestEventHandler.cs
+++ b/src/Reown.Sign/Runtime/Models/SessionRequestEventHandler.cs
@@ -39,7 +39,7 @@ namespace Reown.Sign.Models
         {
             var context = engine.Context;
 
-            if (Instances.TryGetValue(context, out var instance))
+            if (TryGetLiveInstance(engine, out var instance))
                 return instance;
 
             var newInstance = new SessionRequestEventHandler<T, TR>(engine, enginePrivate);
@@ -58,12 +58,19 @@ namespace Reown.Sign.Models
                 ResponsePredicate = responsePredicate
             };
 
-            DisposeActions.Add(instance.Dispose);
+            TrackDerivedInstance(instance);
 
             return instance;
         }
 
-        protected override void Setup()
+        /// <summary>
+        ///     Subscribes to the shared handler for the wrapped <see cref="SessionRequest{T}" /> type pair and
+        ///     completes only once that handler is itself registered, so that awaiting
+        ///     <see cref="TypedEventHandler{T,TR}.WhenRegisteredAsync" /> on this instance guarantees the whole
+        ///     chain is live.
+        /// </summary>
+        /// <returns>A task that completes once the wrapped handler is registered</returns>
+        protected override async Task SetupAsync()
         {
             var wrappedRef = TypedEventHandler<SessionRequest<T>, TR>.GetInstance(Ref);
 
@@ -74,8 +81,32 @@ namespace Reown.Sign.Models
             {
                 wrappedRef.OnRequest -= WrappedRefOnOnRequest;
                 wrappedRef.OnResponse -= WrappedRefOnOnResponse;
-                wrappedRef.Dispose();
             });
+
+            await wrappedRef.WhenRegisteredAsync();
+        }
+
+        /// <summary>
+        ///     Disposes this handler and, when this is the instance registered for the client's context, the
+        ///     shared handler for the wrapped <see cref="SessionRequest{T}" /> type pair as well. Instances
+        ///     produced by the filter methods only unsubscribe, because they share that wrapped handler.
+        /// </summary>
+        /// <param name="disposing">Whether managed resources should be released</param>
+        protected override void Dispose(bool disposing)
+        {
+            var disposeWrapped = disposing && !Disposed && IsRegisteredInstance();
+
+            base.Dispose(disposing);
+
+            if (disposeWrapped)
+            {
+                TypedEventHandler<SessionRequest<T>, TR>.DisposeInstance(Ref);
+            }
+        }
+
+        private bool IsRegisteredInstance()
+        {
+            return Instances.TryGetValue(Ref.Context, out var registered) && ReferenceEquals(registered, this);
         }
 
         private Task WrappedRefOnOnResponse(ResponseEventArgs<TR> e)

--- a/src/Reown.Sign/Runtime/Models/SessionRequestEventHandler.cs
+++ b/src/Reown.Sign/Runtime/Models/SessionRequestEventHandler.cs
@@ -19,6 +19,8 @@ namespace Reown.Sign.Models
     {
         private readonly IEnginePrivate _enginePrivate;
 
+        private TypedEventHandler<SessionRequest<T>, TR> _wrappedRef;
+
         protected SessionRequestEventHandler(ICoreClient engine, IEnginePrivate enginePrivate) : base(engine)
         {
             _enginePrivate = enginePrivate;
@@ -74,16 +76,31 @@ namespace Reown.Sign.Models
         {
             var wrappedRef = TypedEventHandler<SessionRequest<T>, TR>.GetInstance(Ref);
 
+            _wrappedRef = wrappedRef;
+
             wrappedRef.OnRequest += WrappedRefOnOnRequest;
             wrappedRef.OnResponse += WrappedRefOnOnResponse;
 
-            DisposeActions.Add(() =>
+            await wrappedRef.WhenRegisteredAsync();
+        }
+
+        /// <summary>
+        ///     Detaches from the shared handler for the wrapped <see cref="SessionRequest{T}" /> type pair. This
+        ///     runs whenever the last subscription is removed, not only on disposal, so re-subscribing this
+        ///     instance cannot leave a second set of forwarding handlers behind.
+        /// </summary>
+        protected override void Teardown()
+        {
+            var wrappedRef = _wrappedRef;
+            if (wrappedRef != null)
             {
+                _wrappedRef = null;
+
                 wrappedRef.OnRequest -= WrappedRefOnOnRequest;
                 wrappedRef.OnResponse -= WrappedRefOnOnResponse;
-            });
+            }
 
-            await wrappedRef.WhenRegisteredAsync();
+            base.Teardown();
         }
 
         /// <summary>

--- a/src/Reown.Sign/Runtime/Models/SessionRequestEventHandler.cs
+++ b/src/Reown.Sign/Runtime/Models/SessionRequestEventHandler.cs
@@ -44,11 +44,18 @@ namespace Reown.Sign.Models
             if (TryGetLiveInstance(engine, out var instance))
                 return instance;
 
-            var newInstance = new SessionRequestEventHandler<T, TR>(engine, enginePrivate);
+            lock (InstancesLock)
+            {
+                if (Instances.TryGetValue(context, out var raced))
+                {
+                    return raced;
+                }
 
-            Instances.Add(context, newInstance);
+                var newInstance = new SessionRequestEventHandler<T, TR>(engine, enginePrivate);
+                Instances.Add(context, newInstance);
 
-            return newInstance;
+                return newInstance;
+            }
         }
 
         protected override TypedEventHandler<T, TR> BuildNew(ICoreClient @ref,
@@ -123,7 +130,10 @@ namespace Reown.Sign.Models
 
         private bool IsRegisteredInstance()
         {
-            return Instances.TryGetValue(Ref.Context, out var registered) && ReferenceEquals(registered, this);
+            lock (InstancesLock)
+            {
+                return Instances.TryGetValue(Ref.Context, out var registered) && ReferenceEquals(registered, this);
+            }
         }
 
         private Task WrappedRefOnOnResponse(ResponseEventArgs<TR> e)

--- a/test/Reown.Core.Common.Test/SdkErrorsTests.cs
+++ b/test/Reown.Core.Common.Test/SdkErrorsTests.cs
@@ -28,6 +28,7 @@ public class SdkErrorsTests
     [InlineData(ErrorType.JSONRPC_REQUEST_METHOD_REJECTED, "User rejected the request.")]
     [InlineData(ErrorType.USER_DISCONNECTED, "User disconnected.")]
     [InlineData(ErrorType.SESSION_SETTLEMENT_FAILED, "Session settlement failed.")]
+    [InlineData(ErrorType.SESSION_REQUEST_EXPIRED, "Request expired. Please try again.")]
     [InlineData(ErrorType.WC_METHOD_UNSUPPORTED, "Unsupported wc_ method")]
     [InlineData(ErrorType.UNKNOWN, "Unknown error {params}")]
     public void MessageFromType_KnownTypes_ReturnsExpectedMessage(ErrorType type, string expected)
@@ -37,7 +38,6 @@ public class SdkErrorsTests
 
     [Theory]
     [InlineData(ErrorType.SETTLE_TIMEOUT)]
-    [InlineData(ErrorType.SESSION_REQUEST_EXPIRED)]
     public void MessageFromType_UnmappedTypes_FallsBackToGenericMessage(ErrorType type)
     {
         Assert.Equal("{message}", SdkErrors.MessageFromType(type));

--- a/test/Reown.Core.Network.Test/TypedMessageHandlerTests.cs
+++ b/test/Reown.Core.Network.Test/TypedMessageHandlerTests.cs
@@ -4,10 +4,12 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NSubstitute;
 using Reown.Core.Common.Logging;
+using Reown.Core.Common.Utils;
 using Reown.Core.Controllers;
 using Reown.Core.Crypto;
 using Reown.Core.Crypto.Models;
 using Reown.Core.Interfaces;
+using Reown.Core.Models;
 using Reown.Core.Models.Relay;
 using Reown.Core.Network.Models;
 using Xunit;
@@ -94,6 +96,166 @@ namespace Reown.Core.Network.Test
                 this, new MessageEvent { Topic = topic, Message = "encrypted" });
 
             Assert.Contains(_logger.Messages, m => m.Contains($"Dropping message on topic {topic}"));
+        }
+
+        /// <summary>
+        ///     With no options the request is published under the id derived from its parameters, with the
+        ///     lifetime declared on the request type and no encode options.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task SendRequest_WithNullOptions_PublishesTheDerivedIdAndTheAttributedTimeToLive()
+        {
+            const string topic = "send-derived-id";
+
+            var coreClient = CreateCoreClientForSend();
+            var capture = CaptureSend(coreClient);
+            var handler = new TypedMessageHandler(coreClient);
+
+            var parameters = new SendProbeRequest { a = 7 };
+            var derivedId = handler.GenerateRequestId(parameters);
+
+            var id = await handler.SendRequest<SendProbeRequest, SendProbeResponse>(topic, parameters, requestOptions: null);
+
+            Assert.Equal(derivedId, id);
+            Assert.Equal(derivedId, capture.Payload?.Id);
+            Assert.Null(capture.EncodeOptions);
+            Assert.Equal(Clock.ONE_MINUTE, capture.PublishOptions?.TTL);
+        }
+
+        /// <summary>
+        ///     An explicit id is the one published, which is what lets a caller register a response listener
+        ///     before the request goes out.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task SendRequest_WithARequestId_PublishesThatId()
+        {
+            const string topic = "send-explicit-id";
+            const long explicitId = 1234567890123456;
+
+            var coreClient = CreateCoreClientForSend();
+            var capture = CaptureSend(coreClient);
+            var handler = new TypedMessageHandler(coreClient);
+
+            var parameters = new SendProbeRequest { a = 7 };
+            Assert.NotEqual(explicitId, handler.GenerateRequestId(parameters));
+
+            var id = await handler.SendRequest<SendProbeRequest, SendProbeResponse>(topic, parameters,
+                new SendRequestOptions { RequestId = explicitId });
+
+            Assert.Equal(explicitId, id);
+            Assert.Equal(explicitId, capture.Payload?.Id);
+        }
+
+        /// <summary>
+        ///     An expiry replaces the lifetime declared on the request type.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task SendRequest_WithAnExpiry_OverridesTheAttributedTimeToLive()
+        {
+            const string topic = "send-expiry";
+
+            var coreClient = CreateCoreClientForSend();
+            var capture = CaptureSend(coreClient);
+            var handler = new TypedMessageHandler(coreClient);
+
+            await handler.SendRequest<SendProbeRequest, SendProbeResponse>(topic, new SendProbeRequest { a = 7 },
+                new SendRequestOptions { Expiry = Clock.THIRTY_SECONDS });
+
+            Assert.Equal(Clock.THIRTY_SECONDS, capture.PublishOptions?.TTL);
+        }
+
+        /// <summary>
+        ///     Encode options reach the crypto layer untouched.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task SendRequest_ForwardsTheEncodeOptions()
+        {
+            const string topic = "send-encode-options";
+
+            var coreClient = CreateCoreClientForSend();
+            var capture = CaptureSend(coreClient);
+            var handler = new TypedMessageHandler(coreClient);
+
+            var encodeOptions = new EncodeOptions { SenderPublicKey = "sender", ReceiverPublicKey = "receiver" };
+
+            await handler.SendRequest<SendProbeRequest, SendProbeResponse>(topic, new SendProbeRequest { a = 7 },
+                new SendRequestOptions { EncodeOptions = encodeOptions });
+
+            Assert.Same(encodeOptions, capture.EncodeOptions);
+        }
+
+        /// <summary>
+        ///     The overload that takes the expiry and encode options directly still derives the id and forwards
+        ///     both values, so callers written against it keep their behaviour.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task SendRequest_WithTheExpiryOverload_DerivesTheIdAndForwardsBothValues()
+        {
+            const string topic = "send-legacy-overload";
+
+            var coreClient = CreateCoreClientForSend();
+            var capture = CaptureSend(coreClient);
+            var handler = new TypedMessageHandler(coreClient);
+
+            var parameters = new SendProbeRequest { a = 7 };
+            var encodeOptions = new EncodeOptions { SenderPublicKey = "sender", ReceiverPublicKey = "receiver" };
+
+            var id = await handler.SendRequest<SendProbeRequest, SendProbeResponse>(topic, parameters,
+                Clock.THIRTY_SECONDS, encodeOptions);
+
+            Assert.Equal(handler.GenerateRequestId(parameters), id);
+            Assert.Equal(handler.GenerateRequestId(parameters), capture.Payload?.Id);
+            Assert.Equal(Clock.THIRTY_SECONDS, capture.PublishOptions?.TTL);
+            Assert.Same(encodeOptions, capture.EncodeOptions);
+        }
+
+        private static ICoreClient CreateCoreClientForSend()
+        {
+            var coreClient = CreateCoreClient();
+            coreClient.History.JsonRpcHistoryOfType<SendProbeRequest, SendProbeResponse>()
+                .Returns(Task.FromResult(Substitute.For<IJsonRpcHistory<SendProbeRequest, SendProbeResponse>>()));
+            return coreClient;
+        }
+
+        private static SendCapture CaptureSend(ICoreClient coreClient)
+        {
+            var capture = new SendCapture();
+
+            coreClient.Crypto
+                .Encode(Arg.Any<string>(), Arg.Do<IJsonRpcPayload>(p => capture.Payload = p),
+                    Arg.Do<EncodeOptions>(o => capture.EncodeOptions = o))
+                .Returns(Task.FromResult("encoded"));
+
+            coreClient.Relayer
+                .Publish(Arg.Any<string>(), Arg.Any<string>(), Arg.Do<PublishOptions>(o => capture.PublishOptions = o))
+                .Returns(Task.CompletedTask);
+
+            return capture;
+        }
+
+        private sealed class SendCapture
+        {
+            public IJsonRpcPayload? Payload { get; set; }
+            public EncodeOptions? EncodeOptions { get; set; }
+            public PublishOptions? PublishOptions { get; set; }
+        }
+
+        [RpcMethod("test_send_request")]
+        [RpcRequestOptions(Clock.ONE_MINUTE, 99820)]
+        public sealed class SendProbeRequest
+        {
+            public int a;
+        }
+
+        [RpcResponseOptions(Clock.ONE_MINUTE, 99821)]
+        public sealed class SendProbeResponse
+        {
+            public int result;
         }
 
         private static ICoreClient CreateCoreClient()

--- a/test/Reown.Sign.Test/AckDeferringConnection.cs
+++ b/test/Reown.Sign.Test/AckDeferringConnection.cs
@@ -1,0 +1,244 @@
+using Reown.Core.Network;
+using Reown.Core.Network.Interfaces;
+using Reown.Core.Network.Models;
+using Reown.Core.Network.Websocket;
+
+namespace Reown.Sign.Test;
+
+/// <summary>
+///     Builds connections that hold back the relay's acknowledgement of our own <c>irn_publish</c> until
+///     the peer's response has been delivered, which forces the frame ordering that a loaded relay
+///     produces naturally.
+/// </summary>
+internal sealed class AckDeferringConnectionBuilder : IConnectionBuilder
+{
+    private readonly WebsocketConnectionBuilder _inner = new();
+
+    /// <summary>
+    ///     The connection most recently created by this builder.
+    /// </summary>
+    public AckDeferringConnection? Connection { get; private set; }
+
+    public async Task<IJsonRpcConnection> CreateConnection(string url, string? context = null)
+    {
+        var connection = new AckDeferringConnection(await _inner.CreateConnection(url, context));
+        Connection = connection;
+        return connection;
+    }
+}
+
+/// <summary>
+///     Decorates a relay connection so that, while armed, the acknowledgement of an <c>irn_publish</c> we
+///     sent is withheld until an inbound relay push has been forwarded and had time to be processed. The
+///     relay gives no ordering guarantee between the two frames, so this reproduces deterministically what
+///     otherwise happens intermittently: the peer's response reaches the SDK before the publish returns.
+/// </summary>
+internal sealed class AckDeferringConnection : IJsonRpcConnection
+{
+    private const string PublishMethod = "irn_publish";
+    private const string SubscriptionMethod = "irn_subscription";
+
+    /// <summary>
+    ///     How long to keep holding the acknowledgement after the inbound push was forwarded, so that the
+    ///     push is fully processed before the publish call returns.
+    /// </summary>
+    private static readonly TimeSpan PostPushDelay = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    ///     Upper bound on how long an acknowledgement is held when no inbound push arrives at all, so that
+    ///     a request without a response cannot wedge the connection.
+    /// </summary>
+    private static readonly TimeSpan SafetyDelay = TimeSpan.FromSeconds(10);
+
+    private readonly IJsonRpcConnection _inner;
+    private readonly object _gate = new();
+    private readonly HashSet<long> _pendingPublishIds = [];
+    private readonly List<string> _heldAcks = [];
+
+    private bool _armed;
+
+    public AckDeferringConnection(IJsonRpcConnection inner)
+    {
+        _inner = inner;
+
+        _inner.PayloadReceived += OnInnerPayloadReceived;
+        _inner.Closed += (_, e) => Closed?.Invoke(this, e);
+        _inner.ErrorReceived += (_, e) => ErrorReceived?.Invoke(this, e);
+        _inner.Opened += (_, e) => Opened?.Invoke(this, e);
+        _inner.RegisterErrored += (_, e) => RegisterErrored?.Invoke(this, e);
+    }
+
+    /// <summary>
+    ///     Whether an inbound push was forwarded while an acknowledgement was being held. When this is
+    ///     false the test did not actually exercise the inverted ordering.
+    /// </summary>
+    public bool DeliveredPushBeforeAck { get; private set; }
+
+    public bool Connected => _inner.Connected;
+    public bool Connecting => _inner.Connecting;
+    public string Url => _inner.Url;
+    public bool IsPaused => _inner.IsPaused;
+
+    public event EventHandler<string>? PayloadReceived;
+    public event EventHandler? Closed;
+    public event EventHandler<Exception>? ErrorReceived;
+    public event EventHandler<object>? Opened;
+    public event EventHandler<Exception>? RegisterErrored;
+
+    public Task Open() => _inner.Open();
+
+    public Task Open<T>(T options) => _inner.Open(options);
+
+    public Task Close()
+    {
+        ReleaseAll();
+        return _inner.Close();
+    }
+
+    public Task SendRequest<T>(IJsonRpcRequest<T> requestPayload, object context)
+    {
+        lock (_gate)
+        {
+            if (_armed && requestPayload.Method == PublishMethod)
+            {
+                _pendingPublishIds.Add(requestPayload.Id);
+            }
+        }
+
+        return _inner.SendRequest(requestPayload, context);
+    }
+
+    public Task SendResult<T>(IJsonRpcResult<T> responsePayload, object context) => _inner.SendResult(responsePayload, context);
+
+    public Task SendError(IJsonRpcError errorPayload, object context) => _inner.SendError(errorPayload, context);
+
+    public void Dispose()
+    {
+        _inner.PayloadReceived -= OnInnerPayloadReceived;
+        ReleaseAll();
+        _inner.Dispose();
+    }
+
+    /// <summary>
+    ///     Starts withholding publish acknowledgements.
+    /// </summary>
+    public void Arm()
+    {
+        lock (_gate)
+        {
+            _armed = true;
+            DeliveredPushBeforeAck = false;
+        }
+    }
+
+    /// <summary>
+    ///     Stops withholding acknowledgements and forwards anything still held.
+    /// </summary>
+    public void ReleaseAll()
+    {
+        lock (_gate)
+        {
+            _armed = false;
+            _pendingPublishIds.Clear();
+        }
+
+        Release();
+    }
+
+    private void OnInnerPayloadReceived(object? sender, string json)
+    {
+        var isPush = json.Contains(SubscriptionMethod, StringComparison.Ordinal);
+        var holdThisFrame = false;
+        var releaseAfterPush = false;
+
+        lock (_gate)
+        {
+            if (_armed)
+            {
+                if (isPush)
+                {
+                    if (_heldAcks.Count > 0)
+                    {
+                        DeliveredPushBeforeAck = true;
+                        releaseAfterPush = true;
+                    }
+                }
+                else if (TryGetResponseId(json, out var id) && _pendingPublishIds.Remove(id))
+                {
+                    _heldAcks.Add(json);
+                    holdThisFrame = true;
+                }
+            }
+        }
+
+        if (holdThisFrame)
+        {
+            _ = ReleaseAfterAsync(SafetyDelay);
+            return;
+        }
+
+        PayloadReceived?.Invoke(this, json);
+
+        if (releaseAfterPush)
+        {
+            _ = ReleaseAfterAsync(PostPushDelay);
+        }
+    }
+
+    private async Task ReleaseAfterAsync(TimeSpan delay)
+    {
+        await Task.Delay(delay);
+        Release();
+    }
+
+    private void Release()
+    {
+        string[] held;
+        lock (_gate)
+        {
+            if (_heldAcks.Count == 0)
+            {
+                return;
+            }
+
+            held = _heldAcks.ToArray();
+            _heldAcks.Clear();
+        }
+
+        foreach (var payload in held)
+        {
+            PayloadReceived?.Invoke(this, payload);
+        }
+    }
+
+    private static bool TryGetResponseId(string json, out long id)
+    {
+        id = 0;
+
+        var idIndex = json.IndexOf("\"id\"", StringComparison.Ordinal);
+        if (idIndex < 0)
+        {
+            return false;
+        }
+
+        var colon = json.IndexOf(':', idIndex);
+        if (colon < 0)
+        {
+            return false;
+        }
+
+        var start = colon + 1;
+        while (start < json.Length && (json[start] == ' ' || json[start] == '"'))
+        {
+            start++;
+        }
+
+        var end = start;
+        while (end < json.Length && char.IsDigit(json[end]))
+        {
+            end++;
+        }
+
+        return end > start && long.TryParse(json.AsSpan(start, end - start), out id);
+    }
+}

--- a/test/Reown.Sign.Test/AckDeferringConnection.cs
+++ b/test/Reown.Sign.Test/AckDeferringConnection.cs
@@ -74,6 +74,11 @@ internal sealed class AckDeferringConnection : IJsonRpcConnection
     /// </summary>
     public bool DeliveredPushBeforeAck { get; private set; }
 
+    /// <summary>
+    ///     Whether a publish acknowledgement was actually withheld while armed.
+    /// </summary>
+    public bool HeldAcknowledgement { get; private set; }
+
     public bool Connected => _inner.Connected;
     public bool Connecting => _inner.Connecting;
     public string Url => _inner.Url;
@@ -128,6 +133,7 @@ internal sealed class AckDeferringConnection : IJsonRpcConnection
         {
             _armed = true;
             DeliveredPushBeforeAck = false;
+            HeldAcknowledgement = false;
         }
     }
 
@@ -166,6 +172,7 @@ internal sealed class AckDeferringConnection : IJsonRpcConnection
                 else if (TryGetResponseId(json, out var id) && _pendingPublishIds.Remove(id))
                 {
                     _heldAcks.Add(json);
+                    HeldAcknowledgement = true;
                     holdThisFrame = true;
                 }
             }

--- a/test/Reown.Sign.Test/RequestAsyncOrderingTests.cs
+++ b/test/Reown.Sign.Test/RequestAsyncOrderingTests.cs
@@ -22,6 +22,8 @@ public class RequestAsyncOrderingTests : IAsyncLifetime
 {
     private const string TestAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
 
+    private static readonly TimeSpan RequestDeadline = TimeSpan.FromSeconds(30);
+
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly AckDeferringConnectionBuilder _dappConnectionBuilder = new();
 
@@ -102,7 +104,8 @@ public class RequestAsyncOrderingTests : IAsyncLifetime
     {
         var topic = await EstablishSession();
 
-        _wallet.Engine.SessionRequestEvents<OrderingTestRequest, OrderingTestResponse>().OnRequest += requestData =>
+        var walletHandler = _wallet.Engine.SessionRequestEvents<OrderingTestRequest, OrderingTestResponse>();
+        walletHandler.OnRequest += requestData =>
         {
             var data = requestData.Request.Params;
             requestData.Response = new OrderingTestResponse
@@ -113,6 +116,10 @@ public class RequestAsyncOrderingTests : IAsyncLifetime
             return Task.CompletedTask;
         };
 
+        // The wallet has to be able to receive the request before it is published, for the same reason the
+        // dapp has to be able to receive the response before it publishes.
+        await walletHandler.WhenRegisteredAsync();
+
         var connection = _dappConnectionBuilder.Connection;
         Assert.NotNull(connection);
 
@@ -120,7 +127,7 @@ public class RequestAsyncOrderingTests : IAsyncLifetime
 
         try
         {
-            var response = await _dapp.RequestAsync<OrderingTestRequest, OrderingTestResponse>(
+            var request = _dapp.RequestAsync<OrderingTestRequest, OrderingTestResponse>(
                 topic,
                 RpcMethodAttribute.MethodForType<OrderingTestRequest>(),
                 new OrderingTestRequest
@@ -129,15 +136,24 @@ public class RequestAsyncOrderingTests : IAsyncLifetime
                     b = 7
                 });
 
-            Assert.Equal(42, response.result);
+            // The production timeout is fifteen minutes, far longer than a test may wait. Without this
+            // deadline an unfixed implementation would hang instead of failing.
+            var finished = await Task.WhenAny(request, Task.Delay(RequestDeadline));
+
+            Assert.True(ReferenceEquals(finished, request),
+                $"RequestAsync did not complete within {RequestDeadline.TotalSeconds} s, which is what the response-listener race looks like.");
+
+            Assert.Equal(42, (await request).result);
         }
         finally
         {
             connection.ReleaseAll();
         }
 
+        Assert.True(connection.HeldAcknowledgement,
+            "The publish acknowledgement was never withheld, so the inverted frame ordering was not exercised.");
         Assert.True(connection.DeliveredPushBeforeAck,
-            "The test did not manage to deliver the response before the publish acknowledgement, so the race was not exercised.");
+            "The response was not delivered while the acknowledgement was held, so the race was not exercised.");
     }
 
     [Fact]

--- a/test/Reown.Sign.Test/RequestAsyncOrderingTests.cs
+++ b/test/Reown.Sign.Test/RequestAsyncOrderingTests.cs
@@ -1,0 +1,231 @@
+using Reown.Core;
+using Reown.Core.Common.Logging;
+using Reown.Core.Common.Model.Errors;
+using Reown.Core.Common.Utils;
+using Reown.Core.Network.Models;
+using Reown.Core.Storage;
+using Reown.Core.Storage.Interfaces;
+using Reown.Sign.Models;
+using Reown.Sign.Models.Engine;
+using Reown.TestUtils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Reown.Sign.Test;
+
+/// <summary>
+///     Covers the ordering contract of <see cref="Engine.RequestAsync{T,TR}" />: a response that reaches
+///     the SDK before the relay acknowledges our own publish must still complete the call, and a request
+///     that is never answered must fail with a descriptive error instead of waiting forever.
+/// </summary>
+public class RequestAsyncOrderingTests : IAsyncLifetime
+{
+    private const string TestAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+
+    private readonly ITestOutputHelper _testOutputHelper;
+    private readonly AckDeferringConnectionBuilder _dappConnectionBuilder = new();
+
+    private SignClient _dapp = null!;
+    private SignClient _wallet = null!;
+
+    public RequestAsyncOrderingTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [RpcMethod("ordering_test_method")]
+    [RpcRequestOptions(Clock.ONE_MINUTE, 99810)]
+    public class OrderingTestRequest
+    {
+        public int a;
+        public int b;
+    }
+
+    [RpcResponseOptions(Clock.ONE_MINUTE, 99811)]
+    public class OrderingTestResponse
+    {
+        public int result;
+    }
+
+    [RpcMethod("ordering_unanswered_method")]
+    [RpcRequestOptions(Clock.ONE_MINUTE, 99812)]
+    [RpcResponseOptions(Clock.ONE_MINUTE, 99813)]
+    public class UnansweredTestRequest
+    {
+        public int a;
+    }
+
+    public async Task InitializeAsync()
+    {
+        ReownLogger.Instance = new TestOutputHelperLogger(_testOutputHelper);
+
+        _dapp = await SignClient.Init(new SignClientOptions
+        {
+            ProjectId = TestValues.TestProjectId,
+            RelayUrl = TestValues.TestRelayUrl,
+            Metadata = BuildMetadata("Ordering Dapp"),
+            Storage = new InMemoryStorage(),
+            ConnectionBuilder = _dappConnectionBuilder
+        });
+
+        _wallet = await SignClient.Init(new SignClientOptions
+        {
+            ProjectId = TestValues.TestProjectId,
+            RelayUrl = TestValues.TestRelayUrl,
+            Metadata = BuildMetadata("Ordering Wallet"),
+            Storage = new InMemoryStorage()
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        _dappConnectionBuilder.Connection?.ReleaseAll();
+
+        if (_dapp?.CoreClient != null)
+        {
+            await _dapp.CoreClient.Storage.Clear();
+            _dapp.Dispose();
+        }
+
+        if (_wallet?.CoreClient != null)
+        {
+            await _wallet.CoreClient.Storage.Clear();
+            _wallet.Dispose();
+        }
+
+        ReownLogger.Instance = null;
+    }
+
+    [Fact]
+    [Trait("Category", "integration")]
+    public async Task RequestAsync_CompletesWhenTheResponseArrivesBeforeThePublishAcknowledgement()
+    {
+        var topic = await EstablishSession();
+
+        _wallet.Engine.SessionRequestEvents<OrderingTestRequest, OrderingTestResponse>().OnRequest += requestData =>
+        {
+            var data = requestData.Request.Params;
+            requestData.Response = new OrderingTestResponse
+            {
+                result = data.a * data.b
+            };
+
+            return Task.CompletedTask;
+        };
+
+        var connection = _dappConnectionBuilder.Connection;
+        Assert.NotNull(connection);
+
+        connection.Arm();
+
+        try
+        {
+            var response = await _dapp.RequestAsync<OrderingTestRequest, OrderingTestResponse>(
+                topic,
+                RpcMethodAttribute.MethodForType<OrderingTestRequest>(),
+                new OrderingTestRequest
+                {
+                    a = 6,
+                    b = 7
+                });
+
+            Assert.Equal(42, response.result);
+        }
+        finally
+        {
+            connection.ReleaseAll();
+        }
+
+        Assert.True(connection.DeliveredPushBeforeAck,
+            "The test did not manage to deliver the response before the publish acknowledgement, so the race was not exercised.");
+    }
+
+    [Fact]
+    [Trait("Category", "integration")]
+    public async Task RequestAsync_WithNoResponder_FailsWithSessionRequestExpired()
+    {
+        var topic = await EstablishSession();
+
+        var exception = await Assert.ThrowsAsync<ReownNetworkException>(() =>
+            _dapp.RequestAsync<UnansweredTestRequest, bool>(
+                topic,
+                RpcMethodAttribute.MethodForType<UnansweredTestRequest>(),
+                new UnansweredTestRequest
+                {
+                    a = 1
+                },
+                expiry: Clock.THIRTY_SECONDS));
+
+        Assert.Equal(ErrorType.SESSION_REQUEST_EXPIRED, exception.CodeType);
+        Assert.Contains(RpcMethodAttribute.MethodForType<UnansweredTestRequest>(), exception.Message);
+    }
+
+    private async Task<string> EstablishSession()
+    {
+        var connectOptions = new ConnectOptions
+        {
+            RequiredNamespaces = new RequiredNamespaces
+            {
+                {
+                    "eip155", new ProposedNamespace
+                    {
+                        Methods =
+                        [
+                            RpcMethodAttribute.MethodForType<OrderingTestRequest>(),
+                            RpcMethodAttribute.MethodForType<UnansweredTestRequest>()
+                        ],
+                        Chains = ["eip155:1"],
+                        Events = ["chainChanged", "accountsChanged"]
+                    }
+                }
+            }
+        };
+
+        var settled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _wallet.SessionProposed += async (_, @event) =>
+        {
+            try
+            {
+                var approvedNamespaces = new Namespaces(@event.Proposal.RequiredNamespaces);
+                approvedNamespaces["eip155"].WithAccount($"eip155:1:{TestAddress}");
+
+                var approveData = await _wallet.Approve(new ApproveParams
+                {
+                    Id = @event.Id,
+                    Namespaces = approvedNamespaces
+                });
+
+                await approveData.Acknowledged();
+
+                settled.TrySetResult(true);
+            }
+            catch (Exception e)
+            {
+                settled.TrySetException(e);
+            }
+        };
+
+        var connectData = await _dapp.Connect(connectOptions);
+        _ = await _wallet.Pair(connectData.Uri);
+
+        await settled.Task;
+        var session = await connectData.Approval;
+
+        return session.Topic;
+    }
+
+    private static Metadata BuildMetadata(string name)
+    {
+        return new Metadata
+        {
+            Description = name,
+            Icons =
+            [
+                "https://raw.githubusercontent.com/reown-com/reown-dotnet/main/media/reown-avatar-positive.png"
+            ],
+            Name = name,
+            Url = "https://reown.com"
+        };
+    }
+}

--- a/test/Reown.Sign.Test/TypedEventHandlerRegistrationTests.cs
+++ b/test/Reown.Sign.Test/TypedEventHandlerRegistrationTests.cs
@@ -4,6 +4,9 @@ using Reown.Core.Interfaces;
 using Reown.Core.Models;
 using Reown.Core.Models.MessageHandler;
 using Reown.Core.Network.Models;
+using Reown.Sign.Interfaces;
+using Reown.Sign.Models;
+using Reown.Sign.Models.Engine.Methods;
 using Xunit;
 
 namespace Reown.Sign.Test;
@@ -112,6 +115,90 @@ public class TypedEventHandlerRegistrationTests
         singleton.Dispose();
 
         Assert.True(filtered.Disposed);
+    }
+
+    [Fact]
+    public void GetInstance_AfterTheOwningClientIsDisposed_ReturnsAFreshInstance()
+    {
+        const string context = "registration-reinit";
+
+        var firstClient = BuildCoreClient(context, Task.FromResult(new DisposeHandlerToken(() => { })));
+        var first = TypedEventHandler<RegistrationProbeRequest, RegistrationProbeResponse>.GetInstance(firstClient);
+
+        firstClient.Disposed.Returns(true);
+
+        var secondClient = BuildCoreClient(context, Task.FromResult(new DisposeHandlerToken(() => { })));
+        var second = TypedEventHandler<RegistrationProbeRequest, RegistrationProbeResponse>.GetInstance(secondClient);
+
+        try
+        {
+            Assert.NotSame(first, second);
+            Assert.True(first.Disposed);
+        }
+        finally
+        {
+            second.Dispose();
+        }
+    }
+
+    [Fact]
+    public void GetInstance_WhileTheOwningClientIsAlive_ReturnsTheSameInstance()
+    {
+        var client = BuildCoreClient($"registration-shared-{Guid.NewGuid()}", Task.FromResult(new DisposeHandlerToken(() => { })));
+
+        var first = TypedEventHandler<RegistrationProbeRequest, RegistrationProbeResponse>.GetInstance(client);
+
+        try
+        {
+            Assert.Same(first, TypedEventHandler<RegistrationProbeRequest, RegistrationProbeResponse>.GetInstance(client));
+            Assert.False(first.Disposed);
+        }
+        finally
+        {
+            first.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task SessionRequestEvents_WhenRegisteredAsync_WaitsForTheWrappedHandler()
+    {
+        var registration = new TaskCompletionSource<DisposeHandlerToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var messageHandler = Substitute.For<ITypedMessageHandler>();
+        messageHandler
+            .HandleMessageType<SessionRequest<RegistrationProbeRequest>, RegistrationProbeResponse>(
+                Arg.Any<Func<string, JsonRpcRequest<SessionRequest<RegistrationProbeRequest>>, Task>>(),
+                Arg.Any<Func<string, JsonRpcResponse<RegistrationProbeResponse>, Task>>())
+            .Returns(registration.Task);
+
+        var coreClient = Substitute.For<ICoreClient>();
+        coreClient.Context.Returns($"registration-wrapped-{Guid.NewGuid()}");
+        coreClient.MessageHandler.Returns(messageHandler);
+
+        var handler = SessionRequestEventHandler<RegistrationProbeRequest, RegistrationProbeResponse>
+            .GetInstance(coreClient, Substitute.For<IEnginePrivate>());
+
+        try
+        {
+            var filtered = handler.FilterResponses(_ => true);
+            filtered.OnResponse += _ => Task.CompletedTask;
+
+            var registered = filtered.WhenRegisteredAsync();
+
+            // Readiness has to be transitive: the filtered handler is only live once the shared handler for
+            // the wrapped SessionRequest type pair is registered.
+            Assert.False(registered.IsCompleted);
+
+            registration.SetResult(new DisposeHandlerToken(() => { }));
+
+            await registered;
+
+            Assert.True(registered.IsCompletedSuccessfully);
+        }
+        finally
+        {
+            handler.Dispose();
+        }
     }
 
     private static ICoreClient BuildCoreClient(string context, Task<DisposeHandlerToken> registration)

--- a/test/Reown.Sign.Test/TypedEventHandlerRegistrationTests.cs
+++ b/test/Reown.Sign.Test/TypedEventHandlerRegistrationTests.cs
@@ -1,0 +1,132 @@
+using NSubstitute;
+using Reown.Core.Common.Utils;
+using Reown.Core.Interfaces;
+using Reown.Core.Models;
+using Reown.Core.Models.MessageHandler;
+using Reown.Core.Network.Models;
+using Xunit;
+
+namespace Reown.Sign.Test;
+
+/// <summary>
+///     Covers the invariant the fix for the RequestAsync response-listener race depends on: subscribing to
+///     a <see cref="TypedEventHandler{T,TR}" /> hands the caller a task it can await to know the handler is
+///     actually live, and instances produced by the filter methods clean up after themselves without
+///     evicting the shared singleton.
+/// </summary>
+[Trait("Category", "unit")]
+public class TypedEventHandlerRegistrationTests
+{
+    [RpcMethod("registration_probe_method")]
+    [RpcRequestOptions(Clock.ONE_MINUTE, 99801)]
+    public class RegistrationProbeRequest
+    {
+        public int a;
+    }
+
+    [RpcResponseOptions(Clock.ONE_MINUTE, 99802)]
+    public class RegistrationProbeResponse
+    {
+        public int result;
+    }
+
+    [Fact]
+    public async Task WhenRegisteredAsync_DoesNotCompleteUntilTheMessageHandlerIsRegistered()
+    {
+        var registration = new TaskCompletionSource<DisposeHandlerToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var coreClient = BuildCoreClient($"registration-gate-{Guid.NewGuid()}", registration.Task);
+
+        var handler = TypedEventHandler<RegistrationProbeRequest, RegistrationProbeResponse>.GetInstance(coreClient);
+
+        try
+        {
+            handler.OnResponse += _ => Task.CompletedTask;
+
+            var registered = handler.WhenRegisteredAsync();
+
+            Assert.False(registered.IsCompleted);
+
+            registration.SetResult(new DisposeHandlerToken(() => { }));
+
+            await registered;
+
+            Assert.True(registered.IsCompletedSuccessfully);
+        }
+        finally
+        {
+            handler.Dispose();
+        }
+    }
+
+    [Fact]
+    public void WhenRegisteredAsync_WithNoSubscribers_IsAlreadyComplete()
+    {
+        var registration = new TaskCompletionSource<DisposeHandlerToken>();
+        var coreClient = BuildCoreClient($"registration-idle-{Guid.NewGuid()}", registration.Task);
+
+        var handler = TypedEventHandler<RegistrationProbeRequest, RegistrationProbeResponse>.GetInstance(coreClient);
+
+        try
+        {
+            Assert.True(handler.WhenRegisteredAsync().IsCompleted);
+        }
+        finally
+        {
+            handler.Dispose();
+        }
+    }
+
+    [Fact]
+    public void DisposingAFilteredInstance_LeavesTheSingletonRegistered()
+    {
+        var coreClient = BuildCoreClient($"registration-filter-{Guid.NewGuid()}",
+            Task.FromResult(new DisposeHandlerToken(() => { })));
+
+        var singleton = TypedEventHandler<RegistrationProbeRequest, RegistrationProbeResponse>.GetInstance(coreClient);
+
+        try
+        {
+            var filtered = singleton.FilterResponses(_ => true);
+
+            filtered.Dispose();
+
+            Assert.True(filtered.Disposed);
+            Assert.False(singleton.Disposed);
+            Assert.Same(singleton, TypedEventHandler<RegistrationProbeRequest, RegistrationProbeResponse>.GetInstance(coreClient));
+        }
+        finally
+        {
+            singleton.Dispose();
+        }
+    }
+
+    [Fact]
+    public void DisposingTheSingleton_DisposesFilteredInstancesItHandedOut()
+    {
+        var coreClient = BuildCoreClient($"registration-cascade-{Guid.NewGuid()}",
+            Task.FromResult(new DisposeHandlerToken(() => { })));
+
+        var singleton = TypedEventHandler<RegistrationProbeRequest, RegistrationProbeResponse>.GetInstance(coreClient);
+        var filtered = singleton.FilterResponses(_ => true);
+
+        singleton.Dispose();
+
+        Assert.True(filtered.Disposed);
+    }
+
+    private static ICoreClient BuildCoreClient(string context, Task<DisposeHandlerToken> registration)
+    {
+        var messageHandler = Substitute.For<ITypedMessageHandler>();
+        messageHandler
+            .HandleMessageType<RegistrationProbeRequest, RegistrationProbeResponse>(
+                Arg.Any<Func<string, JsonRpcRequest<RegistrationProbeRequest>, Task>>(),
+                Arg.Any<Func<string, JsonRpcResponse<RegistrationProbeResponse>, Task>>())
+            .Returns(registration);
+
+        var coreClient = Substitute.For<ICoreClient>();
+        coreClient.Context.Returns(context);
+        coreClient.MessageHandler.Returns(messageHandler);
+
+        return coreClient;
+    }
+}


### PR DESCRIPTION
`Engine.RequestAsync` published a `wc_sessionRequest` and only afterwards subscribed the listener that
completes the `TaskCompletionSource` it awaits. `SendRequest` awaits the relay's acknowledgement of our own
`irn_publish`; that acknowledgement and the peer's response are independent frames with no ordering guarantee.
When the response arrives first, `TypedMessageHandler.ProcessResponse` finds no handler registered for that
request/response type pair and drops it permanently, and with no timeout the await never returns. This is the
cause of the 30-minute rs-relay `validate_sharp` stalls (2026-08-18 and twice on 2026-08-25); it reproduces
against the production relay as well as staging.

- **Registration is now awaitable, and awaited before publishing.** `TypedEventHandler.Setup()` was
  `async void`; it becomes `protected virtual Task SetupAsync()`, and `WhenRegisteredAsync()` hands the caller
  the task. `SessionRequestEventHandler` awaits the wrapped `SessionRequest<T>` handler's own registration, so
  readiness is transitive. A bare reorder would not have been enough: once `SendRequest` no longer runs first,
  the JSON-RPC history for the type pair is cold and the async-void setup really does return before the handler
  is live.
- **The request id is derived once and reused.** New `ITypedMessageHandler.GenerateRequestId<T>` plus a
  `SendRequest` overload that takes a `SendRequestOptions` object carrying the id, the expiry and the encode
  options, so the listener is registered for the exact id that gets published. The existing `SendRequest`
  delegates to it, so the payload is hashed exactly once. Options go in an object rather than another optional
  parameter because adding an optional parameter is a binary-breaking change for callers compiled against the
  NuGet packages, while adding a property is not.
- **The wait is bounded.** Default `expiry ?? min(SessionRequest TTL, 900 s)`, clamped to [30 s, 7 days] —
  30 s is the relay's minimum publish TTL; on
  expiry it throws `ReownNetworkException` with `SESSION_REQUEST_EXPIRED` (8000) and
  `"Request expired. Please try again."` plus method, id, topic and seconds waited. The publish leg is raced
  against the same deadline, so an acknowledgement that never arrives no longer hangs the call. The `expiry`
  parameter that `RequestAsync` accepted and silently ignored now reaches the publish.
- **Same ordering fixed at the other sites:** `ApproveAsync`, `UpdateSessionAsync`, `ExtendAsync`, session
  `PingAsync`, `ConnectAsync` (the proposal is stored before the publish), `AuthenticateAsync` and
  `Pairing.Ping` register before publishing and roll back, step by step, if the publish fails. The two 500 ms
  `Task.Delay` mitigations in the ping response handlers are gone.
- **Handler lifetime**, which the per-request cleanup depends on: the wrapped listeners are detached in
  `Teardown` rather than on disposal, a filtered instance no longer disposes the handler it wraps, `Dispose`
  only unregisters itself when it is the registered instance, and `GetInstance` discards an instance whose
  client was disposed. Context strings are derived from the client name and get reused, so without the last one
  a client re-created after dispose received a handler bound to the dead one.

### Consistency with the other clients

| | TypeScript | Swift | This change |
|---|---|---|---|
| Handler registered before publish | yes | yes (engine-lifetime subscriber) | yes, and awaited |
| Unanswered request | bounded by expiry, default 900 s | bounded by a 3 s expiry sweep, default 300 s | bounded by expiry, default 900 s |
| Error surfaced | `Error("Request expired. Please try again.")` | none — the caller returned at the publish ack | `ReownNetworkException` 8000, same wording plus context |

TypeScript's `request()` is the closest analogue: it takes `clientRpcId = payloadId()`, arms the delayed promise
with the expiry, registers `events.once(engineEvent("session_request", clientRpcId))`, and only then calls
`sendRequest`. Its inbound path throws if no listener exists for the id.

Deliberate differences, each better as its own change than widened into this one:

- TypeScript uses one number for the local wait, the on-wire expiry and the relay TTL. Here a caller-supplied
  expiry does both, but with no expiry the relay TTL stays the `Clock.ONE_DAY` declared on `SessionRequest<T>`
  while the wait falls back to 900 s. Lowering the declared TTL changes the offline delivery window for
  requests and responses and is unrelated to the race.
- TypeScript and Swift reject a caller expiry outside 300 s–7 days; this clamps to the relay's own
  30 s–7 days instead, which cannot reject a value an existing caller already passes.
- All three reference clients put an `expiryTimestamp` inside `params.request` and enforce it on receipt. This
  does not, and that is a wire-format change of its own.
- The acknowledgement waits in `PingAsync`, `Pairing.Ping`, `UpdateSessionAsync` and `ExtendAsync` are still
  unbounded. Their listeners are now always registered before the publish, so the systematic cause is gone, but
  giving four more public APIs a new failure mode belongs in a separate change.

### Breaking changes

- `ITypedMessageHandler` gains a `SendRequest` overload taking `SendRequestOptions` and a
  `GenerateRequestId`, and `TypedEventHandler`'s `protected virtual Setup()` becomes `SetupAsync()`.
  `TypedMessageHandler` is the only implementation of the interface and `SessionRequestEventHandler` the only
  subclass, both in this repo, but an external implementation or subclass would need updating.
- The new overload makes two existing call shapes ambiguous: `SendRequest<T, TR>(topic, parameters, null)` and
  the same call with `default` as the third argument now match both `long? expiry` and `SendRequestOptions`. The
  fix at such a call site is `expiry: null`. Every other shape still binds to the same overload as before,
  including a `long`, a `long?`, `default(long?)` and all named-argument forms; nothing binds silently to the
  wrong one, because no type converts to both `long?` and `SendRequestOptions`. No caller in this repo passes
  the third argument positionally as `null` or `default`.
- `EventHandlerMap.ListenOnce` returns an `Action` that removes the registration instead of `void`. Source
  compatible, binary incompatible.
- A caller that passes `expiry` gets behaviour it did not get before, because the parameter was ignored: the
  value now bounds the wait and becomes the relay TTL. No caller in this repo passes it.

### Testing

- `dotnet build Reown.NoUnity.slnf -c Release` — clean, all five target frameworks.
- `dotnet test Reown.NoUnity.slnf --filter Category=unit` — pass.
- `dotnet test -m:1 Reown.NoUnity.slnf --filter Category=integration` — pass, 9/9 assemblies.
- Race harness (connect, two `RequestAsync`, dispose both clients, re-init from the same storage, repeat):
  **0 hangs in 50 runs against each of staging and production relay.** Baseline on unmodified `develop` was
  5 hangs / 74 runs on staging and 1 / 20 on production.
- `RequestAsyncOrderingTests` drives the inverted frame ordering through a connection decorator that withholds
  the publish acknowledgement until the response has been delivered. Restoring the old publish-then-register
  order makes it fail deterministically with `RequestAsync did not complete within 30 s`; it passes in 1 s with
  the fix. A second test asserts the expiry error for an unanswered request.
- `TypedEventHandlerRegistrationTests` pins the registration invariants, including transitive readiness through
  `SessionRequestEventHandler` and the stale-instance case that a client re-created after dispose hits.
- `TypedMessageHandlerTests` covers the send path without a relay: the derived id and attributed lifetime with no
  options, an explicit `RequestId` reaching the published payload, an `Expiry` overriding the attributed
  lifetime, encode options forwarded untouched, and the same three for the older overload. Making
  `SendRequest` ignore `RequestId` fails the explicit-id test on all three target frameworks.

### Not verified, and known gaps

- Three known limitations left alone deliberately, each pre-existing: `Engine.SubscribeToSessionEvent` still
  combines its handler through the non-atomic `EventHandlerMap` indexer; `RpcPayloadId.GenerateFromDataHash` is
  a pure content hash, so two identical payloads on one topic share an id; and two live clients that share a
  context still share handlers, so disposing one tears down the other's registrations.



