### PR TITLE
ci: stop running every workflow twice on the release PR

### DIFF
--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -23,7 +23,13 @@ concurrency:
 
 jobs:
   test:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # A develop -> main release PR has develop as its head branch, so the
+    # push-triggered run already covers this exact commit.
+    if: >-
+      github.event_name != 'pull_request'
+      || (github.event.pull_request.draft == false
+          && !(github.event.pull_request.head.repo.full_name == github.repository
+               && github.event.pull_request.head.ref == 'develop'))
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,7 +25,9 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository)
+    # A develop -> main release PR has develop as its head branch, so the
+    # push-triggered run already covers this exact commit.
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref != 'develop')
     name: Build and analyze
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/sync-unity-package-version.yml
+++ b/.github/workflows/sync-unity-package-version.yml
@@ -20,6 +20,12 @@ permissions:
 
 jobs:
   sync-unity-version:
+    # A develop -> main release PR has develop as its head branch, so the
+    # push-triggered run already covers this exact commit.
+    if: >-
+      github.event_name != 'pull_request'
+      || !(github.event.pull_request.head.repo.full_name == github.repository
+           && github.event.pull_request.head.ref == 'develop')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/unity-build-test.yml
+++ b/.github/workflows/unity-build-test.yml
@@ -30,7 +30,9 @@ concurrency:
 
 jobs:
   buildForAllSupportedPlatforms:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository)
+    # A develop -> main release PR has develop as its head branch, so the
+    # push-triggered run already covers this exact commit.
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref != 'develop')
     name: Build for ${{ matrix.targetPlatform }}
     runs-on: ubuntu-latest
     strategy:
@@ -75,7 +77,9 @@ jobs:
           name: Build-${{ matrix.targetPlatform }}
           path: Builds/${{ matrix.targetPlatform }}
   testAllModes:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository)
+    # A develop -> main release PR has develop as its head branch, so the
+    # push-triggered run already covers this exact commit.
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref != 'develop')
     name: Test in ${{ matrix.testMode }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
On a `develop -> main` release PR the head branch is `develop`, so the commit pushed to develop *is* the PR head commit. Four workflows trigger on both `push: branches: [develop]` and `pull_request`, and each produced two runs for the same SHA — both reported on the PR. Verified on #343: `.NET Build & Test`, `Build Unity Sample`, `SonarCloud` and `Sync Unity Package Version` each had one `push` run and one `pull_request` run. Feature PRs into develop had one run each and are unaffected.

- Skip the `pull_request` run when the PR head is this repository's `develop` branch — the `push` run already covers that exact commit.
- The same-repo qualifier keeps fork PRs running, including one whose branch happens to be named `develop`.
- `Deploy to Vercel` skips along with the Unity build it depends on, so the release PR no longer gets a preview deployment. Every PR into develop still gets one.
- `SonarCloud` analyses the release commit as the develop branch rather than as a PR against main.

The two `CTA Assistant` runs per PR are unrelated and intentional: one on `opened`/`synchronize`, one on `closed` to apply `lock-pullrequest-aftermerge`.

Validated with `actionlint`; no new findings.
