### PR TITLE
fix(core): stop heartbeat loop on dispose

### DIFF
--- a/src/Reown.Core/Runtime/Controllers/HeartBeat.cs
+++ b/src/Reown.Core/Runtime/Controllers/HeartBeat.cs
@@ -32,7 +32,10 @@ namespace Reown.Core
             Interval = interval;
         }
 
-        private CancellationTokenSource CancellationTokenSource { get; set; } = new();
+        /// <summary>
+        ///     The CancellationTokenSource that can be used to stop the Heartbeat module
+        /// </summary>
+        public CancellationTokenSource CancellationTokenSource { get; private set; } = new();
 
         /// <summary>
         ///     The name of this Heartbeat module

--- a/src/Reown.Core/Runtime/Controllers/HeartBeat.cs
+++ b/src/Reown.Core/Runtime/Controllers/HeartBeat.cs
@@ -12,6 +12,10 @@ namespace Reown.Core
     /// </summary>
     public class HeartBeat : IHeartBeat
     {
+        private readonly object _lifecycleLock = new();
+        private Task _pulseTask = Task.CompletedTask;
+        private bool _initialized;
+
         /// <summary>
         ///     The context UUID that this heartbeat module uses
         /// </summary>
@@ -57,44 +61,113 @@ namespace Reown.Core
         public event EventHandler OnPulse;
 
         /// <summary>
-        ///     Initialize the heartbeat module. This will start the pulse event and
-        ///     will continuously emit the pulse event at the configured interval. If the
-        ///     HeartBeatCancellationToken is cancelled, then the interval will be halted.
+        ///     Starts the pulse loop if it has not already been started. The loop stops when either the supplied
+        ///     cancellation token or the <see cref="CancellationTokenSource" /> is cancelled.
         /// </summary>
-        /// <returns></returns>
+        /// <param name="cancellationToken">A token that can stop the pulse loop.</param>
+        /// <returns>A task that completes after the pulse loop has been started.</returns>
         public Task InitAsync(CancellationToken cancellationToken = default)
         {
-            if (cancellationToken != default)
+            lock (_lifecycleLock)
             {
-                CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            }
-
-            var token = CancellationTokenSource.Token;
-            Task.Run(async () =>
-            {
-                while (!token.IsCancellationRequested)
+                if (Disposed || _initialized)
                 {
-                    try
-                    {
-                        Pulse();
-                    }
-                    catch (Exception ex)
-                    {
-                        ReownLogger.LogError(ex);
-                    }
-
-                    await Task.Delay(Interval, token);
+                    return Task.CompletedTask;
                 }
-            }, token);
+
+                if (cancellationToken.CanBeCanceled)
+                {
+                    var previousCancellationTokenSource = CancellationTokenSource;
+                    CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                        previousCancellationTokenSource.Token,
+                        cancellationToken);
+                    previousCancellationTokenSource.Dispose();
+                }
+
+                _initialized = true;
+                var token = CancellationTokenSource.Token;
+                _pulseTask = Task.Run(() => PulseLoopAsync(token));
+                ObservePulseTask(_pulseTask);
+            }
 
             return Task.CompletedTask;
         }
 
-        private void Pulse()
+        internal Task PulseTask
         {
-            OnPulse?.Invoke(this, EventArgs.Empty);
+            get
+            {
+                lock (_lifecycleLock)
+                {
+                    return _pulseTask;
+                }
+            }
         }
 
