### PR TITLE
fix(core): stop a rebuilt client from wiping the stored keychain

### DIFF
--- a/src/Reown.Core.Crypto/Runtime/Crypto.cs
+++ b/src/Reown.Core.Crypto/Runtime/Crypto.cs
@@ -12,6 +12,7 @@ using Org.BouncyCastle.Crypto.Generators;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Crypto.Signers;
 using Org.BouncyCastle.Security;
+using Reown.Core.Common.Logging;
 using Reown.Core.Common.Utils;
 using Reown.Core.Crypto.Encoder;
 using Reown.Core.Crypto.Interfaces;
@@ -47,12 +48,15 @@ namespace Reown.Core.Crypto
         private static readonly Encoding DataEncoding = Encoding.UTF8;
         private static readonly Encoding JsonEncoding = Encoding.UTF8;
         private readonly bool _newStorage;
+        private readonly bool _ownsKeyChain;
 
         private bool _initialized;
         protected bool Disposed;
 
         /// <summary>
         ///     Create a new instance of the crypto module, with a given storage module.
+        ///     The keychain built over that storage is owned by this crypto module and is disposed with it.
+        ///     The storage itself belongs to the caller and is left alone.
         /// </summary>
         /// <param name="storage">The storage module to use to load the keychain from</param>
         public Crypto(IKeyValueStorage storage)
@@ -62,10 +66,13 @@ namespace Reown.Core.Crypto
 
             KeyChain = new KeyChain(storage);
             Storage = storage;
+            _ownsKeyChain = true;
         }
 
         /// <summary>
         ///     Create a new instance of the crypto module, with a given keychain.
+        ///     The keychain belongs to the caller: it is not disposed with this crypto module, so it stays
+        ///     usable afterwards.
         /// </summary>
         /// <param name="keyChain">The keychain to use for this crypto module</param>
         public Crypto(IKeyChain keyChain)
@@ -75,7 +82,8 @@ namespace Reown.Core.Crypto
         }
 
         /// <summary>
