### PR TITLE
fix(storage): keep readable entries when one entry cannot be deserialised

### DIFF
--- a/src/Reown.Core.Storage/Runtime/FileSystemStorage.cs
+++ b/src/Reown.Core.Storage/Runtime/FileSystemStorage.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Reown.Core.Common.Logging;
 
 namespace Reown.Core.Storage
@@ -153,7 +154,6 @@ namespace Reown.Core.Storage
                 _semaphoreSlim.Release();
             }
 
-            // Hard fail here if the storage file is bad, unless it's serialized as a Dictionary (for backwards compatibility)
             var jsonSerializerSettings = new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.Auto
@@ -163,11 +163,61 @@ namespace Reown.Core.Storage
                 Entries = JsonConvert.DeserializeObject<ConcurrentDictionary<string, object>>(json,
                     jsonSerializerSettings);
             }
-            catch (JsonSerializationException)
+            catch (JsonException)
             {
-                var dict = JsonConvert.DeserializeObject<Dictionary<string, object>>(json, jsonSerializerSettings);
-                Entries = new ConcurrentDictionary<string, object>(dict);
+                // Reading the document as a whole fails for two unrelated reasons, and both are
+                // recoverable one entry at a time: a file written as a plain Dictionary by an older
+                // version, and a single value whose $type no longer resolves. The latter is not
+                // hypothetical — the type names recorded here belong to the integrating application
+                // (JsonRpcHistory stores its request types), so renaming a request class or updating
+                // a dependency that owns one is enough to make the whole file unreadable. Everything
+                // else in it goes down with that one entry, the KeyChain included, and an app that
+                // cannot read its KeyChain has lost every session it had.
+                Entries = LoadEntriesIndividually(json, jsonSerializerSettings);
             }
+        }
+
+        /// <summary>
+        ///     Reads the document one entry at a time, keeping every value that can be read and
+        ///     dropping only those that cannot.
+        /// </summary>
+        /// <remarks>
+        ///     A malformed document still fails: <see cref="JObject.Parse(string)" /> throws, and
+        ///     that is a genuinely unreadable file rather than an entry this build cannot resolve.
+        /// </remarks>
+        private static ConcurrentDictionary<string, object> LoadEntriesIndividually(
+            string json,
+            JsonSerializerSettings jsonSerializerSettings)
+        {
+            var entries = new ConcurrentDictionary<string, object>();
+            var serializer = JsonSerializer.Create(jsonSerializerSettings);
+            var root = JObject.Parse(json);
+            var dropped = 0;
+
+            foreach (var property in root.Properties())
+            {
+                // Written by TypeNameHandling.All on the way out; it describes the dictionary
+                // itself, not an entry.
+                if (string.Equals(property.Name, "$type", StringComparison.Ordinal))
+                    continue;
+
+                try
+                {
+                    var value = property.Value.ToObject<object>(serializer);
+                    if (value != null)
+                        entries[property.Name] = value;
+                }
+                catch (JsonException e)
+                {
+                    dropped++;
+                    ReownLogger.LogError($"Storage entry {property.Name} could not be read and was dropped: {e.Message}");
+                }
+            }
+
+            if (dropped > 0)
+                ReownLogger.LogError($"Storage loaded with {entries.Count} entry(ies); {dropped} could not be read");
+
+            return entries;
         }
 
         protected override void Dispose(bool disposing)

--- a/test/Reown.Core.Storage.Test/FileSystemStorageTest.cs
+++ b/test/Reown.Core.Storage.Test/FileSystemStorageTest.cs
@@ -1,3 +1,4 @@
+﻿using Newtonsoft.Json;
 using Reown.TestUtils;
 using Xunit;
 
@@ -59,5 +60,62 @@ public class FileSystemStorageTest
         await testDictStorage.Init();
         await testDictStorage.SetItem("checkedkey", "testingvalue");
         Assert.True(await testDictStorage.HasItem("checkedkey"));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public async Task AnUnreadableEntryDoesNotTakeTheRestOfTheFileWithIt()
+    {
+        using var tempFolder = new TempFolder();
+        var filePath = Path.Combine(tempFolder.Folder.FullName, ".wctestdata");
+
+        // $type names a type this build cannot resolve — what an integrating application leaves
+        // behind when it renames a request class or updates the dependency that owns one.
+        await File.WriteAllTextAsync(filePath, """
+        {
+          "$type": "System.Collections.Concurrent.ConcurrentDictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], System.Collections.Concurrent",
+          "keychain": "the-entry-that-must-survive",
+          "history": {
+            "$type": "Some.Removed.Namespace.RequestType, Some.Removed.Assembly",
+            "topic": "abc"
+          }
+        }
+        """);
+
+        var storage = new FileSystemStorage(filePath);
+        await storage.Init();
+
+        Assert.Equal("the-entry-that-must-survive", await storage.GetItem<string>("keychain"));
+        Assert.False(await storage.HasItem("history"));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public async Task AFileWrittenAsAPlainDictionaryStillLoads()
+    {
+        using var tempFolder = new TempFolder();
+        var filePath = Path.Combine(tempFolder.Folder.FullName, ".wctestdata");
+
+        await File.WriteAllTextAsync(filePath, """
+        {
+          "somekey": "somevalue"
+        }
+        """);
+
+        var storage = new FileSystemStorage(filePath);
+        await storage.Init();
+
+        Assert.Equal("somevalue", await storage.GetItem<string>("somekey"));
+    }
+
+    [Fact] [Trait("Category", "unit")]
+    public async Task AMalformedFileStillThrows()
+    {
+        using var tempFolder = new TempFolder();
+        var filePath = Path.Combine(tempFolder.Folder.FullName, ".wctestdata");
+
+        await File.WriteAllTextAsync(filePath, "{ this is not json");
+
+        var storage = new FileSystemStorage(filePath);
+
+        await Assert.ThrowsAnyAsync<JsonException>(() => storage.Init());
     }
 }


### PR DESCRIPTION
Closes #347.

### The problem

`FileSystemStorage.Load()` deserialises the whole document in one call, so a single value that cannot be read takes the entire file down — the KeyChain along with it. An application that cannot read its KeyChain cannot decrypt any session it has.

The existing `catch (JsonSerializationException)` retry is about the document *shape* (a file written as a plain `Dictionary` by an older version). When the cause is a value rather than the shape, the retry fails in exactly the same way.

This is reachable in ordinary use because the `$type` names in this file are not all owned by the SDK: `JsonRpcHistory` records the integrating application's request types, written assembly-qualified by `TypeNameHandling.All`. Renaming a request class, or updating a dependency that owns one of those types, is enough for a name to stop resolving. We lost ~2 MB of state that way — history, sessions and KeyChain together — when a third-party type disappeared in a routine dependency update.

#337 narrowed the window by expiring history records, but a type that disappears while a record is still live produces the same total loss.

### The change

The fallback now reads the document one entry at a time: the root is parsed as `JObject`, each value is deserialised on its own, and only the values that cannot be read are dropped, each one logged. A missing type costs one history record instead of the KeyChain.

Both existing behaviours are preserved and now pinned by tests:

- a file written as a plain `Dictionary` still loads — it goes through the same per-entry path;
- a genuinely malformed file still throws, because `JObject.Parse` fails on it.

### Tests

Three added to `FileSystemStorageTest`, and `AnUnreadableEntryDoesNotTakeTheRestOfTheFileWithIt` fails on the unpatched code — verified by reverting the source change and re-running, where the other two still pass, so they document existing behaviour rather than changing it.

7 tests green on net8.0, net9.0 and net10.0.