+        private async Task PulseLoopAsync(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    Pulse();
+                    await Task.Delay(Interval, token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    LogError(ex);
+                }
+            }
+        }
+
+        private static void ObservePulseTask(Task pulseTask)
+        {
+            pulseTask.ContinueWith(
+                task => LogError(task.Exception),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+
+        private void Pulse()
+        {
+            var handlers = OnPulse;
+            if (handlers == null)
+            {
+                return;
+            }
+
+            foreach (EventHandler handler in handlers.GetInvocationList())
+            {
+                try
+                {
+                    handler(this, EventArgs.Empty);
+                }
+                catch (Exception ex)
+                {
+                    LogError(ex);
+                }
+            }
+        }
+
+        private static void LogError(Exception exception)
+        {
+            try
+            {
+                ReownLogger.LogError(exception);
+            }
+            catch
+            {
+            }
+        }
+
+        /// <summary>
+        ///     Cancels the pulse loop and releases the resources used by this heartbeat module.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
@@ -103,14 +176,35 @@ namespace Reown.Core
 
         protected virtual void Dispose(bool disposing)
         {
-            if (Disposed) return;
+            CancellationTokenSource cancellationTokenSource = null;
 
-            if (disposing)
+            lock (_lifecycleLock)
             {
-                CancellationTokenSource?.Dispose();
+                if (Disposed) return;
+
+                Disposed = true;
+                if (disposing)
+                {
+                    cancellationTokenSource = CancellationTokenSource;
+                }
             }
 
-            Disposed = true;
+            if (cancellationTokenSource == null)
+            {
+                return;
+            }
+
+            try
+            {
+                cancellationTokenSource.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            finally
+            {
+                cancellationTokenSource.Dispose();
+            }
         }
     }
 }

--- a/src/Reown.Core/Runtime/Controllers/HeartBeat.cs
+++ b/src/Reown.Core/Runtime/Controllers/HeartBeat.cs
@@ -32,10 +32,7 @@ namespace Reown.Core
             Interval = interval;
         }
 
-        /// <summary>
-        ///     The CancellationTokenSource that can be used to stop the Heartbeat module
-        /// </summary>
-        public CancellationTokenSource CancellationTokenSource { get; private set; } = new();
+        private CancellationTokenSource CancellationTokenSource { get; set; } = new();
 
         /// <summary>
         ///     The name of this Heartbeat module
@@ -61,8 +58,8 @@ namespace Reown.Core
         public event EventHandler OnPulse;
 
         /// <summary>
-        ///     Starts the pulse loop if it has not already been started. The loop stops when either the supplied
-        ///     cancellation token or the <see cref="CancellationTokenSource" /> is cancelled.
+        ///     Starts the pulse loop if it has not already been started. The loop stops when the supplied
+        ///     cancellation token is cancelled or this heartbeat module is disposed.
         /// </summary>
         /// <param name="cancellationToken">A token that can stop the pulse loop.</param>
         /// <returns>A task that completes after the pulse loop has been started.</returns>
@@ -86,7 +83,7 @@ namespace Reown.Core
 
                 _initialized = true;
                 var token = CancellationTokenSource.Token;
-                _pulseTask = Task.Run(() => PulseLoopAsync(token));
+                _pulseTask = Task.Run(() => PulseLoopAsync(token), CancellationToken.None);
                 ObservePulseTask(_pulseTask);
             }
 
@@ -141,11 +138,11 @@ namespace Reown.Core
                 return;
             }
 
-            foreach (EventHandler handler in handlers.GetInvocationList())
+            foreach (Delegate handler in handlers.GetInvocationList())
             {
                 try
                 {
-                    handler(this, EventArgs.Empty);
+                    ((EventHandler)handler)(this, EventArgs.Empty);
                 }
                 catch (Exception ex)
                 {
@@ -160,8 +157,9 @@ namespace Reown.Core
             {
                 ReownLogger.LogError(exception);
             }
-            catch
+            catch (Exception loggerException)
             {
+                System.Diagnostics.Debug.WriteLine(loggerException);
             }
         }
 
@@ -194,17 +192,8 @@ namespace Reown.Core
                 return;
             }
 
-            try
-            {
-                cancellationTokenSource.Cancel();
-            }
-            catch (ObjectDisposedException)
-            {
-            }
-            finally
-            {
-                cancellationTokenSource.Dispose();
-            }
+            cancellationTokenSource.Cancel();
+            cancellationTokenSource.Dispose();
         }
     }
 }