-        ///     Create a new instance of the crypto module using an empty keychain stored in-memory using a Dictionary
+        ///     Create a new instance of the crypto module using an empty keychain stored in-memory using a Dictionary.
+        ///     Both the storage and the keychain are created here, so both are disposed with this crypto module.
         /// </summary>
         public Crypto() : this(new InMemoryStorage())
         {
@@ -137,8 +145,14 @@ namespace Reown.Core.Crypto
         ///     been initialized
         ///     Initializing the module will invoke Init() on the backing KeyChain
         /// </summary>
+        /// <exception cref="ObjectDisposedException">Thrown if this crypto module has been disposed</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     Thrown by the backing keychain if the storage holds a keychain that cannot be read
+        /// </exception>
         public async Task Init()
         {
+            ThrowIfDisposed();
+
             if (!_initialized)
             {
                 if (_newStorage)
@@ -593,9 +607,20 @@ namespace Reown.Core.Crypto
 
         private void IsInitialized()
         {
+            ThrowIfDisposed();
+
             if (!_initialized)
             {
                 throw new InvalidOperationException($"{nameof(Crypto)} module not initialized.");
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (Disposed)
+            {
+                throw new ObjectDisposedException(nameof(Crypto),
+                    $"This {nameof(Crypto)} module has been disposed and cannot be reused. Create a new {nameof(Crypto)} module instead of sharing one between clients.");
             }
         }
 
@@ -658,8 +683,10 @@ namespace Reown.Core.Crypto
             {
                 seed = await KeyChain.Get(CryptoClientSeed);
             }
-            catch (InvalidOperationException)
+            catch (KeychainKeyNotFoundException)
             {
+                LogMissingClientSeed();
+
                 var seedRaw = new byte[32];
                 RandomNumberGenerator.Fill(seedRaw);
                 seed = seedRaw.ToHex();
@@ -669,6 +696,23 @@ namespace Reown.Core.Crypto
             return seed.HexToByteArray();
         }
 
+        private void LogMissingClientSeed()
+        {
+            var otherKeyCount = KeyChain.Keychain.Count;
+            if (otherKeyCount == 0)
+            {
+                ReownLogger.Log(
+                    $"[{Name}] No client seed found in the keychain, generating a new one. The client id changes with it. " +
+                    "This is expected on a first run; on any other run it means the keychain came up empty and existing sessions can no longer be decrypted.");
+            }
+            else
+            {
+                ReownLogger.LogError(
+                    $"[{Name}] No client seed found in the keychain, but it holds {otherKeyCount} other key(s). " +
+                    "Generating a new client seed, which changes the client id.");
+            }
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (Disposed)
@@ -676,7 +720,15 @@ namespace Reown.Core.Crypto
 
             if (disposing)
             {
-                KeyChain?.Dispose();
+                if (_ownsKeyChain)
+                {
+                    KeyChain?.Dispose();
+                }
+
+                if (_newStorage)
+                {
+                    Storage?.Dispose();
+                }
             }
 
             Disposed = true;

--- a/src/Reown.Core.Crypto/Runtime/Interfaces/IKeyChain.cs
+++ b/src/Reown.Core.Crypto/Runtime/Interfaces/IKeyChain.cs
@@ -9,6 +9,13 @@ namespace Reown.Core.Crypto.Interfaces
     /// <summary>
     ///     A module that represents a keychain
     /// </summary>
+    /// <remarks>
+    ///     A keychain that comes up empty overwrites the stored keys as soon as the first key is written, so a
+    ///     disposed keychain must not be reused. Implementations are expected to throw
+    ///     <see cref="System.ObjectDisposedException" /> from every key operation once disposed, which is what
+    ///     the default <see cref="KeyChain" /> does.
+    ///     The backing storage belongs to whoever created it and is not disposed with the keychain.
+    /// </remarks>
     public interface IKeyChain : IModule
     {
         /// <summary>

--- a/src/Reown.Core.Crypto/Runtime/Interfaces/IKeyChain.cs
+++ b/src/Reown.Core.Crypto/Runtime/Interfaces/IKeyChain.cs
@@ -9,13 +9,6 @@ namespace Reown.Core.Crypto.Interfaces
     /// <summary>
     ///     A module that represents a keychain
     /// </summary>
-    /// <remarks>
-    ///     A keychain that comes up empty overwrites the stored keys as soon as the first key is written, so a
-    ///     disposed keychain must not be reused. Implementations are expected to throw
-    ///     <see cref="System.ObjectDisposedException" /> from every key operation once disposed, which is what
-    ///     the default <see cref="KeyChain" /> does.
-    ///     The backing storage belongs to whoever created it and is not disposed with the keychain.
-    /// </remarks>
     public interface IKeyChain : IModule
     {
         /// <summary>

--- a/src/Reown.Core.Crypto/Runtime/KeyChain.cs
+++ b/src/Reown.Core.Crypto/Runtime/KeyChain.cs
@@ -78,17 +78,8 @@ namespace Reown.Core.Crypto
         }
 
         /// <summary>
-        ///     Dispose this keychain. The backing storage is left alone: the keychain does not own it and the
-        ///     caller may still be using it.
-        ///     A disposed keychain cannot be reused: <see cref="Init" />, <see cref="Has" />, <see cref="Get" />,
-        ///     <see cref="Set" /> and <see cref="Delete" /> all throw <see cref="ObjectDisposedException" />
-        ///     afterwards.
+        ///     Dispose this keychain. Every key operation throws <see cref="ObjectDisposedException" /> afterwards.
         /// </summary>
-        /// <remarks>
-        ///     The in-memory keys are deliberately not cleared here. Clearing them would race with a
-        ///     <see cref="Set" /> that is already past its disposed check, which would write an empty keychain
-        ///     over the stored keys.
-        /// </remarks>
         public void Dispose()
         {
             _disposed = true;

--- a/src/Reown.Core.Crypto/Runtime/KeyChain.cs
+++ b/src/Reown.Core.Crypto/Runtime/KeyChain.cs
@@ -234,8 +234,8 @@ namespace Reown.Core.Crypto
         {
             ThrowIfDisposed();
 
-            // We need to copy the contents, otherwise Dispose()
-            // may clear the reference stored inside InMemoryStorage
+            // Store a copy: InMemoryStorage keeps the reference it is given, so passing the live dictionary
+            // would let a later Set() change the stored keychain and every keychain that loaded it
             await Storage.SetItem(StorageKey, new Dictionary<string, string>(_keyChain));
         }
     }

--- a/src/Reown.Core.Crypto/Runtime/KeyChain.cs
+++ b/src/Reown.Core.Crypto/Runtime/KeyChain.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
+using Reown.Core.Common.Logging;
 using Reown.Core.Common.Utils;
 using Reown.Core.Crypto.Interfaces;
 using Reown.Core.Storage.Interfaces;
@@ -15,6 +16,7 @@ namespace Reown.Core.Crypto
     {
         private readonly string _storagePrefix = Constants.CORE_STORAGE_PREFIX;
 
+        private bool _disposed;
         private bool _initialized;
         private Dictionary<string, string> _keyChain = new();
 
@@ -75,17 +77,35 @@ namespace Reown.Core.Crypto
                 "reown.core.crypto.keychain";
         }
 
+        /// <summary>
+        ///     Dispose this keychain. The backing storage is left alone: the keychain does not own it and the
+        ///     caller may still be using it.
+        ///     A disposed keychain cannot be reused: <see cref="Init" />, <see cref="Has" />, <see cref="Get" />,
+        ///     <see cref="Set" /> and <see cref="Delete" /> all throw <see cref="ObjectDisposedException" />
+        ///     afterwards.
+        /// </summary>
+        /// <remarks>
+        ///     The in-memory keys are deliberately not cleared here. Clearing them would race with a
+        ///     <see cref="Set" /> that is already past its disposed check, which would write an empty keychain
+        ///     over the stored keys.
+        /// </remarks>
         public void Dispose()
         {
-            _keyChain?.Clear();
-            Storage?.Dispose();
+            _disposed = true;
         }
 
         /// <summary>
         ///     Initialize the KeyChain, this will load the keychain into memory from the storage
         /// </summary>
+        /// <exception cref="ObjectDisposedException">Thrown if this keychain has been disposed</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     Thrown if the storage holds a keychain that cannot be read. Starting with an empty keychain in
+        ///     that case would overwrite the stored keys with the first key written afterwards.
+        /// </exception>
         public async Task Init()
         {
+            ThrowIfDisposed();
+
             if (!_initialized)
             {
                 var keyChain = await GetKeyChain();
@@ -171,9 +191,20 @@ namespace Reown.Core.Crypto
 
         private void IsInitialized()
         {
+            ThrowIfDisposed();
+
             if (!_initialized)
             {
                 throw new InvalidOperationException($"{nameof(Keychain)} module not initialized.");
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(KeyChain),
+                    $"This {nameof(KeyChain)} has been disposed and cannot be reused. Create a new {nameof(KeyChain)} instance instead of sharing one between clients.");
             }
         }
 
@@ -182,14 +213,27 @@ namespace Reown.Core.Crypto
             var hasKey = await Storage.HasItem(StorageKey);
             if (!hasKey)
             {
-                await Storage.SetItem(StorageKey, new Dictionary<string, string>());
+                ReownLogger.Log(
+                    $"[{Name}] No keychain found in storage at {StorageKey}, starting with an empty keychain.");
+                return null;
             }
 
-            return await Storage.GetItem<Dictionary<string, string>>(StorageKey);
+            var keyChain = await Storage.GetItem<Dictionary<string, string>>(StorageKey);
+            if (keyChain == null)
+            {
+                throw new InvalidOperationException(
+                    $"The keychain stored at {StorageKey} could not be read as a key/value dictionary. Refusing to " +
+                    "start with an empty keychain, which would overwrite the stored keys. Remove that storage entry " +
+                    "to start with a fresh keychain, which requires reconnecting every existing session.");
+            }
+
+            return keyChain;
         }
 
         private async Task SaveKeyChain()
         {
+            ThrowIfDisposed();
+
             // We need to copy the contents, otherwise Dispose()
             // may clear the reference stored inside InMemoryStorage
             await Storage.SetItem(StorageKey, new Dictionary<string, string>(_keyChain));

--- a/src/Reown.Core.Storage/Runtime/FileSystemStorage.cs
+++ b/src/Reown.Core.Storage/Runtime/FileSystemStorage.cs
@@ -176,7 +176,6 @@ namespace Reown.Core.Storage
 
             if (disposing)
             {
-                // Null until Init() runs, so a storage that was never initialized can still be disposed
                 _semaphoreSlim?.Dispose();
             }
 

--- a/src/Reown.Core.Storage/Runtime/FileSystemStorage.cs
+++ b/src/Reown.Core.Storage/Runtime/FileSystemStorage.cs
@@ -176,7 +176,8 @@ namespace Reown.Core.Storage
 
             if (disposing)
             {
-                _semaphoreSlim.Dispose();
+                // Null until Init() runs, so a storage that was never initialized can still be disposed
+                _semaphoreSlim?.Dispose();
             }
 
             Disposed = true;

--- a/src/Reown.Core/Runtime/Controllers/Pairing.cs
+++ b/src/Reown.Core/Runtime/Controllers/Pairing.cs
@@ -588,7 +588,6 @@ namespace Reown.Core.Controllers
                 Store?.Dispose();
                 PairingCreated -= PairingCreatedCallback;
 
-                // Null until Init() runs, so a pairing module that was never initialized can still be disposed
                 _pairingDeleteMessageHandler?.Dispose();
                 _pairingPingMessageHandler?.Dispose();
             }

--- a/src/Reown.Core/Runtime/Controllers/Pairing.cs
+++ b/src/Reown.Core/Runtime/Controllers/Pairing.cs
@@ -571,8 +571,10 @@ namespace Reown.Core.Controllers
             {
                 Store?.Dispose();
                 PairingCreated -= PairingCreatedCallback;
-                _pairingDeleteMessageHandler.Dispose();
-                _pairingPingMessageHandler.Dispose();
+
+                // Null until Init() runs, so a pairing module that was never initialized can still be disposed
+                _pairingDeleteMessageHandler?.Dispose();
+                _pairingPingMessageHandler?.Dispose();
             }
 
             Disposed = true;

--- a/src/Reown.Core/Runtime/Controllers/Relayer.cs
+++ b/src/Reown.Core/Runtime/Controllers/Relayer.cs
@@ -553,7 +553,6 @@ namespace Reown.Core.Controllers
                 Publisher?.Dispose();
                 Messages?.Dispose();
 
-                // Provider is null until the transport is started
                 if (Provider != null)
                 {
                     Provider.Connected -= OnProviderConnected;

--- a/src/Reown.Core/Runtime/Controllers/Relayer.cs
+++ b/src/Reown.Core/Runtime/Controllers/Relayer.cs
@@ -553,13 +553,16 @@ namespace Reown.Core.Controllers
                 Publisher?.Dispose();
                 Messages?.Dispose();
 
-                // Un-listen to events
-                Provider.Connected -= OnProviderConnected;
-                Provider.Disconnected -= OnProviderDisconnected;
-                Provider.RawMessageReceived -= OnProviderRawMessageReceived;
-                Provider.ErrorReceived -= OnProviderErrorReceived;
+                // Provider is null until the transport is started
+                if (Provider != null)
+                {
+                    Provider.Connected -= OnProviderConnected;
+                    Provider.Disconnected -= OnProviderDisconnected;
+                    Provider.RawMessageReceived -= OnProviderRawMessageReceived;
+                    Provider.ErrorReceived -= OnProviderErrorReceived;
 
-                Provider.Dispose();
+                    Provider.Dispose();
+                }
             }
 
             Disposed = true;

--- a/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
+++ b/src/Reown.Core/Runtime/Controllers/TypedMessageHandler.cs
@@ -268,15 +268,20 @@ namespace Reown.Core.Controllers
 
                 try
                 {
-                    var payload = await CoreClient.Crypto.Decode<JsonRpcResponse<TR>>(topic, message, options);
+                    JsonRpcResponse<TR> payload;
+                    try
+                    {
+                        payload = await CoreClient.Crypto.Decode<JsonRpcResponse<TR>>(topic, message, options);
+                    }
+                    catch (Exception ex) when (ex is KeychainKeyNotFoundException || ex is ObjectDisposedException)
+                    {
+                        ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
+                        return;
+                    }
 
                     await history.Resolve(payload);
 
                     await responseCallback(topic, payload);
-                }
-                catch (KeychainKeyNotFoundException ex)
-                {
-                    ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
                 }
                 catch (Exception ex) when (ex is JsonException)
                 {
@@ -462,7 +467,7 @@ namespace Reown.Core.Controllers
             {
                 return (true, await CoreClient.Crypto.Decode<T>(topic, message, options));
             }
-            catch (KeychainKeyNotFoundException ex)
+            catch (Exception ex) when (ex is KeychainKeyNotFoundException || ex is ObjectDisposedException)
             {
                 ReownLogger.Log($"[{Name}] Dropping message on topic {topic}: {ex.Message}");
                 return (false, default);

--- a/src/Reown.Core/Runtime/CoreClient.cs
+++ b/src/Reown.Core/Runtime/CoreClient.cs
@@ -26,7 +26,7 @@ namespace Reown.Core
         private readonly string _optName;
         private readonly string guid = "";
         private readonly IKeyValueStorage _ownedStorage;
-        private readonly ICrypto _ownedCrypto;
+        private readonly Crypto.Crypto _ownedCrypto;
 
         /// <summary>
         ///     Create a new Core with the given options.

--- a/src/Reown.Core/Runtime/CoreClient.cs
+++ b/src/Reown.Core/Runtime/CoreClient.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Reown.Core.Controllers;
-using Reown.Core.Crypto;
 using Reown.Core.Crypto.Interfaces;
 using Reown.Core.Interfaces;
 using Reown.Core.Models;
@@ -26,36 +25,44 @@ namespace Reown.Core
 
         private readonly string _optName;
         private readonly string guid = "";
+        private readonly IKeyValueStorage _ownedStorage;
+        private readonly ICrypto _ownedCrypto;
 
         /// <summary>
         ///     Create a new Core with the given options.
         /// </summary>
-        /// <param name="options">The options to use to configure the new Core module</param>
+        /// <param name="options">
+        ///     The options to use to configure the new Core module. The options object is read but never written to,
+        ///     and every module it supplies belongs to the caller: only the modules this client creates itself are
+        ///     disposed with it. The same options object can therefore be used to build another client once this
+        ///     one has been disposed.
+        /// </param>
         public CoreClient(CoreOptions options = null)
         {
             if (options == null)
             {
-                var storage = new InMemoryStorage();
                 options = new CoreOptions
                 {
-                    KeyChain = new KeyChain(storage),
                     ProjectId = null,
-                    RelayUrl = null,
-                    Storage = storage
+                    RelayUrl = null
                 };
-            }
 
-            if (options.Storage == null)
-            {
-                options.Storage = new FileSystemStorage();
+                _ownedStorage = new InMemoryStorage();
+                Storage = _ownedStorage;
             }
-            
-            options.RelayUrlBuilder ??= new RelayUrlBuilder();
+            else if (options.Storage == null)
+            {
+                _ownedStorage = new FileSystemStorage();
+                Storage = _ownedStorage;
+            }
+            else
+            {
+                Storage = options.Storage;
+            }
 
             Options = options;
             ProjectId = options.ProjectId;
             RelayUrl = options.RelayUrl;
-            Storage = options.Storage;
 
             if (options.CryptoModule != null)
             {
@@ -63,12 +70,10 @@ namespace Reown.Core
             }
             else
             {
-                if (options.KeyChain == null)
-                {
-                    options.KeyChain = new KeyChain(options.Storage);
-                }
-
-                Crypto = new Crypto.Crypto(options.KeyChain);
+                _ownedCrypto = options.KeyChain != null
+                    ? new Crypto.Crypto(options.KeyChain)
+                    : new Crypto.Crypto(Storage);
+                Crypto = _ownedCrypto;
             }
 
             HeartBeat = new HeartBeat();
@@ -84,7 +89,7 @@ namespace Reown.Core
                 ProjectId = ProjectId,
                 RelayUrl = options.RelayUrl,
                 ConnectionTimeout = options.ConnectionTimeout,
-                RelayUrlBuilder = options.RelayUrlBuilder
+                RelayUrlBuilder = options.RelayUrlBuilder ?? new RelayUrlBuilder()
             });
 
             MessageHandler = new TypedMessageHandler(this);
@@ -208,12 +213,14 @@ namespace Reown.Core
             if (disposing)
             {
                 HeartBeat?.Dispose();
-                Crypto?.Dispose();
+
+                // Relayer and MessageHandler go before Crypto: in-flight messages decode through it.
                 Relayer?.Dispose();
-                Storage?.Dispose();
                 MessageHandler?.Dispose();
                 Expirer?.Dispose();
                 Pairing?.Dispose();
+                _ownedCrypto?.Dispose();
+                _ownedStorage?.Dispose();
                 Verify?.Dispose();
             }
 

--- a/src/Reown.Core/Runtime/Models/CoreOptions.cs
+++ b/src/Reown.Core/Runtime/Models/CoreOptions.cs
@@ -12,6 +12,14 @@ namespace Reown.Core.Models
     /// <summary>
     ///     Options used to configure the Core module.
     /// </summary>
+    /// <remarks>
+    ///     <see cref="CoreClient" /> reads these options and never writes to them. Every module supplied here stays
+    ///     owned by the caller: the client disposes only the modules it created itself, so a supplied storage,
+    ///     keychain or crypto module is still usable after that client has been disposed.
+    ///     One options object can therefore build one client after another, but only in sequence: two clients that
+    ///     are live at the same time need their own storage and keychain, because both write the whole keychain to
+    ///     the same storage key.
+    /// </remarks>
     public class CoreOptions
     {
         /// <summary>
@@ -38,13 +46,19 @@ namespace Reown.Core.Models
         /// <summary>
         ///     The <see cref="IKeyValueStorage" /> module to use for storage. This module will be used by most Core modules
         ///     for storing data and by the default <see cref="IKeyChain" /> module (if no <see cref="IKeyChain" /> module is provided).
-        ///     If this is set to null, then the default <see cref="FileSystemStorage" />
+        ///     If this is set to null, then the default <see cref="FileSystemStorage" /> will be used, and that one is
+        ///     disposed with the client that created it.
+        ///     A storage set here belongs to the caller and is not disposed with the client, so it stays usable
+        ///     afterwards. Do not dispose it while a client is still using it.
         /// </summary>
         [JsonProperty("storage")] public IKeyValueStorage Storage { get; set; }
 
         /// <summary>
         ///     The <see cref="IKeyChain" /> module to use for the <see cref="ICrypto" /> module.
-        ///     If set to null, then the default <see cref="KeyChain" /> module will be used with the provided Storage module.
+        ///     If set to null, then the default <see cref="KeyChain" /> module will be used with the provided Storage
+        ///     module, and that one is disposed with the client that created it.
+        ///     A keychain set here belongs to the caller and is not disposed with the client, so it stays usable
+        ///     afterwards. Two live clients must not share one keychain.
         /// </summary>
         [JsonProperty("keychain")] public IKeyChain KeyChain { get; set; }
 
@@ -57,7 +71,9 @@ namespace Reown.Core.Models
         /// <summary>
         ///     The <see cref="ICrypto" /> module to use for crypto operations. This option
         ///     overrides the KeyChain option. If set to null, then a default Crypto module will be used
-        ///     with either the KeyChain option or a default keychain
+        ///     with either the KeyChain option or a default keychain, and that one is disposed with the client that
+        ///     created it.
+        ///     A crypto module set here belongs to the caller and is not disposed with the client.
         /// </summary>
         public ICrypto CryptoModule { get; set; }
 

--- a/src/Reown.Sign.Unity/Runtime/PlayerPrefsStorage.cs
+++ b/src/Reown.Sign.Unity/Runtime/PlayerPrefsStorage.cs
@@ -111,7 +111,6 @@ namespace Reown.Sign.Unity
 
             if (disposing)
             {
-                // Null until Init() runs, so a storage that was never initialized can still be disposed
                 _semaphoreSlim?.Dispose();
             }
 

--- a/src/Reown.Sign.Unity/Runtime/PlayerPrefsStorage.cs
+++ b/src/Reown.Sign.Unity/Runtime/PlayerPrefsStorage.cs
@@ -111,7 +111,8 @@ namespace Reown.Sign.Unity
 
             if (disposing)
             {
-                _semaphoreSlim.Dispose();
+                // Null until Init() runs, so a storage that was never initialized can still be disposed
+                _semaphoreSlim?.Dispose();
             }
 
             Disposed = true;

--- a/src/Reown.Sign.Unity/Runtime/SignClientUnity.cs
+++ b/src/Reown.Sign.Unity/Runtime/SignClientUnity.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Reown.Core.Common.Logging;
 using Reown.Core.Common.Model.Errors;
-using Reown.Core.Crypto;
 using Reown.Core.Storage;
 using Reown.Core.Storage.Interfaces;
 using Reown.Sign.Models;
@@ -41,9 +40,7 @@ namespace Reown.Sign.Unity
         {
             if (options.Storage == null)
             {
-                var storage = await BuildUnityStorage();
-                options.Storage = storage;
-                options.KeyChain ??= new KeyChain(storage);
+                options.Storage = await BuildUnityStorage();
             }
 
             options.RelayUrlBuilder ??= new UnityRelayUrlBuilder();

--- a/src/Reown.Sign/Runtime/SignClient.cs
+++ b/src/Reown.Sign/Runtime/SignClient.cs
@@ -6,7 +6,6 @@ using Newtonsoft.Json.Linq;
 using Reown.Core;
 using Reown.Core.Common.Model.Errors;
 using Reown.Core.Controllers;
-using Reown.Core.Crypto;
 using Reown.Core.Interfaces;
 using Reown.Core.Models;
 using Reown.Core.Models.MessageHandler;
@@ -77,11 +76,7 @@ namespace Reown.Sign
             // Setup storage
             if (options.Storage == null)
             {
-                var storage = new FileSystemStorage();
-                options.Storage = storage;
-
-                // If keychain is also not set, use the same storage instance
-                options.KeyChain ??= new KeyChain(storage);
+                options.Storage = new FileSystemStorage();
             }
 
 #if !UNITY_2021_1_OR_NEWER

--- a/test/Reown.Core.Crypto.Test/CryptoClientSeedTests.cs
+++ b/test/Reown.Core.Crypto.Test/CryptoClientSeedTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Concurrent;
+using Reown.Core.Common.Logging;
+using Reown.Core.Storage;
+using Xunit;
+
+namespace Reown.Core.Crypto.Test;
+
+public class CryptoClientSeedTests
+{
+    private const string SymKey = "6c0b1f43b1f5b1e0eeb2c0e05f5b2b2ff5f2a5b3c8a4e7d9f1a2b3c4d5e6f708";
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public ConcurrentQueue<string> Messages { get; } = new();
+        public ConcurrentQueue<string> Errors { get; } = new();
+
+        public void Log(string message) => Messages.Enqueue(message);
+
+        public void LogError(string message) => Errors.Enqueue(message);
+
+        public void LogError(Exception e) => Errors.Enqueue(e.ToString());
+    }
+
+    private static async Task<CapturingLogger> CaptureLogsAsync(Func<Task> action)
+    {
+        var logger = new CapturingLogger();
+        var previousLogger = ReownLogger.Instance;
+        ReownLogger.Instance = logger;
+
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            ReownLogger.Instance = previousLogger;
+        }
+
+        return logger;
+    }
+
+    private static async Task<DisposeTrackingStorage> CreateStorageAsync()
+    {
+        var storage = new DisposeTrackingStorage();
+        await storage.Init();
+        return storage;
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task ClientIdIsStableAcrossCryptoModulesOverTheSameStorage()
+    {
+        var storage = await CreateStorageAsync();
+
+        var first = new Crypto(new KeyChain(storage));
+        await first.Init();
+        var clientId = await first.GetClientId();
+        first.Dispose();
+
+        var second = new Crypto(new KeyChain(storage));
+        await second.Init();
+
+        Assert.Equal(clientId, await second.GetClientId());
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task GetClientIdOnADisposedCryptoModuleThrowsInsteadOfGeneratingANewSeed()
+    {
+        var storage = await CreateStorageAsync();
+
+        var keyChain = new KeyChain(storage);
+        var crypto = new Crypto(keyChain);
+        await crypto.Init();
+        await crypto.SetSymKey(SymKey, "session-topic");
+
+        var storedBefore =
+            new Dictionary<string, string>(await storage.GetItem<Dictionary<string, string>>(keyChain.StorageKey));
+        crypto.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => crypto.GetClientId());
+
+        var storedAfter = await storage.GetItem<Dictionary<string, string>>(keyChain.StorageKey);
+        Assert.Equal(storedBefore.Count, storedAfter.Count);
+        foreach (var entry in storedBefore)
+        {
+            Assert.Equal(entry.Value, Assert.Contains(entry.Key, storedAfter));
+        }
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task GeneratingAClientSeedForAnEmptyKeychainIsLogged()
+    {
+        var logger = await CaptureLogsAsync(async () =>
+        {
+            var crypto = new Crypto(new KeyChain(await CreateStorageAsync()));
+            await crypto.Init();
+            await crypto.GetClientId();
+        });
+
+        Assert.Contains(logger.Messages, message => message.Contains("No client seed found in the keychain"));
+        Assert.DoesNotContain(logger.Errors, message => message.Contains("No client seed found in the keychain"));
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task GeneratingAClientSeedForAKeychainHoldingOtherKeysIsLoggedAsAnError()
+    {
+        var logger = await CaptureLogsAsync(async () =>
+        {
+            var crypto = new Crypto(new KeyChain(await CreateStorageAsync()));
+            await crypto.Init();
+            await crypto.SetSymKey(SymKey, "session-topic");
+            await crypto.GetClientId();
+        });
+
+        Assert.Contains(logger.Errors, message => message.Contains("but it holds 1 other key(s)"));
+    }
+}

--- a/test/Reown.Core.Crypto.Test/CryptoOwnershipTests.cs
+++ b/test/Reown.Core.Crypto.Test/CryptoOwnershipTests.cs
@@ -1,0 +1,59 @@
+using Reown.Core.Storage;
+using Xunit;
+
+namespace Reown.Core.Crypto.Test;
+
+/// <summary>
+///     Tests that a <see cref="Crypto" /> module disposes the keychain it built itself and leaves a keychain it
+///     was given alone, so that a caller can keep using its own keychain after the module is gone.
+/// </summary>
+public class CryptoOwnershipTests
+{
+    private const string SymKey = "6c0b1f43b1f5b1e0eeb2c0e05f5b2b2ff5f2a5b3c8a4e7d9f1a2b3c4d5e6f708";
+
+    [Fact, Trait("Category", "unit")]
+    public async Task DisposeDisposesAKeyChainBuiltFromTheGivenStorage()
+    {
+        var storage = new DisposeTrackingStorage();
+        await storage.Init();
+
+        var crypto = new Crypto(storage);
+        await crypto.Init();
+        var keyChain = crypto.KeyChain;
+        crypto.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => keyChain.Has("some-tag"));
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task DisposeLeavesACallerSuppliedKeyChainUsable()
+    {
+        var storage = new DisposeTrackingStorage();
+        await storage.Init();
+
+        var keyChain = new KeyChain(storage);
+        var crypto = new Crypto(keyChain);
+        await crypto.Init();
+        await crypto.SetSymKey(SymKey);
+        crypto.Dispose();
+
+        Assert.NotEmpty(keyChain.Keychain);
+        await keyChain.Set("some-tag", "some-key");
+        Assert.Equal("some-key", await keyChain.Get("some-tag"));
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task DisposeLeavesTheGivenStorageAlone()
+    {
+        var storage = new DisposeTrackingStorage();
+        await storage.Init();
+
+        var crypto = new Crypto(storage);
+        await crypto.Init();
+        crypto.Dispose();
+
+        Assert.Equal(0, storage.DisposeCount);
+        await storage.SetItem("some-key", "some-value");
+        Assert.Equal("some-value", await storage.GetItem<string>("some-key"));
+    }
+}

--- a/test/Reown.Core.Crypto.Test/DisposeTrackingStorage.cs
+++ b/test/Reown.Core.Crypto.Test/DisposeTrackingStorage.cs
@@ -1,0 +1,57 @@
+using Reown.Core.Storage;
+
+namespace Reown.Core.Crypto.Test;
+
+/// <summary>
+///     An <see cref="InMemoryStorage" /> that counts how often it was disposed and refuses every operation
+///     afterwards. <see cref="InMemoryStorage" /> on its own keeps working once disposed, which would let a test
+///     pass whether or not the object under test disposed a storage it does not own.
+/// </summary>
+internal sealed class DisposeTrackingStorage : InMemoryStorage
+{
+    public int DisposeCount { get; private set; }
+
+    public override Task<string[]> GetKeys()
+    {
+        ThrowIfDisposed();
+        return base.GetKeys();
+    }
+
+    public override Task<T> GetItem<T>(string key)
+    {
+        ThrowIfDisposed();
+        return base.GetItem<T>(key);
+    }
+
+    public override Task SetItem<T>(string key, T value)
+    {
+        ThrowIfDisposed();
+        return base.SetItem(key, value);
+    }
+
+    public override Task RemoveItem(string key)
+    {
+        ThrowIfDisposed();
+        return base.RemoveItem(key);
+    }
+
+    public override Task<bool> HasItem(string key)
+    {
+        ThrowIfDisposed();
+        return base.HasItem(key);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        DisposeCount++;
+        base.Dispose(disposing);
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (DisposeCount > 0)
+        {
+            throw new ObjectDisposedException(nameof(DisposeTrackingStorage));
+        }
+    }
+}

--- a/test/Reown.Core.Crypto.Test/DisposeTrackingStorage.cs
+++ b/test/Reown.Core.Crypto.Test/DisposeTrackingStorage.cs
@@ -49,9 +49,6 @@ internal sealed class DisposeTrackingStorage : InMemoryStorage
 
     private void ThrowIfDisposed()
     {
-        if (DisposeCount > 0)
-        {
-            throw new ObjectDisposedException(nameof(DisposeTrackingStorage));
-        }
+        ObjectDisposedException.ThrowIf(DisposeCount > 0, this);
     }
 }

--- a/test/Reown.Core.Crypto.Test/KeyChainTests.cs
+++ b/test/Reown.Core.Crypto.Test/KeyChainTests.cs
@@ -132,6 +132,8 @@ public class KeyChainTests
 
         keyChain.Dispose();
         keyChain.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => keyChain.Has("tag"));
     }
 
     [Fact, Trait("Category", "unit")]

--- a/test/Reown.Core.Crypto.Test/KeyChainTests.cs
+++ b/test/Reown.Core.Crypto.Test/KeyChainTests.cs
@@ -61,4 +61,109 @@ public class KeyChainTests
     {
         Assert.Throws<ArgumentNullException>(() => new KeychainKeyNotFoundException(null!));
     }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task InitDoesNotWriteAnEmptyKeychainToStorage()
+    {
+        var storage = new InMemoryStorage();
+        await storage.Init();
+
+        var keyChain = new KeyChain(storage);
+        await keyChain.Init();
+
+        Assert.False(await storage.HasItem(keyChain.StorageKey));
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task InitThrowsWhenTheStoredKeychainCannotBeRead()
+    {
+        var storage = new InMemoryStorage();
+        await storage.Init();
+
+        var keyChain = new KeyChain(storage);
+        await storage.SetItem<object>(keyChain.StorageKey, "not-a-keychain");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => keyChain.Init());
+
+        Assert.Equal("not-a-keychain", await storage.GetItem<object>(keyChain.StorageKey));
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task InitAfterDisposeThrowsObjectDisposedException()
+    {
+        var keyChain = await CreateInitializedKeyChainAsync();
+        keyChain.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => keyChain.Init());
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task GetAfterDisposeThrowsObjectDisposedException()
+    {
+        var keyChain = await CreateInitializedKeyChainAsync();
+        await keyChain.Set("tag", "key");
+        keyChain.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => keyChain.Get("tag"));
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task SetAfterDisposeThrowsAndLeavesStoredKeysIntact()
+    {
+        var storage = new InMemoryStorage();
+        await storage.Init();
+
+        var keyChain = new KeyChain(storage);
+        await keyChain.Init();
+        await keyChain.Set("session-tag", "session-key");
+        keyChain.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => keyChain.Set("client-seed", "seed"));
+
+        var stored = await storage.GetItem<Dictionary<string, string>>(keyChain.StorageKey);
+        Assert.Equal("session-key", Assert.Contains("session-tag", stored));
+        Assert.Single(stored);
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task DisposeIsIdempotent()
+    {
+        var keyChain = await CreateInitializedKeyChainAsync();
+
+        keyChain.Dispose();
+        keyChain.Dispose();
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task DisposeLeavesTheStorageAlone()
+    {
+        var storage = new DisposeTrackingStorage();
+        await storage.Init();
+
+        var keyChain = new KeyChain(storage);
+        await keyChain.Init();
+        await keyChain.Set("session-tag", "session-key");
+        keyChain.Dispose();
+
+        Assert.Equal(0, storage.DisposeCount);
+        await storage.SetItem("some-key", "some-value");
+        Assert.Equal("some-value", await storage.GetItem<string>("some-key"));
+    }
+
+    [Fact, Trait("Category", "unit")]
+    public async Task ReplacementKeyChainOverTheSameStorageLoadsStoredKeys()
+    {
+        var storage = new DisposeTrackingStorage();
+        await storage.Init();
+
+        var first = new KeyChain(storage);
+        await first.Init();
+        await first.Set("session-tag", "session-key");
+        first.Dispose();
+
+        var second = new KeyChain(storage);
+        await second.Init();
+
+        Assert.Equal("session-key", await second.Get("session-tag"));
+    }
 }

--- a/test/Reown.Core.Network.Test/CoreClientOptionsTests.cs
+++ b/test/Reown.Core.Network.Test/CoreClientOptionsTests.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Threading.Tasks;
+using Reown.Core.Crypto;
+using Reown.Core.Models;
+using Reown.Core.Storage;
+using Reown.Core.Storage.Interfaces;
+using Xunit;
+
+namespace Reown.Core.Network.Test
+{
+    /// <summary>
+    ///     Tests that a <see cref="CoreClient" /> reads its <see cref="CoreOptions" /> without writing to them and
+    ///     disposes only the modules it created itself, so that a client built later from the same options object
+    ///     does not inherit disposed modules.
+    /// </summary>
+    public sealed class CoreClientOptionsTests
+    {
+        private const string SymKey = "6c0b1f43b1f5b1e0eeb2c0e05f5b2b2ff5f2a5b3c8a4e7d9f1a2b3c4d5e6f708";
+
+        private static CoreOptions CreateOptions(IKeyValueStorage storage)
+        {
+            return new CoreOptions
+            {
+                Name = "core-client-options-test",
+                ProjectId = "test-project-id",
+                Storage = storage
+            };
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ConstructorDoesNotStoreTheKeyChainOnTheGivenOptions()
+        {
+            var options = CreateOptions(new InMemoryStorage());
+
+            var client = new CoreClient(options);
+
+            Assert.Null(options.KeyChain);
+
+            client.Dispose();
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ConstructorDoesNotStoreTheDefaultStorageOnTheGivenOptions()
+        {
+            var options = new CoreOptions
+            {
+                Name = "core-client-options-test",
+                ProjectId = "test-project-id"
+            };
+
+            var client = new CoreClient(options);
+
+            Assert.Null(options.Storage);
+            Assert.NotNull(client.Storage);
+
+            client.Dispose();
+        }
+
+        /// <summary>
+        ///     Rebuilding a client from the same options object must leave the stored keys and the client id alone.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task ClientRebuiltFromTheSameOptionsKeepsTheStoredKeys()
+        {
+            var storage = new DisposeTrackingStorage();
+            await storage.Init();
+            var options = CreateOptions(storage);
+
+            var first = new CoreClient(options);
+            await first.Crypto.Init();
+            var clientId = await first.Crypto.GetClientId();
+            var topic = await first.Crypto.SetSymKey(SymKey);
+            first.Dispose();
+
+            var second = new CoreClient(options);
+            await second.Crypto.Init();
+
+            Assert.Equal(clientId, await second.Crypto.GetClientId());
+            Assert.True(await second.Crypto.HasKeys(topic));
+
+            second.Dispose();
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task DisposeLeavesACallerSuppliedStorageAlone()
+        {
+            var storage = new DisposeTrackingStorage();
+            await storage.Init();
+
+            var client = new CoreClient(CreateOptions(storage));
+            await client.Crypto.Init();
+            client.Dispose();
+
+            Assert.Equal(0, storage.DisposeCount);
+            await storage.SetItem("some-key", "some-value");
+            Assert.Equal("some-value", await storage.GetItem<string>("some-key"));
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task DisposeLeavesACallerSuppliedKeyChainUsable()
+        {
+            var storage = new InMemoryStorage();
+            await storage.Init();
+
+            var keyChain = new KeyChain(storage);
+            var options = CreateOptions(storage);
+            options.KeyChain = keyChain;
+
+            var client = new CoreClient(options);
+            await client.Crypto.Init();
+            await keyChain.Set("some-tag", SymKey);
+            client.Dispose();
+
+            Assert.Equal(SymKey, await keyChain.Get("some-tag"));
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task DisposeLeavesACallerSuppliedCryptoModuleUsable()
+        {
+            var storage = new InMemoryStorage();
+            await storage.Init();
+
+            var crypto = new Crypto.Crypto(storage);
+            await crypto.Init();
+
+            var options = CreateOptions(storage);
+            options.CryptoModule = crypto;
+
+            var client = new CoreClient(options);
+            var topic = await crypto.SetSymKey(SymKey);
+            client.Dispose();
+
+            Assert.True(await crypto.HasKeys(topic));
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task DisposeDisposesTheKeyChainItCreated()
+        {
+            var storage = new InMemoryStorage();
+            await storage.Init();
+
+            var client = new CoreClient(CreateOptions(storage));
+            await client.Crypto.Init();
+            var keyChain = client.Crypto.KeyChain;
+            client.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => keyChain.Has("some-tag"));
+        }
+
+        /// <summary>
+        ///     An <see cref="InMemoryStorage" /> that counts how often it was disposed and refuses every operation
+        ///     afterwards. <see cref="InMemoryStorage" /> on its own keeps working once disposed, which would let a
+        ///     test pass whether or not the client disposed a storage it does not own.
+        /// </summary>
+        private sealed class DisposeTrackingStorage : InMemoryStorage
+        {
+            public int DisposeCount { get; private set; }
+
+            public override Task<T> GetItem<T>(string key)
+            {
+                ThrowIfDisposed();
+                return base.GetItem<T>(key);
+            }
+
+            public override Task SetItem<T>(string key, T value)
+            {
+                ThrowIfDisposed();
+                return base.SetItem(key, value);
+            }
+
+            public override Task RemoveItem(string key)
+            {
+                ThrowIfDisposed();
+                return base.RemoveItem(key);
+            }
+
+            public override Task<bool> HasItem(string key)
+            {
+                ThrowIfDisposed();
+                return base.HasItem(key);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCount++;
+                base.Dispose(disposing);
+            }
+
+            private void ThrowIfDisposed()
+            {
+                if (DisposeCount > 0)
+                {
+                    throw new ObjectDisposedException(nameof(DisposeTrackingStorage));
+                }
+            }
+        }
+    }
+}

--- a/test/Reown.Core.Network.Test/CoreClientOptionsTests.cs
+++ b/test/Reown.Core.Network.Test/CoreClientOptionsTests.cs
@@ -195,10 +195,7 @@ namespace Reown.Core.Network.Test
 
             private void ThrowIfDisposed()
             {
-                if (DisposeCount > 0)
-                {
-                    throw new ObjectDisposedException(nameof(DisposeTrackingStorage));
-                }
+                ObjectDisposedException.ThrowIf(DisposeCount > 0, this);
             }
         }
     }

--- a/test/Reown.Core.Network.Test/TypedMessageHandlerTests.cs
+++ b/test/Reown.Core.Network.Test/TypedMessageHandlerTests.cs
@@ -96,6 +96,33 @@ namespace Reown.Core.Network.Test
             Assert.Contains(_logger.Messages, m => m.Contains($"Dropping message on topic {topic}"));
         }
 
+        /// <summary>
+        ///     A relayed message that arrives after the crypto module was disposed is dropped the same way
+        ///     as one whose key is missing, instead of surfacing as an error during teardown.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "unit")]
+        public async Task RelayMessageCallback_DropsMessage_WhenCryptoModuleDisposed()
+        {
+            const string topic = "disposed-crypto-topic";
+            var coreClient = CreateCoreClient();
+            coreClient.Crypto
+                .Decode<JsonRpcPayload>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DecodeOptions>())
+                .Returns<Task<JsonRpcPayload>>(_ => throw new ObjectDisposedException(nameof(Crypto)));
+
+            var handler = new TypedMessageHandler(coreClient);
+            await handler.Init();
+
+            var rawMessageRaised = false;
+            handler.RawMessage += (_, _) => rawMessageRaised = true;
+
+            coreClient.Relayer.OnMessageReceived += Raise.Event<EventHandler<MessageEvent>>(
+                this, new MessageEvent { Topic = topic, Message = "encrypted" });
+
+            Assert.False(rawMessageRaised);
+            Assert.Contains(_logger.Messages, m => m.Contains($"Dropping message on topic {topic}"));
+        }
+
         private static ICoreClient CreateCoreClient()
         {
             var coreClient = Substitute.For<ICoreClient>();


### PR DESCRIPTION
Fixes #329.

A `CoreClient` built from an options object that had already built a client came up with an empty keychain, and the first key it wrote replaced the whole stored keychain — a wallet lost four live sessions this way. Disposing the first client cleared the keychain's keys and disposed the storage, while the options object kept holding that dead keychain for the next client to pick up.

- **A disposed keychain is dead, not empty.** `KeyChain.Dispose()` no longer clears the keys or disposes the storage; every key operation throws `ObjectDisposedException` afterwards. The keys are deliberately left in place, because clearing them would race with a `Set` already past its disposed check and persist an empty keychain.
- **`Init()` no longer creates an empty keychain entry** when storage holds none, and refuses to start empty when the stored keychain cannot be read as a dictionary — starting empty there would overwrite the stored keys on the first write.
- **Ownership rule in Core: dispose only what you created.** The client reads its options without writing to them and disposes only the storage, keychain and crypto module it built itself. A supplied storage, keychain or crypto module stays usable after the client is gone, so one options object can build another client. This matches the .NET convention for injected `IDisposable` dependencies.
- **A missing client seed is now reported.** It was silently replaced with a fresh one, which changes the client id and is the symptom users saw; it logs an error when the keychain holds other keys, and an informational line on a genuine first run.
- **Disposal no longer throws on a client that was never initialized** (relayer provider, pairing handlers, storage semaphores), and a message that arrives after crypto is gone is dropped rather than faulting the handler.

The same ownership rule still needs applying to the Sign and WalletKit layers, which set `options.Storage` themselves and dispose a supplied core client; that is a follow-up.

### Testing

`dotnet test Reown.NoUnity.slnf --filter Category=unit` — 435 tests pass on each of net8.0/net9.0/net10.0; integration suites pass on net10.0 (Sign 35, WalletKit 11). New tests cover the rebuild path with a storage double that throws once disposed, so they fail if either fix is reverted. Unity compilation was not verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