--- a/test/Reown.Core.Network.Test/HeartBeatTests.cs
+++ b/test/Reown.Core.Network.Test/HeartBeatTests.cs
@@ -9,33 +9,46 @@ namespace Reown.Core.Network.Test;
 [Trait("Category", "unit")]
 public class HeartBeatTests
 {
-    private static readonly TimeSpan NoPulseTimeout = TimeSpan.FromMilliseconds(200);
+    private const int PulseInterval = 100;
+    private static readonly TimeSpan NoPulseTimeout = TimeSpan.FromMilliseconds(500);
 
     [Fact]
     public async Task Dispose_StopsFurtherPulses()
     {
         var firstPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var additionalPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseFirstPulse = new ManualResetEventSlim(false);
         var pulseCount = 0;
-        var heartBeat = new HeartBeat(25);
+        var heartBeat = new HeartBeat(PulseInterval);
         heartBeat.OnPulse += (_, _) =>
         {
             if (Interlocked.Increment(ref pulseCount) == 1)
             {
                 firstPulse.TrySetResult(true);
+                releaseFirstPulse.Wait();
                 return;
             }
 
             additionalPulse.TrySetResult(true);
         };
 
-        await heartBeat.InitAsync();
-        await WaitForCompletionAsync(firstPulse.Task);
+        try
+        {
+            await heartBeat.InitAsync();
+            await WaitForCompletionAsync(firstPulse.Task);
 
-        heartBeat.Dispose();
+            heartBeat.Dispose();
+            releaseFirstPulse.Set();
 
-        await AssertDoesNotCompleteAsync(additionalPulse.Task);
-        await WaitForCompletionAsync(heartBeat.PulseTask);
+            await AssertDoesNotCompleteAsync(additionalPulse.Task);
+            await WaitForCompletionAsync(heartBeat.PulseTask);
+        }
+        finally
+        {
+            heartBeat.Dispose();
+            releaseFirstPulse.Set();
+        }
+
         Assert.False(heartBeat.PulseTask.IsFaulted);
     }
 
@@ -44,7 +57,7 @@ public class HeartBeatTests
     {
         var laterPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var successfulPulseCount = 0;
-        var heartBeat = new HeartBeat(25);
+        var heartBeat = new HeartBeat(PulseInterval);
         heartBeat.OnPulse += (_, _) => throw new InvalidOperationException("subscriber failure");
         heartBeat.OnPulse += (_, _) =>
         {
@@ -75,13 +88,15 @@ public class HeartBeatTests
         using var cancellationTokenSource = new CancellationTokenSource();
         var firstPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var additionalPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseFirstPulse = new ManualResetEventSlim(false);
         var pulseCount = 0;
-        var heartBeat = new HeartBeat(25);
+        var heartBeat = new HeartBeat(PulseInterval);
         heartBeat.OnPulse += (_, _) =>
         {
             if (Interlocked.Increment(ref pulseCount) == 1)
             {
                 firstPulse.TrySetResult(true);
+                releaseFirstPulse.Wait();
                 return;
             }
 
@@ -94,6 +109,7 @@ public class HeartBeatTests
             await WaitForCompletionAsync(firstPulse.Task);
 
             cancellationTokenSource.Cancel();
+            releaseFirstPulse.Set();
 
             await AssertDoesNotCompleteAsync(additionalPulse.Task);
             await WaitForCompletionAsync(heartBeat.PulseTask);
@@ -101,6 +117,7 @@ public class HeartBeatTests
         finally
         {
             heartBeat.Dispose();
+            releaseFirstPulse.Set();
         }
 
         Assert.False(heartBeat.PulseTask.IsFaulted);
@@ -113,7 +130,7 @@ public class HeartBeatTests
         var unexpectedPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         using var releaseFirstPulse = new ManualResetEventSlim(false);
         var pulseCount = 0;
-        var heartBeat = new HeartBeat(25);
+        var heartBeat = new HeartBeat(PulseInterval);
         heartBeat.OnPulse += (_, _) =>
         {
             if (Interlocked.Increment(ref pulseCount) == 1)

--- a/test/Reown.Core.Network.Test/HeartBeatTests.cs
+++ b/test/Reown.Core.Network.Test/HeartBeatTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Reown.Core;
+using Xunit;
+
+namespace Reown.Core.Network.Test;
+
+[Trait("Category", "unit")]
+public class HeartBeatTests
+{
+    private static readonly TimeSpan NoPulseTimeout = TimeSpan.FromMilliseconds(200);
+
+    [Fact]
+    public async Task Dispose_StopsFurtherPulses()
+    {
+        var firstPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var additionalPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pulseCount = 0;
+        var heartBeat = new HeartBeat(25);
+        heartBeat.OnPulse += (_, _) =>
+        {
+            if (Interlocked.Increment(ref pulseCount) == 1)
+            {
+                firstPulse.TrySetResult(true);
+                return;
+            }
+
+            additionalPulse.TrySetResult(true);
+        };
+
+        await heartBeat.InitAsync();
+        await WaitForCompletionAsync(firstPulse.Task);
+
+        heartBeat.Dispose();
+
+        await AssertDoesNotCompleteAsync(additionalPulse.Task);
+        await WaitForCompletionAsync(heartBeat.PulseTask);
+        Assert.False(heartBeat.PulseTask.IsFaulted);
+    }
+
+    [Fact]
+    public async Task ThrowingSubscriber_DoesNotStopOtherSubscribersOrLaterPulses()
+    {
+        var laterPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var successfulPulseCount = 0;
+        var heartBeat = new HeartBeat(25);
+        heartBeat.OnPulse += (_, _) => throw new InvalidOperationException("subscriber failure");
+        heartBeat.OnPulse += (_, _) =>
+        {
+            if (Interlocked.Increment(ref successfulPulseCount) >= 2)
+            {
+                laterPulse.TrySetResult(true);
+            }
+        };
+
+        try
+        {
+            await heartBeat.InitAsync();
+
+            await WaitForCompletionAsync(laterPulse.Task);
+        }
+        finally
+        {
+            heartBeat.Dispose();
+            await WaitForCompletionAsync(heartBeat.PulseTask);
+        }
+
+        Assert.False(heartBeat.PulseTask.IsFaulted);
+    }
+
+    [Fact]
+    public async Task CancellationToken_StopsFurtherPulsesWithoutFaultingTheLoop()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var firstPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var additionalPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pulseCount = 0;
+        var heartBeat = new HeartBeat(25);
+        heartBeat.OnPulse += (_, _) =>
+        {
+            if (Interlocked.Increment(ref pulseCount) == 1)
+            {
+                firstPulse.TrySetResult(true);
+                return;
+            }
+
+            additionalPulse.TrySetResult(true);
+        };
+
+        try
+        {
+            await heartBeat.InitAsync(cancellationTokenSource.Token);
+            await WaitForCompletionAsync(firstPulse.Task);
+
+            cancellationTokenSource.Cancel();
+
+            await AssertDoesNotCompleteAsync(additionalPulse.Task);
+            await WaitForCompletionAsync(heartBeat.PulseTask);
+        }
+        finally
+        {
+            heartBeat.Dispose();
+        }
+
+        Assert.False(heartBeat.PulseTask.IsFaulted);
+    }
+
+    [Fact]
+    public async Task InitAsync_CalledTwice_StartsOnlyOnePulseLoop()
+    {
+        var firstPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var unexpectedPulse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseFirstPulse = new ManualResetEventSlim(false);
+        var pulseCount = 0;
+        var heartBeat = new HeartBeat(25);
+        heartBeat.OnPulse += (_, _) =>
+        {
+            if (Interlocked.Increment(ref pulseCount) == 1)
+            {
+                firstPulse.TrySetResult(true);
+                releaseFirstPulse.Wait();
+                return;
+            }
+
+            unexpectedPulse.TrySetResult(true);
+        };
+
+        try
+        {
+            await heartBeat.InitAsync();
+            await WaitForCompletionAsync(firstPulse.Task);
+
+            await heartBeat.InitAsync();
+
+            await AssertDoesNotCompleteAsync(unexpectedPulse.Task);
+        }
+        finally
+        {
+            releaseFirstPulse.Set();
+            heartBeat.Dispose();
+            await WaitForCompletionAsync(heartBeat.PulseTask);
+        }
+    }
+
+    private static async Task AssertDoesNotCompleteAsync(Task task)
+    {
+        var completedTask = await Task.WhenAny(task, Task.Delay(NoPulseTimeout));
+
+        Assert.NotSame(task, completedTask);
+    }
+
+    private static async Task WaitForCompletionAsync(Task task)
+    {
+        var completedTask = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        Assert.Same(task, completedTask);
+        await task;
+    }
+}


### PR DESCRIPTION
## Summary
- cancel and observe the heartbeat pulse loop during disposal
- isolate pulse subscribers so a throwing handler does not skip other subscribers
- add lifecycle tests for disposal, cancellation, and duplicate initialization

## Validation
- dotnet build Reown.NoUnity.slnf --no-restore
- dotnet test Reown.NoUnity.slnf --verbosity minimal --filter Category=unit